### PR TITLE
fix: configure git credentials for Poetry build

### DIFF
--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -1,6 +1,11 @@
 [build]
 builder = "RAILPACK"
 
+[build.env]
+GIT_CONFIG_COUNT = "1"
+GIT_CONFIG_KEY_0 = "url.https://$GITHUB_TOKEN@github.com/.insteadOf"
+GIT_CONFIG_VALUE_0 = "https://github.com/"
+
 [deploy]
 startCommand = "poetry run uvicorn main:app --host 0.0.0.0 --port $PORT"
 healthcheckPath = "/health"


### PR DESCRIPTION
Enables Poetry to clone private llm-common repository during Railway build.

**Issue:** Poetry git clone fails with auth error even though GITHUB_TOKEN is set in Railway.

**Fix:** Added GIT_CONFIG environment variables to teach git how to use GITHUB_TOKEN for authentication.

Closes affordabot-puq