### PR TITLE
Fix syntax error in admin.py (Railway deployment blocker)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -138,6 +138,20 @@ async def _run_scrape_task(task_id: str, jurisdiction: str, force: bool, db: Sup
         # ... existing legislation logic ...
         # Import scraper registry
         from services.scraper.san_jose import SanJoseScraper
+        
+    except Exception as e:
+        error_msg = str(e)
+        print(f"Task {task_id} failed: {error_msg}")
+        import traceback
+        traceback.print_exc()
+        
+        # Update task status to failed
+        if db.client:
+            db.client.table('admin_tasks').update({
+                'status': 'failed',
+                'completed_at': datetime.now().isoformat(),
+                'error_message': error_msg
+            }).eq('id', task_id).execute()
 
 
 class ManualScrapeResponse(BaseModel):


### PR DESCRIPTION
## Problem
Railway deployment failing with SyntaxError in routers/admin.py line 143.

## Root Cause
The `_run_scrape_task` function has a `try` block at line 76, but the new `harvest` and `rag` scrape type handlers have early `return` statements that bypass the `except` block, leaving it orphaned.

## Fix
Added missing `except` block after the early returns to properly close the try statement.

## Testing
- ✅ Syntax check passes locally
- ✅ Should be caught by `make lint` (Python syntax validation)

## Related
- Unblocks Railway deployment
- Feature-Key: affordabot-71b