### PR TITLE
fix: add missing CORSMiddleware import

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, HTTPException, BackgroundTasks
+from fastapi.middleware.cors import CORSMiddleware
 from services.llm.analyzer import LegislationAnalyzer
 from services.notifications.email import EmailNotificationService
 from middleware.rate_limit import RateLimiter


### PR DESCRIPTION
Fixes `NameError: name 'CORSMiddleware' is not defined` on startup.

**Cause:** `CORSMiddleware` was used in `main.py` but the import was missing.
**Fix:** Added `from fastapi.middleware.cors import CORSMiddleware`.

Closes affordabot-puq