### PR TITLE
fix: use nixpacks.toml preInstall phase for git auth

### DIFF
--- a/backend/nixpacks.toml
+++ b/backend/nixpacks.toml
@@ -1,0 +1,6 @@
+[phases.preInstall]
+cmds = ["git config --global url.\"https://${GITHUB_TOKEN}:x-oauth-basic@github.com/\".insteadOf \"https://github.com/\""]
+dependsOn = ["setup"]
+
+[phases.install]
+dependsOn = ["preInstall"]

--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -2,7 +2,7 @@
 builder = "RAILPACK"
 
 [build.env]
-NIXPACKS_INSTALL_CMD = "git config --global url.\"https://${GITHUB_TOKEN}:x-oauth-basic@github.com/\".insteadOf \"https://github.com/\" && poetry install --no-interaction --no-ansi --only main --no-root"
+
 
 [deploy]
 startCommand = "poetry run uvicorn main:app --host 0.0.0.0 --port $PORT"


### PR DESCRIPTION
Configures git credentials in a custom `preInstall` phase in `nixpacks.toml`.

**Reason:** Previous attempts with `NIXPACKS_INSTALL_CMD` were ignored by Railpack.
**Fix:** Explicitly defining a phase dependency ensures git config runs before Poetry install.

Closes affordabot-puq