### PR TITLE
fix: use RAILPACK_INSTALL_COMMAND for git auth

### DIFF
--- a/backend/git-askpass.sh
+++ b/backend/git-askpass.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo $GITHUB_TOKEN

--- a/backend/nixpacks.toml
+++ b/backend/nixpacks.toml
@@ -1,6 +1,0 @@
-[phases.preInstall]
-cmds = ["git config --global url.\"https://${GITHUB_TOKEN}:x-oauth-basic@github.com/\".insteadOf \"https://github.com/\""]
-dependsOn = ["setup"]
-
-[phases.install]
-dependsOn = ["preInstall"]

--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -2,8 +2,7 @@
 builder = "RAILPACK"
 
 [build.env]
-GIT_ASKPASS = "/app/git-askpass.sh"
-GIT_USERNAME = "x-oauth-basic"
+RAILPACK_INSTALL_COMMAND = "git config --global url.\"https://${GITHUB_TOKEN}:x-oauth-basic@github.com/\".insteadOf \"https://github.com/\" && poetry install --no-interaction --no-ansi --only main --no-root"
 [deploy]
 startCommand = "poetry run uvicorn main:app --host 0.0.0.0 --port $PORT"
 healthcheckPath = "/health"


### PR DESCRIPTION
Switches to `RAILPACK_INSTALL_COMMAND` for build configuration.

**Reason:** Documentation confirms `RAILPACK_INSTALL_COMMAND` is the correct variable to override install steps in Railpack, not `NIXPACKS_INSTALL_CMD`.
**Fix:** Configures git credentials and runs poetry install in a single command. Removes ineffective `nixpacks.toml` and `git-askpass.sh`.

Closes affordabot-puq