### PR TITLE
fix(ci): support ANTHROPIC_API_KEY secret

### DIFF
--- a/.github/workflows/dx-audit.yml
+++ b/.github/workflows/dx-audit.yml
@@ -37,7 +37,7 @@ jobs:
           assignee: ${{ github.actor }}
         env:
           GH_TOKEN: ${{ github.token }}
-          ANTHROPIC_API_KEY: ${{ secrets.GLM_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY || secrets.GLM_API_KEY }}
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           ANTHROPIC_DEFAULT_SONNET_MODEL: glm-4.7
 


### PR DESCRIPTION
Updates workflow to accept ANTHROPIC_API_KEY as a fallback for GLM_API_KEY.