### PR TITLE
chore: Standardize CI on Python 3.13 [affordabot-8xn]

### DIFF
--- a/.github/workflows/_context-update.yml
+++ b/.github/workflows/_context-update.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,10 +90,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python and Poetry
-        uses: stars-end/agent-skills/github-actions/actions/python-setup@c88517f6d135b00bb177cad20963c57da9d3caa9
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
         with:
-          working-directory: backend/
+          python-version: '3.13'
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Install dependencies
+        run: |
+          cd backend
+          poetry install --no-interaction --no-root
 
       - name: Install Playwright Browsers
         run: |


### PR DESCRIPTION
Ensures all CI workflows run on Python 3.13, matching project configuration.

## Changes
- **ci.yml**: Replaced custom action with standard `setup-python@v5` (3.13) + `snok/install-poetry`.
- **_context-update.yml**: Bumped from 3.11 to 3.13.

## Rationale
Standardization request to match local dev environment.
