### PR TITLE
fix: use GIT_ASKPASS for Railpack git auth

### DIFF
--- a/backend/git-askpass.sh
+++ b/backend/git-askpass.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo $GITHUB_TOKEN

--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -2,8 +2,8 @@
 builder = "RAILPACK"
 
 [build.env]
-
-
+GIT_ASKPASS = "/app/git-askpass.sh"
+GIT_USERNAME = "x-oauth-basic"
 [deploy]
 startCommand = "poetry run uvicorn main:app --host 0.0.0.0 --port $PORT"
 healthcheckPath = "/health"


### PR DESCRIPTION
Implements GIT_ASKPASS strategy for git authentication in Railpack.

**Mechanism:**
1. `backend/git-askpass.sh` echoes `GITHUB_TOKEN`.
2. `railway.toml` sets `GIT_ASKPASS` env var to this script.
3. Git automatically calls this script when password is needed during clone.

This bypasses the need for `git config` commands in build phases.

Closes affordabot-puq