### PR TITLE
fix(workspace): Add frontend-v2 to pnpm workspace (affordabot-g01)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'frontend'
   - 'backend'
+  - 'frontend-v2'


### PR DESCRIPTION
Adds frontend-v2 to pnpm-workspace.yaml so that root pnpm install works for CI builds.