### PR TITLE
fix: use master branch for llm-common dependency

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -2116,27 +2116,31 @@ utils = ["numpydoc"]
 
 [[package]]
 name = "llm-common"
-version = "0.3.0"
-description = "Shared LLM framework for affordabot and prime-radiant-ai"
+version = "0.1.0"
+description = "Shared LLM utilities for Affordabot and Prime-Radiant-AI"
 optional = false
-python-versions = ">=3.13,<4.0"
+python-versions = ">=3.9"
 groups = ["main"]
 files = []
-develop = true
+develop = false
 
 [package.dependencies]
-cachetools = "^5.3.0"
-httpx = "^0.27.0"
-instructor = "^1.0.0"
-openai = "^1.0.0"
-pydantic = "^2.0.0"
-python-dotenv = "^1.0.0"
-tenacity = "^8.0.0"
-typing-extensions = "^4.0.0"
+eval_type_backport = "*"
+httpx = ">=0.24.0"
+instructor = ">=1.0.0"
+litellm = ">=1.0.0"
+openai = ">=1.0.0"
+pydantic = ">=2.0.0"
+supabase = ">=2.0.0"
+
+[package.extras]
+dev = ["pytest (>=7.0.0)", "pytest-asyncio (>=0.21.0)", "python-dotenv (>=1.0.0)"]
 
 [package.source]
-type = "directory"
-url = "../../llm-common"
+type = "git"
+url = "https://github.com/fengning-starsend/llm-common.git"
+reference = "master"
+resolved_reference = "bee119170bb1aa9378262f4f6c4595f24cd8dae2"
 
 [[package]]
 name = "lxml"
@@ -5664,4 +5668,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "730eb861ccde635774e0fd4abb22368a1927858090f5a991115680c2c1d1b6c1"
+content-hash = "13542cd6fd14be4136a842439d52ccc11c0a6c2a7826bb1340d2a8aab75266b1"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,7 +31,7 @@ sentry-sdk = {extras = ["fastapi"], version = "*"}
 sendgrid = "*"
 eval_type_backport = "*"
 scrapy = "*"
-llm-common = { git = "https://github.com/fengning-starsend/llm-common.git", rev = "main" }
+llm-common = { git = "https://github.com/fengning-starsend/llm-common.git", rev = "master" }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"


### PR DESCRIPTION
Fixes Railway build failure from PR #9.

PR #9 merged with `rev = "main"` but llm-common uses `master` branch.
This causes Poetry lockfile mismatch and build failure.

**Fix:** Changed to `rev = "master"` and regenerated lockfile.

Closes affordabot-puq