### PR TITLE
fix: verification mocks include required LegislationAnalysisResponse fields

### DIFF
--- a/backend/scripts/verification/stories/verify_economic_impact_validity.py
+++ b/backend/scripts/verification/stories/verify_economic_impact_validity.py
@@ -57,6 +57,9 @@ class ImpactVerifyingLLM(LLMClient):
         # Return canned High Impact response for the 'generate' step
         if "policy analyst" in msg_str.lower():
             resp = LegislationAnalysisResponse(
+                title="Mock Bill",
+                jurisdiction="Mock Verif",
+                status="Mocked",
                 bill_number="BILL-TEST-101",
                 impacts=[
                     LegislationImpact(

--- a/backend/scripts/verification/verify_analysis_loop.py
+++ b/backend/scripts/verification/verify_analysis_loop.py
@@ -68,6 +68,9 @@ async def main():
         async def analyze(self, text, number, jurisdiction):
             from schemas.analysis import LegislationAnalysisResponse, LegislationImpact, ImpactEvidence
             return LegislationAnalysisResponse(
+                title="Mock Bill Title",
+                jurisdiction=jurisdiction,
+                status="Mock Status",
                 bill_number=number,
                 impacts=[
                     LegislationImpact(
@@ -183,6 +186,9 @@ async def main():
             
             if "policy analyst" in msg_str: # Generate Step
                 resp = LegislationAnalysisResponse(
+                    title="Mock Bill From Loop",
+                    jurisdiction="Mock Jurisdiction",
+                    status="Under Review",
                     bill_number="Test Bill 123",
                     impacts=[
                         LegislationImpact(

--- a/backend/scripts/verification/verify_e2e_glassbox.py
+++ b/backend/scripts/verification/verify_e2e_glassbox.py
@@ -145,6 +145,9 @@ async def main():
                     content = resp.model_dump_json()
                 else:
                     resp = LegislationAnalysisResponse(
+                        title="Mock Bill Title",
+                        jurisdiction="Mock Jurisdiction",
+                        status="Mock Status",
                         bill_number="MOCK-BILL-001",
                         impacts=[
                             LegislationImpact(


### PR DESCRIPTION
Unblocks make verify-dev after schema change adding required title/jurisdiction/status fields.

Feature-Key: affordabot-ahpb