### PR TITLE
fix(ci): Enable llm-pipeline context and remove stale glob

### DIFF
--- a/.context/area-config.yml
+++ b/.context/area-config.yml
@@ -11,13 +11,13 @@ areas:
 
   llm-pipeline:
     description: "RAG pipeline, embeddings, LLM interactions, and flow orchestration"
+    enabled: true
     keywords: "llm, rag, embedding, vector, flow, generate, review"
     tags: ["backend", "ai", "rag"]
     globs:
       - "backend/flows/**/*"
       - "backend/services/llm_service.py"
       - "backend/services/embedding_service.py"
-      - "packages/llm-common/**/*"
 
   admin-ui:
     description: "Admin dashboard, task management, and review interfaces"


### PR DESCRIPTION
Fixes CI `update-contexts` failure on master. Enables the `llm-pipeline` area (required since changes were detected) and removes the deleted `packages/llm-common` path from configuration.