### PR TITLE
fix: Resolve CI #306 failures (Clerk & Lint) [affordabot-8xn]

### DIFF
--- a/backend/scripts/verification/verify_sanjose_pipeline.py
+++ b/backend/scripts/verification/verify_sanjose_pipeline.py
@@ -162,7 +162,8 @@ async def verify_pipeline():
              async def chat_completion(self, messages, model): 
                  from dataclasses import dataclass
                  @dataclass
-                 class Resp: content="Mock Answer"
+                 class Resp:
+                    content: str = "Mock Answer"
                  return Resp()
 
         pipeline = SearchPipelineService(

--- a/backend/tests/services/storage/test_s3_storage.py
+++ b/backend/tests/services/storage/test_s3_storage.py
@@ -40,7 +40,7 @@ def test_ensure_bucket_exists(mock_minio, s3_env):
         mock_client = mock_minio.return_value
         mock_client.bucket_exists.return_value = False
         
-        storage = S3Storage()
+        S3Storage()
         # _ensure_bucket is called in __init__
         mock_client.make_bucket.assert_called_with("test-bucket")
 
@@ -49,7 +49,7 @@ def test_ensure_bucket_already_exists(mock_minio, s3_env):
         mock_client = mock_minio.return_value
         mock_client.bucket_exists.return_value = True
         
-        storage = S3Storage()
+        S3Storage()
         mock_client.make_bucket.assert_not_called()
 
 @pytest.mark.asyncio

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -6,9 +6,9 @@ const isProtected = createRouteMatcher([
     '/admin(.*)',
 ]);
 
-export default clerkMiddleware((auth, req) => {
+export default clerkMiddleware(async (auth, req) => {
     if (isProtected(req)) {
-        auth().protect();
+        (await auth()).protect();
     }
 });
 


### PR DESCRIPTION
Fixes persistent CI failures on master.

## Fixes
- **Frontend**: `middleware.ts` updated for Clerk v6 (`await auth()`).
- **Backend**: Fixed newly exposed lint errors (`E701`, `F841`).

Targeting **Green Master**.
