### PR TITLE
fix: CI Postgres Auth & Context Update Runner [affordabot-8xn]

### DIFF
--- a/.github/workflows/_context-update.yml
+++ b/.github/workflows/_context-update.yml
@@ -40,7 +40,7 @@ on:
 
 jobs:
   analyze-and-update:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U postgres"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -119,10 +119,10 @@ jobs:
         env:
           DATABASE_URL: postgresql://postgres:password@localhost:5432/affordabot
 
-      - name: Run San Jose V3 Verification
+      - name: Run San Jose Pipeline Verification
         run: |
           cd backend
-          poetry run python scripts/verification/verify_sanjose_v3.py
+          poetry run python scripts/verification/verify_sanjose_pipeline.py
         env:
           DATABASE_URL: postgresql://postgres:password@localhost:5432/affordabot
           ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}

--- a/.github/workflows/pr-context-update.yml
+++ b/.github/workflows/pr-context-update.yml
@@ -37,7 +37,7 @@ permissions:
 
 jobs:
   check-merged:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     outputs:
       should_proceed: ${{ steps.check.outputs.should_proceed }}
@@ -82,7 +82,7 @@ jobs:
 
   summary:
     needs: [check-merged, update-contexts]
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Workflow summary


### PR DESCRIPTION
## Failures Fixed

1. **Master CI (Exit 300 equivalent / FATAL role root)**
   - **Root Cause**: `pg_isready` defaulted to `root` user, failing auth against Postgres service. Tests failed because DB wasn't ready or  was missing.
   - **Fixes**:
     - Added `-U postgres` to `pg_isready`.
     - Pointed verification step to the correct `verify_sanjose_pipeline.py`.

2. **PR Context Update (Exit 87 equivalent / Python missing)**
   - **Root Cause**: Self-hosted runner (Debian 12) lacked the requested Python 3.11 version/tool cache.
   - **Fixes**: Switched workflows to `ubuntu-latest` (GitHub-hosted) which guarantees Python availability and network access.

## Verification
- Validated workflow syntax.
- Confirmed `verify_sanjose_pipeline.py` is CI-safe (mocks enabled).
