### PR TITLE
affordabot-bzmu: stabilize dev /admin bypass

### DIFF
--- a/frontend/src/app/api/_lib/backendUrl.ts
+++ b/frontend/src/app/api/_lib/backendUrl.ts
@@ -12,9 +12,8 @@ function inferRailwayBackendUrlFromHost(hostHeader?: string): string | undefined
 }
 
 export function getBackendUrl(hostHeader?: string): string {
-  const derivedForPr =
-    hostHeader && hostHeader.includes('-pr-') ? inferRailwayBackendUrlFromHost(hostHeader) : undefined;
-  if (derivedForPr) return normalizeBackendUrl(derivedForPr);
+  const derivedFromRailwayHost = inferRailwayBackendUrlFromHost(hostHeader);
+  if (derivedFromRailwayHost) return normalizeBackendUrl(derivedFromRailwayHost);
 
   const raw =
     process.env.RAILWAY_SERVICE_BACKEND_URL ||


### PR DESCRIPTION
- Always try cookie-gated admin bypass; avoid networkidle auth waits

- Infer Railway backend URL from dev host for /api proxies

Feature-Key: affordabot-bzmu
