### PR TITLE
fix: Fix YAML command continuation in verify-overnight.yml

### DIFF
--- a/.github/workflows/verify-overnight.yml
+++ b/.github/workflows/verify-overnight.yml
@@ -72,9 +72,9 @@ jobs:
           cd backend
           poetry run python scripts/verification/unified_verify.py \
             --base-url "$FRONTEND_URL" \
-
             --output ../artifacts/verification
           
+
       - name: Upload Artifacts
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Fix

Remove empty line between --base-url and --output arguments that caused 'command not found: --output' error (exit 127).

Feature-Key: affordabot-9pvc