### PR TITLE
fix: raw_scrapes bill count must join via sources table

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -106,8 +106,13 @@ async def get_jurisdiction(jurisdiction_id: str, request: Request):
         
         # Get related counts
         jur_id = row["id"]
+        # raw_scrapes doesn't have jurisdiction_id directly - join via sources
         bill_count = await db._fetchrow(
-            "SELECT COUNT(*) as count FROM raw_scrapes WHERE jurisdiction_id = $1",
+            """
+            SELECT COUNT(*) as count FROM raw_scrapes rs
+            JOIN sources s ON rs.source_id = s.id
+            WHERE s.jurisdiction_id = $1
+            """,
             jur_id
         )
         source_count = await db._fetchrow(


### PR DESCRIPTION
## Summary

Fixes the jurisdiction detail page error: `column 'jurisdiction_id' does not exist`

### Root Cause

`raw_scrapes` table doesn't have a `jurisdiction_id` column. The relationship is:
```
raw_scrapes.source_id → sources.id → sources.jurisdiction_id → jurisdictions.id
```

### Fix

Changed the bill count query from:
```sql
SELECT COUNT(*) FROM raw_scrapes WHERE jurisdiction_id = 
```

To:
```sql
SELECT COUNT(*) FROM raw_scrapes rs
JOIN sources s ON rs.source_id = s.id
WHERE s.jurisdiction_id = 
```

Feature-Key: affordabot-bok6