### PR TITLE
feat: integrate vm-bootstrap check into DX entrypoint (bd-vz68.3)

### DIFF
--- a/scripts/bd-context
+++ b/scripts/bd-context
@@ -45,6 +45,13 @@
 
 set -e
 
+# Run VM Bootstrap Verification (Linux only, fail-open)
+if [[ "$(uname -s)" == "Linux" ]] && [[ -x "$HOME/agent-skills/vm-bootstrap/verify.sh" ]]; then
+  echo "Running VM bootstrap check..."
+  "$HOME/agent-skills/vm-bootstrap/verify.sh" check || echo "⚠️  VM bootstrap check failed (proceeding anyway)"
+  echo ""
+fi
+
 # Extract feature key from branch name or use provided arg
 if [ -n "$1" ]; then
   FEATURE_KEY="$1"


### PR DESCRIPTION
- Add vm-bootstrap check to scripts/bd-context
- Linux-only guard (skips on macOS)
- Fail-open (warns but continues on failure)
- Agents don't need to rely on AGENTS.md memory for toolchain status

Feature-Key: bd-vz68.3
Agent: antigravity
Role: backend-engineer