### PR TITLE
fix: Pass UUID directly to asyncpg without casting

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -104,20 +104,20 @@ async def get_jurisdiction(jurisdiction_id: str, request: Request):
         if not row:
             raise HTTPException(status_code=404, detail=f"Jurisdiction '{jurisdiction_id}' not found")
         
-        # Get related counts - jur_id is already a UUID from the query, use directly
-        jur_id = row["id"]  # Keep as UUID for DB queries
+        # Get related counts - jur_id is already a UUID from the query
+        jur_id = row["id"]  # asyncpg returns native UUID, pass directly
         # raw_scrapes doesn't have jurisdiction_id directly - join via sources
         bill_count = await db._fetchrow(
             """
             SELECT COUNT(*) as count FROM raw_scrapes rs
             JOIN sources s ON rs.source_id = s.id
-            WHERE s.jurisdiction_id = $1::uuid
+            WHERE s.jurisdiction_id = $1
             """,
-            str(jur_id)  # Cast to string then DB casts to uuid
+            jur_id  # Pass UUID directly, asyncpg handles it
         )
         source_count = await db._fetchrow(
-            "SELECT COUNT(*) as count FROM sources WHERE jurisdiction_id = $1::uuid",
-            str(jur_id)
+            "SELECT COUNT(*) as count FROM sources WHERE jurisdiction_id = $1",
+            jur_id  # Pass UUID directly
         )
         
         return {


### PR DESCRIPTION
## Summary

Fixes the operator mismatch error: `operator does not exist: text = uuid`

### Root Cause

Previous attempts tried to cast UUID to string with SQL `::uuid` cast, but this created a type mismatch between:
- text (string parameter) and
- uuid (column type)

### Fix

asyncpg natively handles Python UUID objects. Simply pass the UUID directly:
```python
jur_id = row['id']  # Native UUID from asyncpg
# Pass directly without casting
WHERE s.jurisdiction_id = $1
..., jur_id  # No str() wrapper
```

Feature-Key: affordabot-bok6