### PR TITLE
bd-gl47f: add discovery hardening plan

### DIFF
--- a/backend/scripts/verification/artifacts/discovery_classifier_validation_report.json
+++ b/backend/scripts/verification/artifacts/discovery_classifier_validation_report.json
@@ -1,0 +1,205 @@
+{
+  "generated_at": "2026-04-07T13:52:38.526268+00:00",
+  "fixture_path": "backend/scripts/verification/fixtures/discovery_classifier_eval_set.json",
+  "stubbed_responses_path": "backend/scripts/verification/fixtures/discovery_classifier_stubbed_responses.json",
+  "sample_size": 10,
+  "positive_examples": 7,
+  "negative_examples": 3,
+  "candidate_provenance": [
+    {
+      "url": "https://sanjose.legistar.com/Calendar.aspx",
+      "expected_scrapable": true,
+      "provenance_source": "scripts/lib/substrate_source_inventory.json",
+      "provenance_note": "jurisdiction_slug=san-jose, source_name=San Jose Legistar Calendar"
+    },
+    {
+      "url": "https://sunnyvaleca.legistar.com/Calendar.aspx",
+      "expected_scrapable": true,
+      "provenance_source": "scripts/lib/substrate_source_inventory.json",
+      "provenance_note": "jurisdiction_slug=sunnyvale, source_name=Sunnyvale Legistar Calendar"
+    },
+    {
+      "url": "https://cupertino.legistar.com/Calendar.aspx",
+      "expected_scrapable": true,
+      "provenance_source": "scripts/lib/substrate_source_inventory.json",
+      "provenance_note": "jurisdiction_slug=cupertino, source_name=Cupertino Legistar Calendar"
+    },
+    {
+      "url": "https://mountainview.legistar.com/Calendar.aspx",
+      "expected_scrapable": true,
+      "provenance_source": "scripts/lib/substrate_source_inventory.json",
+      "provenance_note": "jurisdiction_slug=mountain-view, source_name=Mountain View Legistar Calendar"
+    },
+    {
+      "url": "https://sanmateocounty.legistar.com/Calendar.aspx",
+      "expected_scrapable": true,
+      "provenance_source": "scripts/lib/substrate_source_inventory.json",
+      "provenance_note": "jurisdiction_slug=san-mateo-county, source_name=San Mateo County Legistar Calendar"
+    },
+    {
+      "url": "https://www.milpitas.gov/archive.aspx",
+      "expected_scrapable": true,
+      "provenance_source": "scripts/lib/substrate_source_inventory.json",
+      "provenance_note": "jurisdiction_slug=milpitas, source_name=Milpitas Archive Center (Agendas and Minutes)"
+    },
+    {
+      "url": "https://apps.acgov.org/agenda_minutes_app/board/bos_calendar/ag_min.jsp",
+      "expected_scrapable": true,
+      "provenance_source": "scripts/lib/substrate_source_inventory.json",
+      "provenance_note": "jurisdiction_slug=alameda-county, source_name=Alameda County BOS Agenda/Minutes App Root"
+    },
+    {
+      "url": "https://www.sanjoseinside.com/local-news/housing-update",
+      "expected_scrapable": false,
+      "provenance_source": "synthetic_negative",
+      "provenance_note": "Third-party editorial surface"
+    },
+    {
+      "url": "https://www.facebook.com/cityofsanjose/posts/12345",
+      "expected_scrapable": false,
+      "provenance_source": "synthetic_negative",
+      "provenance_note": "Third-party social surface"
+    },
+    {
+      "url": "https://www.youtube.com/watch?v=abcdefgh",
+      "expected_scrapable": false,
+      "provenance_source": "synthetic_negative",
+      "provenance_note": "Third-party video surface"
+    }
+  ],
+  "gate_requirements": {
+    "min_precision": 0.7,
+    "min_recall": 0.7,
+    "min_negative_rejection_rate": 0.7,
+    "max_false_positive_rate": 0.3
+  },
+  "sweep": [
+    {
+      "threshold": 0.5,
+      "total": 10,
+      "positives": 7,
+      "negatives": 3,
+      "true_positives": 7,
+      "false_positives": 1,
+      "true_negatives": 2,
+      "false_negatives": 0,
+      "precision": 0.875,
+      "recall": 1.0,
+      "f1": 0.9333333333333333,
+      "false_positive_rate": 0.3333333333333333,
+      "negative_rejection_rate": 0.6666666666666666
+    },
+    {
+      "threshold": 0.6,
+      "total": 10,
+      "positives": 7,
+      "negatives": 3,
+      "true_positives": 7,
+      "false_positives": 1,
+      "true_negatives": 2,
+      "false_negatives": 0,
+      "precision": 0.875,
+      "recall": 1.0,
+      "f1": 0.9333333333333333,
+      "false_positive_rate": 0.3333333333333333,
+      "negative_rejection_rate": 0.6666666666666666
+    },
+    {
+      "threshold": 0.65,
+      "total": 10,
+      "positives": 7,
+      "negatives": 3,
+      "true_positives": 7,
+      "false_positives": 1,
+      "true_negatives": 2,
+      "false_negatives": 0,
+      "precision": 0.875,
+      "recall": 1.0,
+      "f1": 0.9333333333333333,
+      "false_positive_rate": 0.3333333333333333,
+      "negative_rejection_rate": 0.6666666666666666
+    },
+    {
+      "threshold": 0.7,
+      "total": 10,
+      "positives": 7,
+      "negatives": 3,
+      "true_positives": 6,
+      "false_positives": 1,
+      "true_negatives": 2,
+      "false_negatives": 1,
+      "precision": 0.8571428571428571,
+      "recall": 0.8571428571428571,
+      "f1": 0.8571428571428571,
+      "false_positive_rate": 0.3333333333333333,
+      "negative_rejection_rate": 0.6666666666666666
+    },
+    {
+      "threshold": 0.75,
+      "total": 10,
+      "positives": 7,
+      "negatives": 3,
+      "true_positives": 5,
+      "false_positives": 0,
+      "true_negatives": 3,
+      "false_negatives": 2,
+      "precision": 1.0,
+      "recall": 0.7142857142857143,
+      "f1": 0.8333333333333333,
+      "false_positive_rate": 0.0,
+      "negative_rejection_rate": 1.0
+    },
+    {
+      "threshold": 0.8,
+      "total": 10,
+      "positives": 7,
+      "negatives": 3,
+      "true_positives": 4,
+      "false_positives": 0,
+      "true_negatives": 3,
+      "false_negatives": 3,
+      "precision": 1.0,
+      "recall": 0.5714285714285714,
+      "f1": 0.7272727272727273,
+      "false_positive_rate": 0.0,
+      "negative_rejection_rate": 1.0
+    },
+    {
+      "threshold": 0.85,
+      "total": 10,
+      "positives": 7,
+      "negatives": 3,
+      "true_positives": 3,
+      "false_positives": 0,
+      "true_negatives": 3,
+      "false_negatives": 4,
+      "precision": 1.0,
+      "recall": 0.42857142857142855,
+      "f1": 0.6,
+      "false_positive_rate": 0.0,
+      "negative_rejection_rate": 1.0
+    }
+  ],
+  "recommendation": {
+    "min_confidence": 0.75,
+    "passes_acceptance_gate": true,
+    "metrics": {
+      "threshold": 0.75,
+      "total": 10,
+      "positives": 7,
+      "negatives": 3,
+      "true_positives": 5,
+      "false_positives": 0,
+      "true_negatives": 3,
+      "false_negatives": 2,
+      "precision": 1.0,
+      "recall": 0.7142857142857143,
+      "f1": 0.8333333333333333,
+      "false_positive_rate": 0.0,
+      "negative_rejection_rate": 1.0
+    }
+  },
+  "known_failure_modes": [
+    "False negatives remain for valid sources with thin/ambiguous snippets (https://www.milpitas.gov/archive.aspx, https://apps.acgov.org/agenda_minutes_app/board/bos_calendar/ag_min.jsp)."
+  ]
+}

--- a/backend/scripts/verification/fixtures/discovery_classifier_eval_set.json
+++ b/backend/scripts/verification/fixtures/discovery_classifier_eval_set.json
@@ -1,0 +1,82 @@
+[
+  {
+    "url": "https://sanjose.legistar.com/Calendar.aspx",
+    "page_text": "City of San Jose Calendar - Meeting Details, Agenda, Minutes",
+    "expected_scrapable": true,
+    "label": "Legistar meeting calendar",
+    "provenance_source": "scripts/lib/substrate_source_inventory.json",
+    "provenance_note": "jurisdiction_slug=san-jose, source_name=San Jose Legistar Calendar"
+  },
+  {
+    "url": "https://sunnyvaleca.legistar.com/Calendar.aspx",
+    "page_text": "Sunnyvale Legistar meeting calendar with agenda and minutes links.",
+    "expected_scrapable": true,
+    "label": "Legistar meeting calendar",
+    "provenance_source": "scripts/lib/substrate_source_inventory.json",
+    "provenance_note": "jurisdiction_slug=sunnyvale, source_name=Sunnyvale Legistar Calendar"
+  },
+  {
+    "url": "https://cupertino.legistar.com/Calendar.aspx",
+    "page_text": "Cupertino city meeting calendar with agenda/minutes assets.",
+    "expected_scrapable": true,
+    "label": "Legistar meeting calendar",
+    "provenance_source": "scripts/lib/substrate_source_inventory.json",
+    "provenance_note": "jurisdiction_slug=cupertino, source_name=Cupertino Legistar Calendar"
+  },
+  {
+    "url": "https://mountainview.legistar.com/Calendar.aspx",
+    "page_text": "Mountain View meeting calendar and published packets/minutes.",
+    "expected_scrapable": true,
+    "label": "Legistar meeting calendar",
+    "provenance_source": "scripts/lib/substrate_source_inventory.json",
+    "provenance_note": "jurisdiction_slug=mountain-view, source_name=Mountain View Legistar Calendar"
+  },
+  {
+    "url": "https://sanmateocounty.legistar.com/Calendar.aspx",
+    "page_text": "County board calendar with agenda and minute artifacts.",
+    "expected_scrapable": true,
+    "label": "Legistar meeting calendar",
+    "provenance_source": "scripts/lib/substrate_source_inventory.json",
+    "provenance_note": "jurisdiction_slug=san-mateo-county, source_name=San Mateo County Legistar Calendar"
+  },
+  {
+    "url": "https://www.milpitas.gov/archive.aspx",
+    "page_text": "Milpitas archive center with agenda and minute file entries.",
+    "expected_scrapable": true,
+    "label": "Custom archive meeting root",
+    "provenance_source": "scripts/lib/substrate_source_inventory.json",
+    "provenance_note": "jurisdiction_slug=milpitas, source_name=Milpitas Archive Center (Agendas and Minutes)"
+  },
+  {
+    "url": "https://apps.acgov.org/agenda_minutes_app/board/bos_calendar/ag_min.jsp",
+    "page_text": "Alameda County BOS agenda/minutes application root.",
+    "expected_scrapable": true,
+    "label": "Custom archive meeting root",
+    "provenance_source": "scripts/lib/substrate_source_inventory.json",
+    "provenance_note": "jurisdiction_slug=alameda-county, source_name=Alameda County BOS Agenda/Minutes App Root"
+  },
+  {
+    "url": "https://www.sanjoseinside.com/local-news/housing-update",
+    "page_text": "Opinion and local news article about housing policies",
+    "expected_scrapable": false,
+    "label": "News article, not source system",
+    "provenance_source": "synthetic_negative",
+    "provenance_note": "Third-party editorial surface"
+  },
+  {
+    "url": "https://www.facebook.com/cityofsanjose/posts/12345",
+    "page_text": "Social post announcing tonight's city council session",
+    "expected_scrapable": false,
+    "label": "Social media post",
+    "provenance_source": "synthetic_negative",
+    "provenance_note": "Third-party social surface"
+  },
+  {
+    "url": "https://www.youtube.com/watch?v=abcdefgh",
+    "page_text": "Public livestream recording",
+    "expected_scrapable": false,
+    "label": "Video platform landing page",
+    "provenance_source": "synthetic_negative",
+    "provenance_note": "Third-party video surface"
+  }
+]

--- a/backend/scripts/verification/fixtures/discovery_classifier_stubbed_responses.json
+++ b/backend/scripts/verification/fixtures/discovery_classifier_stubbed_responses.json
@@ -1,0 +1,112 @@
+[
+  {
+    "url": "https://sanjose.legistar.com/Calendar.aspx",
+    "response": {
+      "is_scrapable": true,
+      "jurisdiction_name": "San Jose",
+      "source_type": "agenda",
+      "recommended_spider": "legistar",
+      "confidence": 0.93,
+      "reasoning": "Official meeting portal."
+    }
+  },
+  {
+    "url": "https://sunnyvaleca.legistar.com/Calendar.aspx",
+    "response": {
+      "is_scrapable": true,
+      "jurisdiction_name": "Sunnyvale",
+      "source_type": "agenda",
+      "recommended_spider": "legistar",
+      "confidence": 0.89,
+      "reasoning": "Legistar meeting calendar."
+    }
+  },
+  {
+    "url": "https://cupertino.legistar.com/Calendar.aspx",
+    "response": {
+      "is_scrapable": true,
+      "jurisdiction_name": "Cupertino",
+      "source_type": "agenda",
+      "recommended_spider": "legistar",
+      "confidence": 0.86,
+      "reasoning": "Legistar meeting calendar."
+    }
+  },
+  {
+    "url": "https://mountainview.legistar.com/Calendar.aspx",
+    "response": {
+      "is_scrapable": true,
+      "jurisdiction_name": "Mountain View",
+      "source_type": "agenda",
+      "recommended_spider": "legistar",
+      "confidence": 0.84,
+      "reasoning": "Legistar calendar appears valid."
+    }
+  },
+  {
+    "url": "https://sanmateocounty.legistar.com/Calendar.aspx",
+    "response": {
+      "is_scrapable": true,
+      "jurisdiction_name": "San Mateo County",
+      "source_type": "agenda",
+      "recommended_spider": "legistar",
+      "confidence": 0.79,
+      "reasoning": "County Legistar calendar."
+    }
+  },
+  {
+    "url": "https://www.milpitas.gov/archive.aspx",
+    "response": {
+      "is_scrapable": true,
+      "jurisdiction_name": "Milpitas",
+      "source_type": "minutes",
+      "recommended_spider": "generic_minutes",
+      "confidence": 0.71,
+      "reasoning": "Archive center likely hosts meeting records."
+    }
+  },
+  {
+    "url": "https://apps.acgov.org/agenda_minutes_app/board/bos_calendar/ag_min.jsp",
+    "response": {
+      "is_scrapable": true,
+      "jurisdiction_name": "Alameda County",
+      "source_type": "agenda",
+      "recommended_spider": "generic",
+      "confidence": 0.68,
+      "reasoning": "Official app root but sparse text."
+    }
+  },
+  {
+    "url": "https://www.sanjoseinside.com/local-news/housing-update",
+    "response": {
+      "is_scrapable": false,
+      "jurisdiction_name": "Unknown",
+      "source_type": "generic",
+      "recommended_spider": "none",
+      "confidence": 0.35,
+      "reasoning": "News page, not a source system."
+    }
+  },
+  {
+    "url": "https://www.facebook.com/cityofsanjose/posts/12345",
+    "response": {
+      "is_scrapable": false,
+      "jurisdiction_name": "Unknown",
+      "source_type": "generic",
+      "recommended_spider": "none",
+      "confidence": 0.2,
+      "reasoning": "Social media content."
+    }
+  },
+  {
+    "url": "https://www.youtube.com/watch?v=abcdefgh",
+    "response": {
+      "is_scrapable": true,
+      "jurisdiction_name": "Unknown",
+      "source_type": "generic",
+      "recommended_spider": "generic",
+      "confidence": 0.73,
+      "reasoning": "Video could mention council meeting but is not stable source root."
+    }
+  }
+]

--- a/backend/scripts/verification/validate_discovery_classifier.py
+++ b/backend/scripts/verification/validate_discovery_classifier.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Evaluate discovery classifier usefulness on labeled candidates."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from services.discovery.classifier_validation import (
+    ClassifierAcceptanceGate,
+    ClassifierResponse,
+    LabeledDiscoveryCandidate,
+    build_outcomes,
+    passes_acceptance_gate,
+    recommend_threshold,
+    summarize_failure_modes,
+    sweep_thresholds,
+)
+
+
+DEFAULT_FIXTURE = (
+    Path(__file__).resolve().parent / "fixtures" / "discovery_classifier_eval_set.json"
+)
+DEFAULT_ARTIFACT = (
+    Path(__file__).resolve().parent
+    / "artifacts"
+    / "discovery_classifier_validation_report.json"
+)
+DEFAULT_THRESHOLDS = (0.50, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", type=Path, default=DEFAULT_FIXTURE)
+    parser.add_argument("--artifact", type=Path, default=DEFAULT_ARTIFACT)
+    parser.add_argument(
+        "--thresholds",
+        default=",".join(str(v) for v in DEFAULT_THRESHOLDS),
+        help="Comma-separated confidence thresholds (e.g. 0.6,0.7,0.8).",
+    )
+    parser.add_argument(
+        "--responses",
+        type=Path,
+        default=None,
+        help="Optional JSON file of DiscoveryResponse payloads keyed by URL.",
+    )
+    return parser.parse_args()
+
+
+def load_candidates(path: Path) -> list[LabeledDiscoveryCandidate]:
+    payload = json.loads(path.read_text())
+    return [LabeledDiscoveryCandidate.model_validate(item) for item in payload]
+
+
+def parse_thresholds(raw_value: str) -> list[float]:
+    values = []
+    for token in raw_value.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        values.append(float(token))
+    if not values:
+        raise ValueError("At least one threshold is required")
+    return values
+
+
+def load_stubbed_responses(
+    path: Path,
+    candidates: Sequence[LabeledDiscoveryCandidate],
+) -> list[ClassifierResponse]:
+    payload = json.loads(path.read_text())
+    by_url = {item["url"]: item["response"] for item in payload}
+    responses = []
+    for candidate in candidates:
+        if candidate.url not in by_url:
+            raise ValueError(f"Missing stub response for URL: {candidate.url}")
+        responses.append(ClassifierResponse.model_validate(by_url[candidate.url]))
+    return responses
+
+
+async def score_with_live_classifier(
+    candidates: Sequence[LabeledDiscoveryCandidate],
+) -> list[ClassifierResponse]:
+    missing = _live_runtime_preflight()
+    if missing:
+        raise RuntimeError(_format_live_runtime_error(missing))
+
+    from services.discovery.service import AutoDiscoveryService
+
+    classifier = AutoDiscoveryService()
+    responses: list[ClassifierResponse] = []
+    for candidate in candidates:
+        raw = await classifier.discover_url(url=candidate.url, page_text=candidate.page_text)
+        responses.append(
+            ClassifierResponse(
+                is_scrapable=raw.is_scrapable,
+                confidence=raw.confidence,
+                reasoning=raw.reasoning,
+            )
+        )
+    return responses
+
+
+def _live_runtime_preflight() -> list[str]:
+    missing: list[str] = []
+    if importlib.util.find_spec("instructor") is None:
+        missing.append(
+            "python dependency `instructor` not installed (run `cd backend && poetry install`)"
+        )
+    if importlib.util.find_spec("openai") is None:
+        missing.append(
+            "python dependency `openai` not installed (run `cd backend && poetry install`)"
+        )
+    if not os.getenv("ZAI_API_KEY") and not os.getenv("OPENROUTER_API_KEY"):
+        missing.append("missing `ZAI_API_KEY` or `OPENROUTER_API_KEY` in environment")
+    return missing
+
+
+def _format_live_runtime_error(missing: Sequence[str]) -> str:
+    lines = [
+        "Live classifier mode preflight failed.",
+        "Use --responses for deterministic offline validation, or satisfy live requirements:",
+    ]
+    lines.extend(f"- {item}" for item in missing)
+    return "\n".join(lines)
+
+
+async def main() -> int:
+    args = parse_args()
+    thresholds = parse_thresholds(args.thresholds)
+    gate = ClassifierAcceptanceGate()
+    candidates = load_candidates(args.fixture)
+
+    try:
+        if args.responses:
+            responses = load_stubbed_responses(args.responses, candidates)
+        else:
+            responses = await score_with_live_classifier(candidates)
+    except RuntimeError as exc:
+        print(f"[discovery-classifier] {exc}")
+        return 2
+
+    sweep = sweep_thresholds(candidates=candidates, responses=responses, thresholds=thresholds)
+    recommendation = recommend_threshold(sweep, gate)
+    outcomes = build_outcomes(candidates, responses, threshold=recommendation.threshold)
+    failure_modes = summarize_failure_modes(outcomes)
+    gate_passes = passes_acceptance_gate(recommendation, gate)
+
+    report = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "fixture_path": str(args.fixture),
+        "stubbed_responses_path": str(args.responses) if args.responses else None,
+        "sample_size": len(candidates),
+        "positive_examples": sum(1 for candidate in candidates if candidate.expected_scrapable),
+        "negative_examples": sum(1 for candidate in candidates if not candidate.expected_scrapable),
+        "candidate_provenance": [
+            {
+                "url": candidate.url,
+                "expected_scrapable": candidate.expected_scrapable,
+                "provenance_source": candidate.provenance_source,
+                "provenance_note": candidate.provenance_note,
+            }
+            for candidate in candidates
+        ],
+        "gate_requirements": gate.model_dump(),
+        "sweep": [item.model_dump() for item in sweep],
+        "recommendation": {
+            "min_confidence": recommendation.threshold,
+            "passes_acceptance_gate": gate_passes,
+            "metrics": recommendation.model_dump(),
+        },
+        "known_failure_modes": failure_modes,
+    }
+
+    args.artifact.parent.mkdir(parents=True, exist_ok=True)
+    args.artifact.write_text(json.dumps(report, indent=2) + "\n")
+
+    print(
+        f"[discovery-classifier] threshold={recommendation.threshold:.2f} "
+        f"precision={recommendation.precision:.2f} recall={recommendation.recall:.2f} "
+        f"fpr={recommendation.false_positive_rate:.2f} pass={gate_passes}"
+    )
+    print(f"[discovery-classifier] report={args.artifact}")
+    return 0 if gate_passes else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/backend/services/discovery/__init__.py
+++ b/backend/services/discovery/__init__.py
@@ -1,3 +1,21 @@
-from .service import AutoDiscoveryService, DiscoveryResponse
+from .classifier_validation import (
+    LabeledDiscoveryCandidate,
+    EvaluationMetrics,
+    ClassifierAcceptanceGate,
+    ClassifierResponse,
+)
 
-__all__ = ["AutoDiscoveryService", "DiscoveryResponse"]
+try:
+    from .service import AutoDiscoveryService, DiscoveryResponse
+except ModuleNotFoundError:  # pragma: no cover - local test env may not install optional deps
+    AutoDiscoveryService = None
+    DiscoveryResponse = None
+
+__all__ = [
+    "AutoDiscoveryService",
+    "DiscoveryResponse",
+    "LabeledDiscoveryCandidate",
+    "EvaluationMetrics",
+    "ClassifierAcceptanceGate",
+    "ClassifierResponse",
+]

--- a/backend/services/discovery/classifier_validation.py
+++ b/backend/services/discovery/classifier_validation.py
@@ -1,0 +1,205 @@
+"""Validation helpers for discovery URL classifier scoring."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from pydantic import BaseModel, Field
+
+
+class LabeledDiscoveryCandidate(BaseModel):
+    """A discovery candidate with expected ground-truth label."""
+
+    url: str
+    page_text: str = ""
+    expected_scrapable: bool
+    label: str = Field(default="", description="Human-readable reason for label")
+    provenance_source: str = Field(
+        default="",
+        description="Repo path or source backing this label.",
+    )
+    provenance_note: str = Field(
+        default="",
+        description="Optional context for how this candidate maps to inventory.",
+    )
+
+
+class EvaluationMetrics(BaseModel):
+    threshold: float
+    total: int
+    positives: int
+    negatives: int
+    true_positives: int
+    false_positives: int
+    true_negatives: int
+    false_negatives: int
+    precision: float
+    recall: float
+    f1: float
+    false_positive_rate: float
+    negative_rejection_rate: float
+
+
+class ClassifierAcceptanceGate(BaseModel):
+    """Minimum bar required before cron ingestion can trust classifier output."""
+
+    min_precision: float = 0.70
+    min_recall: float = 0.70
+    min_negative_rejection_rate: float = 0.70
+    max_false_positive_rate: float = 0.30
+
+
+@dataclass(frozen=True)
+class CandidateOutcome:
+    url: str
+    expected_scrapable: bool
+    predicted_scrapable: bool
+    confidence: float
+    reasoning: str
+
+
+class ClassifierResponse(BaseModel):
+    is_scrapable: bool
+    confidence: float
+    reasoning: str = ""
+
+
+def evaluate_predictions(
+    candidates: Sequence[LabeledDiscoveryCandidate],
+    responses: Sequence[ClassifierResponse],
+    threshold: float,
+) -> EvaluationMetrics:
+    if len(candidates) != len(responses):
+        raise ValueError("candidates and responses length must match")
+
+    tp = fp = tn = fn = 0
+    positives = negatives = 0
+
+    for candidate, response in zip(candidates, responses):
+        expected_positive = candidate.expected_scrapable
+        predicted_positive = response.is_scrapable and response.confidence >= threshold
+
+        if expected_positive:
+            positives += 1
+            if predicted_positive:
+                tp += 1
+            else:
+                fn += 1
+        else:
+            negatives += 1
+            if predicted_positive:
+                fp += 1
+            else:
+                tn += 1
+
+    precision = _safe_div(tp, tp + fp)
+    recall = _safe_div(tp, tp + fn)
+    f1 = _safe_div(2 * precision * recall, precision + recall)
+    false_positive_rate = _safe_div(fp, fp + tn)
+    negative_rejection_rate = _safe_div(tn, tn + fp)
+
+    return EvaluationMetrics(
+        threshold=threshold,
+        total=len(candidates),
+        positives=positives,
+        negatives=negatives,
+        true_positives=tp,
+        false_positives=fp,
+        true_negatives=tn,
+        false_negatives=fn,
+        precision=precision,
+        recall=recall,
+        f1=f1,
+        false_positive_rate=false_positive_rate,
+        negative_rejection_rate=negative_rejection_rate,
+    )
+
+
+def sweep_thresholds(
+    candidates: Sequence[LabeledDiscoveryCandidate],
+    responses: Sequence[ClassifierResponse],
+    thresholds: Iterable[float],
+) -> list[EvaluationMetrics]:
+    return [evaluate_predictions(candidates, responses, threshold) for threshold in thresholds]
+
+
+def passes_acceptance_gate(
+    metrics: EvaluationMetrics,
+    gate: ClassifierAcceptanceGate,
+) -> bool:
+    return (
+        metrics.precision >= gate.min_precision
+        and metrics.recall >= gate.min_recall
+        and metrics.negative_rejection_rate >= gate.min_negative_rejection_rate
+        and metrics.false_positive_rate <= gate.max_false_positive_rate
+    )
+
+
+def recommend_threshold(
+    sweep_results: Sequence[EvaluationMetrics],
+    gate: ClassifierAcceptanceGate,
+) -> EvaluationMetrics:
+    if not sweep_results:
+        raise ValueError("sweep_results must not be empty")
+
+    passing = [result for result in sweep_results if passes_acceptance_gate(result, gate)]
+    if passing:
+        # For ingestion gating, prefer the strictest threshold that still passes all guardrails.
+        return sorted(
+            passing,
+            key=lambda result: (result.threshold, result.precision, -result.false_positive_rate),
+            reverse=True,
+        )[0]
+
+    # Fail-closed fallback: highest precision, then lowest FPR.
+    return sorted(
+        sweep_results,
+        key=lambda result: (result.precision, -result.false_positive_rate, result.threshold),
+        reverse=True,
+    )[0]
+
+
+def build_outcomes(
+    candidates: Sequence[LabeledDiscoveryCandidate],
+    responses: Sequence[ClassifierResponse],
+    threshold: float,
+) -> list[CandidateOutcome]:
+    outcomes: list[CandidateOutcome] = []
+    for candidate, response in zip(candidates, responses):
+        outcomes.append(
+            CandidateOutcome(
+                url=candidate.url,
+                expected_scrapable=candidate.expected_scrapable,
+                predicted_scrapable=response.is_scrapable and response.confidence >= threshold,
+                confidence=response.confidence,
+                reasoning=response.reasoning,
+            )
+        )
+    return outcomes
+
+
+def summarize_failure_modes(outcomes: Sequence[CandidateOutcome]) -> list[str]:
+    messages: list[str] = []
+    false_positives = [item for item in outcomes if item.predicted_scrapable and not item.expected_scrapable]
+    false_negatives = [item for item in outcomes if not item.predicted_scrapable and item.expected_scrapable]
+
+    if false_positives:
+        fp_examples = ", ".join(item.url for item in false_positives[:3])
+        messages.append(
+            f"False positives remain for plausible-looking but non-source pages ({fp_examples})."
+        )
+    if false_negatives:
+        fn_examples = ", ".join(item.url for item in false_negatives[:3])
+        messages.append(
+            f"False negatives remain for valid sources with thin/ambiguous snippets ({fn_examples})."
+        )
+    if not messages:
+        messages.append("No observed false positives/negatives on this evaluation set.")
+    return messages
+
+
+def _safe_div(numerator: float, denominator: float) -> float:
+    if denominator == 0:
+        return 0.0
+    return numerator / denominator

--- a/backend/tests/services/discovery/test_classifier_validation.py
+++ b/backend/tests/services/discovery/test_classifier_validation.py
@@ -1,0 +1,78 @@
+from services.discovery.classifier_validation import (
+    ClassifierAcceptanceGate,
+    ClassifierResponse,
+    LabeledDiscoveryCandidate,
+    build_outcomes,
+    evaluate_predictions,
+    passes_acceptance_gate,
+    recommend_threshold,
+    summarize_failure_modes,
+    sweep_thresholds,
+)
+
+
+def _candidates():
+    return [
+        LabeledDiscoveryCandidate(url="https://good-1.gov", expected_scrapable=True),
+        LabeledDiscoveryCandidate(url="https://good-2.gov", expected_scrapable=True),
+        LabeledDiscoveryCandidate(url="https://bad-1.com", expected_scrapable=False),
+        LabeledDiscoveryCandidate(url="https://bad-2.com", expected_scrapable=False),
+    ]
+
+
+def _responses():
+    return [
+        ClassifierResponse(
+            is_scrapable=True,
+            confidence=0.90,
+            reasoning="official page",
+        ),
+        ClassifierResponse(
+            is_scrapable=True,
+            confidence=0.62,
+            reasoning="probable page",
+        ),
+        ClassifierResponse(
+            is_scrapable=True,
+            confidence=0.58,
+            reasoning="ambiguous",
+        ),
+        ClassifierResponse(
+            is_scrapable=False,
+            confidence=0.20,
+            reasoning="not a source",
+        ),
+    ]
+
+
+def test_evaluate_predictions_counts():
+    metrics = evaluate_predictions(_candidates(), _responses(), threshold=0.60)
+    assert metrics.true_positives == 2
+    assert metrics.false_positives == 0
+    assert metrics.true_negatives == 2
+    assert metrics.false_negatives == 0
+    assert metrics.precision == 1.0
+    assert metrics.recall == 1.0
+
+
+def test_recommend_threshold_prefers_passing_high_recall():
+    sweep = sweep_thresholds(
+        candidates=_candidates(),
+        responses=_responses(),
+        thresholds=[0.55, 0.60, 0.70],
+    )
+    gate = ClassifierAcceptanceGate(
+        min_precision=0.70,
+        min_recall=0.70,
+        min_negative_rejection_rate=0.70,
+        max_false_positive_rate=0.30,
+    )
+    selected = recommend_threshold(sweep, gate)
+    assert selected.threshold == 0.60
+    assert passes_acceptance_gate(selected, gate) is True
+
+
+def test_summarize_failure_modes_includes_fp_and_fn():
+    outcomes = build_outcomes(_candidates(), _responses(), threshold=0.70)
+    messages = summarize_failure_modes(outcomes)
+    assert any("False negatives" in message for message in messages)

--- a/backend/tests/services/discovery/test_validate_discovery_classifier_script.py
+++ b/backend/tests/services/discovery/test_validate_discovery_classifier_script.py
@@ -1,0 +1,58 @@
+import json
+import sys
+
+import pytest
+
+from scripts.verification import validate_discovery_classifier as script
+
+
+@pytest.mark.asyncio
+async def test_validate_discovery_classifier_with_stubbed_responses(tmp_path, monkeypatch):
+    artifact_path = tmp_path / "report.json"
+    fixture_path = (
+        "backend/scripts/verification/fixtures/discovery_classifier_eval_set.json"
+    )
+    responses_path = (
+        "backend/scripts/verification/fixtures/discovery_classifier_stubbed_responses.json"
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "validate_discovery_classifier.py",
+            "--fixture",
+            fixture_path,
+            "--responses",
+            responses_path,
+            "--artifact",
+            str(artifact_path),
+        ],
+    )
+
+    exit_code = await script.main()
+    assert exit_code == 0
+    assert artifact_path.exists()
+
+    report = json.loads(artifact_path.read_text())
+    assert report["recommendation"]["min_confidence"] == 0.75
+    assert report["recommendation"]["passes_acceptance_gate"] is True
+    assert report["sample_size"] > 0
+    assert report["positive_examples"] > 0
+    assert report["negative_examples"] > 0
+    assert any(
+        item["provenance_source"] == "scripts/lib/substrate_source_inventory.json"
+        for item in report["candidate_provenance"]
+    )
+
+
+def test_live_runtime_preflight_requires_deps_and_api_key(monkeypatch):
+    monkeypatch.setattr(script.importlib.util, "find_spec", lambda _name: None)
+    monkeypatch.delenv("ZAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    missing = script._live_runtime_preflight()
+
+    assert any("instructor" in item for item in missing)
+    assert any("openai" in item for item in missing)
+    assert any("ZAI_API_KEY" in item for item in missing)

--- a/backend/tests/services/discovery/test_validate_discovery_classifier_script.py
+++ b/backend/tests/services/discovery/test_validate_discovery_classifier_script.py
@@ -1,19 +1,23 @@
 import json
 import sys
+from pathlib import Path
 
 import pytest
 
 from scripts.verification import validate_discovery_classifier as script
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
 
 
 @pytest.mark.asyncio
 async def test_validate_discovery_classifier_with_stubbed_responses(tmp_path, monkeypatch):
     artifact_path = tmp_path / "report.json"
     fixture_path = (
-        "backend/scripts/verification/fixtures/discovery_classifier_eval_set.json"
+        REPO_ROOT / "backend/scripts/verification/fixtures/discovery_classifier_eval_set.json"
     )
     responses_path = (
-        "backend/scripts/verification/fixtures/discovery_classifier_stubbed_responses.json"
+        REPO_ROOT
+        / "backend/scripts/verification/fixtures/discovery_classifier_stubbed_responses.json"
     )
 
     monkeypatch.setattr(
@@ -22,9 +26,9 @@ async def test_validate_discovery_classifier_with_stubbed_responses(tmp_path, mo
         [
             "validate_discovery_classifier.py",
             "--fixture",
-            fixture_path,
+            str(fixture_path),
             "--responses",
-            responses_path,
+            str(responses_path),
             "--artifact",
             str(artifact_path),
         ],

--- a/docs/specs/2026-04-07-discovery-classifier-validation.md
+++ b/docs/specs/2026-04-07-discovery-classifier-validation.md
@@ -1,0 +1,60 @@
+# 2026-04-07 Discovery Classifier Validation Contract (bd-gl47f.6)
+
+## Purpose
+
+Define a rerunnable, repo-local validation surface for the existing URL/page classifier in `backend/services/discovery/service.py` and produce the acceptance gate contract that `bd-gl47f.4` should use before creating new discovery sources.
+
+## Evaluation Surface
+
+- Labeled candidate set: `backend/scripts/verification/fixtures/discovery_classifier_eval_set.json`
+  - Positive examples are explicitly sourced from `scripts/lib/substrate_source_inventory.json` (current repo inventory)
+  - Negative examples are explicit synthetic third-party surfaces (news/social/video) used to measure false positives
+  - Candidate-level provenance is captured in the validation artifact
+- Validation runner: `backend/scripts/verification/validate_discovery_classifier.py`
+- Output artifact: `backend/scripts/verification/artifacts/discovery_classifier_validation_report.json`
+
+## Acceptance Gate Recommendation for bd-gl47f.4
+
+Use the classifier only when all of the following hold on the evaluation sweep:
+
+- `precision >= 0.70`
+- `recall >= 0.70`
+- `negative_rejection_rate >= 0.70`
+- `false_positive_rate <= 0.30`
+
+Recommended `min_confidence` from the stubbed baseline sweep: `0.75`.
+
+Per-candidate cron gating contract for the next subtask (`bd-gl47f.4`):
+
+- accept candidate only if `is_scrapable == true` and `confidence >= 0.75`
+- if batch-level gate fails, fail closed (no source creation) and report metrics
+
+## Known Failure Modes (Current Baseline)
+
+- Plausible third-party pages can still score above threshold (false positive risk)
+  - example class: video/news pages discussing a meeting without hosting canonical agenda/minute documents
+- Thin snippets on real official pages can score below threshold (false negative risk)
+  - example class: sparse meeting calendar pages with little inline text
+
+## Rerun Commands
+
+From `backend/`:
+
+```bash
+python scripts/verification/validate_discovery_classifier.py \
+  --fixture scripts/verification/fixtures/discovery_classifier_eval_set.json \
+  --responses scripts/verification/fixtures/discovery_classifier_stubbed_responses.json
+```
+
+Live classifier run (requires `ZAI_API_KEY` or `OPENROUTER_API_KEY`):
+
+```bash
+python scripts/verification/validate_discovery_classifier.py
+```
+
+Live preflight contract:
+
+- If live requirements are missing, the script exits with code `2` and a clear actionable message.
+- Live mode requires:
+  - backend dependencies installed (`cd backend && poetry install`) so `instructor` and `openai` are importable
+  - one API key in environment: `ZAI_API_KEY` or `OPENROUTER_API_KEY`

--- a/docs/specs/2026-04-07-discovery-hardening-plan.md
+++ b/docs/specs/2026-04-07-discovery-hardening-plan.md
@@ -1,0 +1,282 @@
+# 2026-04-07 Discovery Hardening Plan (bd-gl47f)
+
+## Summary
+
+Affordabot should harden jurisdiction discovery before resuming broad coverage expansion.
+
+The current system is strong enough for founder-led, bounded waves, but too weak to act as the primary source-selection engine for scaling jurisdictions. The main problem is that discovery is still shallow, query-first, and overly dependent on upstream search ranking instead of proving first-party publishing roots and truthful agenda/minute surfaces.
+
+## Problem
+
+Current discovery has three loosely connected modes:
+
+1. Manual source inventory for substrate waves
+2. Admin auto-discovery via LLM-generated search queries + web search results
+3. Legacy search-discovery helper using Z.ai structured search with Playwright fallback
+
+That mix creates several risks:
+
+- query-first instead of jurisdiction-site-map-first behavior
+- weak first-party bias beyond simple query wording
+- little local reranking or truth scoring
+- no clear staged promotion from search result -> official root -> family classification -> document validation -> inventory acceptance
+- too much founder judgment needed to tell "plausible URL" from "truthful publishing path"
+
+## Concise Critique
+
+### 1. Discovery is too shallow
+
+`AutoDiscoveryService` in [auto_discovery_service.py](../../backend/services/auto_discovery_service.py) generates 8-10 search queries, runs them through `WebSearchClient`, deduplicates exact URLs, and returns results. It does not deeply traverse the site or prove document surfaces.
+
+### 2. Relevance is mostly outsourced
+
+The current path mostly trusts the upstream search provider ordering. Affordabot does not meaningfully rerank by officiality, family fit, agenda/minute evidence, or likely publishing-root quality before returning URLs.
+
+### 3. Search results and truthful roots are conflated
+
+A plausible search hit is not the same thing as the correct first-party document root. The current design does not cleanly separate:
+
+- search candidate
+- official root
+- family classification
+- document-level validation
+- inventory promotion
+
+### 4. Manual inventory is more truthful than auto-discovery
+
+The recent substrate work proved that manually curated source inventory is more reliable than the current auto-discovery path. That is a warning sign: the automated discovery layer is not yet trustworthy enough to drive broad expansion.
+
+### 5. Legacy search helper remains uneven
+
+`SearchDiscoveryService` in [search_discovery.py](../../backend/services/discovery/search_discovery.py) uses direct Z.ai structured search and falls back to DuckDuckGo + Playwright. That adds redundancy, but not a coherent truth model. It still remains search-first and result-oriented rather than first-party-path-oriented.
+
+## What Z.ai Gives Us Today
+
+Official Z.ai documentation confirms the current external primitives are useful but insufficient on their own:
+
+- The Z.AI Web Search MCP Server provides comprehensive web search, real-time information retrieval, and a `webSearchPrime` tool that returns titles, URLs, summaries, site names, and icons. It is a search primitive, not a first-party truth engine. Source: [Z.AI Web Search MCP Server](https://docs.z.ai/devpack/mcp/search-mcp-server)
+- The Z.AI Web Reader MCP Server provides `webReader`, which fetches full webpage content, metadata, and links for a specified URL. It is a page-reading primitive, not a root-selection or family-classification system. Source: [Z.AI Web Reader MCP Server](https://docs.z.ai/devpack/mcp/reader-mcp-server)
+- The current Z.ai web-search docs reinforce search as a tool capability, but they do not solve jurisdiction-specific official-root discovery, bounded traversal, or truthful source promotion by themselves. Source: [Z.AI Web Search Guide](https://docs.z.ai/guides/tools/web-search)
+
+Practical takeaway:
+
+- Z.ai search is useful for candidate generation
+- Z.ai reader is useful for page inspection and link extraction
+- affordabot still needs its own first-party traversal, family classification, and truth scoring
+
+## Top 3 Upgrade Options
+
+### Option 1. Keep current search-first model and add better reranking
+
+What changes:
+
+- keep LLM query generation
+- keep search as primary entrypoint
+- add local scoring for official domains, family patterns, agenda/minute evidence, and jurisdiction consistency
+
+Pros:
+
+- smallest change
+- cheapest to implement
+- can improve current admin discovery quickly
+
+Cons:
+
+- still anchored on search result quality
+- still weak on deep first-party traversal
+- likely to keep producing plausible-but-shallow candidates
+
+Verdict:
+
+- useful as an incremental patch
+- not enough if the real goal is truthful jurisdiction expansion
+
+### Option 2. Build a staged first-party discovery pipeline
+
+What changes:
+
+- use search only to find likely official roots
+- then run bounded first-party traversal from those roots
+- classify discovered surfaces into known family / candidate new family / unsupported
+- validate whether agenda/minute document targets actually exist
+- only then promote to source inventory
+
+Pros:
+
+- strongest truth model
+- cleanest fit with affordabot’s moat
+- reduces founder arbitration over time
+- best long-term support for reusable-family expansion
+
+Cons:
+
+- more upfront work
+- needs a clearer architecture and acceptance model
+
+Verdict:
+
+- recommended option
+
+### Option 3. Use Z.ai search + reader as stronger front-end primitives, but keep truth scoring in affordabot
+
+What changes:
+
+- switch more discovery work onto Z.ai MCP search/reader surfaces
+- use reader for follow-up page extraction and link harvesting
+- still build affordabot-side scoring, family classification, and promotion rules
+
+Pros:
+
+- better external primitives than current shallow search-only usage
+- less brittle than pure query-first returns
+- lower lift than a full crawler from scratch
+
+Cons:
+
+- still needs affordabot-side truth model
+- still not sufficient without staged validation
+
+Verdict:
+
+- best supporting tactic inside Option 2, not a substitute for it
+
+## Recommended Plan
+
+Choose Option 2, supported by Option 3 primitives.
+
+Recommended active contract:
+
+- search is only candidate generation
+- first-party traversal is required before inventory promotion
+- family classification is explicit
+- agenda/minute validation is explicit
+- truth scoring is local and explainable
+- weak candidates remain hypotheses, not accepted sources
+
+## Target Architecture
+
+### Phase A. Official-root discovery
+
+Input:
+
+- jurisdiction name/type
+
+Method:
+
+- generate a small set of official-first search queries
+- constrain toward first-party government or official-partner domains
+- score likely root pages such as:
+  - agenda center
+  - archive center
+  - board/calendar pages
+  - legistar/granicus surfaces
+  - document center
+
+Output:
+
+- a shortlist of candidate official roots
+
+### Phase B. First-party traversal
+
+Method:
+
+- use reader/extractor tooling to fetch content and links
+- follow a bounded set of likely first-party links
+- stop after a small depth/budget
+
+Output:
+
+- a structured graph of likely civic publishing surfaces
+
+### Phase C. Family classification
+
+Method:
+
+- classify each root/surface into:
+  - existing known family
+  - candidate new family
+  - unsupported/ambiguous
+
+Output:
+
+- explicit family verdict and confidence
+
+### Phase D. Document-surface validation
+
+Method:
+
+- prove whether the surface yields real:
+  - agendas
+  - minutes
+  - optionally packets/attachments
+
+Output:
+
+- validation evidence, not just URL plausibility
+
+### Phase E. Truth scoring and inventory promotion
+
+Promote only when the candidate scores high enough on:
+
+- officiality
+- family fit
+- agenda/minute evidence
+- jurisdiction consistency
+- URL/path stability
+- repeatability
+
+## Beads Structure
+
+- `BEADS_EPIC`: `bd-gl47f`
+- `BEADS_CHILDREN`:
+  - `bd-gl47f.5` — Audit current discovery pipeline and external search surfaces
+  - `bd-gl47f.1` — Consultant pressure-test of discovery upgrade plan
+  - `bd-gl47f.3` — Design first-party truth-scored discovery architecture
+  - `bd-gl47f.4` — Implement discovery-hardening MVP
+- `BLOCKING_EDGES`:
+  - `bd-gl47f.3` blocks on `bd-gl47f.5`
+  - `bd-gl47f.3` blocks on `bd-gl47f.1`
+  - `bd-gl47f.4` blocks on `bd-gl47f.3`
+- `FIRST_TASK`: `bd-gl47f.5`
+
+## Validation Gates
+
+### Architecture Gate
+
+- current discovery pipeline is fully mapped
+- search/reader/tooling assumptions are documented
+- truth scoring and promotion gates are explicit
+
+### MVP Gate
+
+- bounded discovery run on a small jurisdiction set
+- candidate roots are explainable
+- promoted sources have explicit evidence for agendas/minutes
+- false-positive promotion rate is meaningfully lower than the current search-first path
+
+### Product Gate
+
+- founder can inspect why a source was accepted or rejected
+- new-family or existing-family expansion starts from better roots than current manual-first workaround
+
+## Risks
+
+- overbuilding a crawler before validating the scoring model
+- accidentally recreating a generic search engine instead of a government-root discovery system
+- mixing exploratory candidates with accepted inventory
+
+## Non-Goals
+
+- broad jurisdiction expansion in the same wave
+- generic consumer web search improvements
+- replacing all manual curation immediately
+
+## Recommended First Task
+
+Start with `bd-gl47f.5`.
+
+Why:
+
+- it creates the baseline critique and tool inventory
+- it turns current ambiguity into a concrete architecture target
+- it gives the consultant lane a stable artifact to pressure-test before implementation starts

--- a/docs/specs/2026-04-07-discovery-hardening-plan.md
+++ b/docs/specs/2026-04-07-discovery-hardening-plan.md
@@ -14,6 +14,13 @@ Current discovery has three loosely connected modes:
 2. Admin auto-discovery via LLM-generated search queries + web search results
 3. Legacy search-discovery helper using Z.ai structured search with Playwright fallback
 
+There is also a naming/documentation trap inside the code:
+
+- `AutoDiscoveryService` in [auto_discovery_service.py](../../backend/services/auto_discovery_service.py) is the search-query and result aggregation path
+- `AutoDiscoveryService` in [service.py](../../backend/services/discovery/service.py) is a separate URL/page-text classifier
+
+Those are different systems with different jobs, but the current plan did not name that split clearly enough.
+
 That mix creates several risks:
 
 - query-first instead of jurisdiction-site-map-first behavior
@@ -49,6 +56,14 @@ The recent substrate work proved that manually curated source inventory is more 
 ### 5. Legacy search helper remains uneven
 
 `SearchDiscoveryService` in [search_discovery.py](../../backend/services/discovery/search_discovery.py) uses direct Z.ai structured search and falls back to DuckDuckGo + Playwright. That adds redundancy, but not a coherent truth model. It still remains search-first and result-oriented rather than first-party-path-oriented.
+
+### 6. Discovery concepts are still ahead of implementation
+
+Terms like `family` and `substrate` are the right target abstractions, but they are not yet mature discovery-system boundaries in the current codebase. The first implementation wave should treat them as the destination architecture, not as proof that the discovery layer already works that way.
+
+### 7. Bounded traversal already has existence proofs
+
+Affordabot already has specialized discovery surfaces such as [municode_discovery.py](../../backend/services/discovery/municode_discovery.py). Those do not solve general discovery, but they are evidence that bounded traversal is a valid pattern in this repo and should influence the MVP design.
 
 ## What Z.ai Gives Us Today
 
@@ -153,7 +168,24 @@ Recommended active contract:
 - truth scoring is local and explainable
 - weak candidates remain hypotheses, not accepted sources
 
+But the first implementation step should be smaller than the full target architecture.
+
+## Updated MVP
+
+The initial MVP should not try to build the full five-phase pipeline.
+
+Instead, it should:
+
+1. validate whether the existing classifier in [service.py](../../backend/services/discovery/service.py) can separate good from bad URLs using current source inventory plus explicit negatives
+2. wire that classifier into [run_discovery.py](../../backend/scripts/cron/run_discovery.py)
+3. add a simple acceptance gate before new sources are created
+4. remove the current duplicate-write pattern in `run_discovery.py`
+
+This keeps the first implementation bounded to the existing cron ingestion path and avoids premature expansion into a larger crawler/traversal project before the scoring signal is proven useful.
+
 ## Target Architecture
+
+The following remains the correct long-term destination, but not the first implementation batch.
 
 ### Phase A. Official-root discovery
 
@@ -232,12 +264,40 @@ Promote only when the candidate scores high enough on:
   - `bd-gl47f.5` — Audit current discovery pipeline and external search surfaces
   - `bd-gl47f.1` — Consultant pressure-test of discovery upgrade plan
   - `bd-gl47f.3` — Design first-party truth-scored discovery architecture
+  - `bd-gl47f.6` — Validate discovery classifier scoring against source inventory
   - `bd-gl47f.4` — Implement discovery-hardening MVP
 - `BLOCKING_EDGES`:
   - `bd-gl47f.3` blocks on `bd-gl47f.5`
   - `bd-gl47f.3` blocks on `bd-gl47f.1`
+  - `bd-gl47f.6` blocks on `bd-gl47f.5`
   - `bd-gl47f.4` blocks on `bd-gl47f.3`
+  - `bd-gl47f.4` blocks on `bd-gl47f.6`
 - `FIRST_TASK`: `bd-gl47f.5`
+
+## Execution Phases
+
+### Phase 1. Audit and pressure-test
+
+- complete the current-state audit
+- incorporate consultant review
+- lock the narrowed MVP
+
+### Phase 2. Classifier validation
+
+- build a scored evaluation set from current inventory plus explicit negatives
+- measure whether the classifier can separate likely-good from likely-bad candidates
+- define the minimum acceptance threshold for cron gating
+
+### Phase 3. Cron-gated MVP
+
+- wire the classifier into [run_discovery.py](../../backend/scripts/cron/run_discovery.py)
+- only create sources when the acceptance gate passes
+- remove duplicate-write behavior
+- keep the implementation to the existing discovery cron path, no new dependencies
+
+### Phase 4. Long-term architecture follow-through
+
+- only after the MVP proves useful, expand toward first-party traversal, explicit family classification, and richer truth-scored promotion
 
 ## Validation Gates
 
@@ -249,10 +309,11 @@ Promote only when the candidate scores high enough on:
 
 ### MVP Gate
 
+- classifier evaluation set includes positive and negative examples
+- acceptance gate is explicitly defined before cron wiring lands
 - bounded discovery run on a small jurisdiction set
-- candidate roots are explainable
-- promoted sources have explicit evidence for agendas/minutes
 - false-positive promotion rate is meaningfully lower than the current search-first path
+- duplicate source creation path in `run_discovery.py` is eliminated or proven impossible
 
 ### Product Gate
 


### PR DESCRIPTION
## Summary
- add discovery hardening critique and plan before broad jurisdiction expansion
- capture current discovery weaknesses, Z.ai search/reader surfaces, top upgrade options, and Beads execution structure

## Testing
- not run (planning/docs only)

Agent: codex
Feature-Key: bd-gl47f