### PR TITLE
fix: Use mise toolkit for overnight CI (local/CI parity)

### DIFF
--- a/.github/workflows/verify-overnight.yml
+++ b/.github/workflows/verify-overnight.yml
@@ -30,14 +30,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - name: Setup mise
+        uses: jdx/mise-action@v2
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          version: latest
           
-      - name: Install Poetry
-        run: pip install poetry
-        
       - name: Install Dependencies
         run: |
           cd backend
@@ -47,6 +44,7 @@ jobs:
         run: |
           cd backend
           poetry run playwright install chromium
+
           
       - name: Run Unified Verification (12 RAG Stories)
         env:


### PR DESCRIPTION
## Fix

- Replace actions/setup-python with jdx/mise-action
- Mise reads .mise.toml for Python 3.13.x  
- Ensures local and CI environments match

Feature-Key: affordabot-9pvc