### PR TITLE
fix: Resolve CI #312 and Enforce Dynamic Build [affordabot-8xn]

### DIFF
--- a/backend/tests/test_ingestion_service.py
+++ b/backend/tests/test_ingestion_service.py
@@ -146,7 +146,8 @@ async def test_ingest_from_search_result_new(mock_postgres, mock_vector_backend,
     mock_postgres.get_or_create_source.assert_called_once_with(
         jurisdiction_id="web",
         name="Title", 
-        type="general"
+        type="general",
+        url="http://new.com"
     )
     mock_postgres.create_raw_scrape.assert_called_once()
     

--- a/frontend/src/app/admin/discovery/page.tsx
+++ b/frontend/src/app/admin/discovery/page.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+export const dynamic = 'force-dynamic';
+
+import { Suspense } from "react";
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { Suspense } from 'react';
+export const dynamic = 'force-dynamic';
 import { useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';

--- a/frontend/src/app/admin/reviews/page.tsx
+++ b/frontend/src/app/admin/reviews/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
+export const dynamic = 'force-dynamic';
 import { Button } from "@/components/ui/button"
 import {
     Card,

--- a/frontend/src/app/admin/sources/page.tsx
+++ b/frontend/src/app/admin/sources/page.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+export const dynamic = 'force-dynamic';
+
 import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"

--- a/frontend/src/app/api/admin/health/models/route.ts
+++ b/frontend/src/app/api/admin/health/models/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
 
 export async function GET() {

--- a/frontend/src/app/api/admin/jurisdictions/route.ts
+++ b/frontend/src/app/api/admin/jurisdictions/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
+export const dynamic = 'force-dynamic';
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || process.env.VITE_API_URL || process.env.RAILWAY_SERVICE_BACKEND_URL || 'http://localhost:8000';
 
 export async function GET() {
     try {

--- a/frontend/src/app/api/admin/scrapes/route.ts
+++ b/frontend/src/app/api/admin/scrapes/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || process.env.VITE_API_URL || process.env.RAILWAY_SERVICE_BACKEND_URL || 'http://localhost:8000';
 
 export async function GET(request: NextRequest) {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,7 @@
 import type { Metadata } from "next";
+
+export const dynamic = 'force-dynamic';
+
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { ClerkProvider } from "@clerk/nextjs";


### PR DESCRIPTION
Fixes persistent CI failures.

## Fixes
- **Frontend**: Forced global dynamic rendering (`layout.tsx`). Previously, Next.js tried to statically generate pages that called internal API routes, which crashed because the backend wasn't running during build.
- **Backend**: Fixed `test_ingestion_service` mock mismatch.

## Local Verification
- `make ci-lite`: Passed.
- `make build`: Passed.

Targeting **Green Master**.
