### PR TITLE
bd-gl47f.4: Harden discovery cron classifier-gated source creation

### DIFF
--- a/backend/scripts/cron/run_discovery.py
+++ b/backend/scripts/cron/run_discovery.py
@@ -9,7 +9,9 @@ import sys
 import os
 import logging
 import asyncio
+import json
 from datetime import datetime
+from pathlib import Path
 from uuid import uuid4
 
 # Add backend to path
@@ -17,11 +19,73 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '../../'))
 
 from db.postgres_client import PostgresDB
 from llm_common import WebSearchClient
-from services.auto_discovery_service import AutoDiscoveryService
+from services.auto_discovery_service import AutoDiscoveryService as SearchDiscoveryService
+from services.discovery.classifier_validation import (
+    ClassifierAcceptanceGate,
+    EvaluationMetrics,
+    passes_acceptance_gate,
+)
+from services.discovery.service import AutoDiscoveryService as DiscoveryClassifierService
 
 # Logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger("discovery")
+
+CLASSIFIER_MIN_CONFIDENCE = 0.75
+VALIDATION_REPORT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "verification"
+    / "artifacts"
+    / "discovery_classifier_validation_report.json"
+)
+
+
+def _load_classifier_validation_contract() -> tuple[bool, dict]:
+    """Load and verify classifier acceptance contract report."""
+    if not VALIDATION_REPORT_PATH.exists():
+        return False, {
+            "status": "failed",
+            "reason": "validation_report_missing",
+            "report_path": str(VALIDATION_REPORT_PATH),
+        }
+
+    try:
+        payload = json.loads(VALIDATION_REPORT_PATH.read_text())
+        recommendation = payload.get("recommendation", {})
+        metrics_payload = recommendation.get("metrics")
+        gate_payload = payload.get("gate_requirements", {})
+        report_says_pass = bool(recommendation.get("passes_acceptance_gate", False))
+        metrics = EvaluationMetrics.model_validate(metrics_payload)
+        gate = ClassifierAcceptanceGate.model_validate(gate_payload)
+        computed_pass = passes_acceptance_gate(metrics, gate)
+    except Exception as exc:
+        return False, {
+            "status": "failed",
+            "reason": "validation_report_invalid",
+            "error": str(exc),
+            "report_path": str(VALIDATION_REPORT_PATH),
+        }
+
+    if not (report_says_pass and computed_pass):
+        return False, {
+            "status": "failed",
+            "reason": "acceptance_gate_failed",
+            "report_path": str(VALIDATION_REPORT_PATH),
+            "report_pass": report_says_pass,
+            "computed_pass": computed_pass,
+            "metrics": metrics.model_dump(),
+            "gate_requirements": gate.model_dump(),
+        }
+
+    return True, {
+        "status": "passed",
+        "reason": "acceptance_gate_passed",
+        "report_path": str(VALIDATION_REPORT_PATH),
+        "min_confidence": CLASSIFIER_MIN_CONFIDENCE,
+        "metrics": metrics.model_dump(),
+        "gate_requirements": gate.model_dump(),
+    }
+
 
 async def main():
     task_id = str(uuid4())
@@ -31,13 +95,17 @@ async def main():
     search_client = WebSearchClient(
         api_key=os.environ.get("ZAI_API_KEY", "mock-key"),
     )
-    discovery_service = AutoDiscoveryService(search_client=search_client, db_client=db)
+    discovery_service = SearchDiscoveryService(search_client=search_client, db_client=db)
+    classifier_service = DiscoveryClassifierService()
+    gate_enabled, gate_contract = _load_classifier_validation_contract()
+    classifier_trusted = classifier_service.client is not None
     
     # 1. Log Start
     try:
         await db.create_admin_task(
             task_id=task_id,
             task_type='discovery',
+            jurisdiction='all',
             status='running'
         )
     except Exception as e:
@@ -49,8 +117,30 @@ async def main():
         jurisdictions_rows = await db._fetch("SELECT * FROM jurisdictions")
         jurisdictions = [dict(row) for row in jurisdictions_rows]
         
-        results = {"found": 0, "new": 0}
-        
+        results = {
+            "found": 0,
+            "accepted": 0,
+            "new": 0,
+            "duplicates": 0,
+            "rejected": 0,
+            "rejected_by_reason": {
+                "batch_gate_fail_closed": 0,
+                "classifier_untrusted_fail_closed": 0,
+                "classifier_error_fail_closed": 0,
+                "not_scrapable": 0,
+                "low_confidence": 0,
+            },
+            "batch_gate": gate_contract,
+            "classifier_trusted": classifier_trusted,
+            "classifier_min_confidence": CLASSIFIER_MIN_CONFIDENCE,
+        }
+
+        if not gate_enabled:
+            logger.error("Discovery source creation fail-closed: validation gate not satisfied")
+            logger.error("Gate details: %s", gate_contract)
+        if not classifier_trusted:
+            logger.error("Discovery source creation fail-closed: classifier client unavailable")
+
         for jur in jurisdictions:
             logger.info(f"🔎 Discovering for {jur['name']}...")
             
@@ -59,39 +149,97 @@ async def main():
             
             for item in discovered_items:
                 results["found"] += 1
-                
-                # Check duplication (PostgresDB doesn't have convenient chained query builder yet for exact logic)
-                # But get_or_create_source handles it IF we pass URL.
-                # Currently get_or_create_source uses name/type.
-                # Let's check manually.
-                
-                existing = await db._fetchrow("SELECT id FROM sources WHERE jurisdiction_id = $1 AND url = $2", jur['id'], item['url'])
-                
-                if not existing:
-                    # Create Source
-                    await db.get_or_create_source(
-                        jurisdiction_id=str(jur['id']),
-                        name=item['title'],
-                        type='web',
-                        url=item['url'] # Assuming we updated get_or_create_source to take URL or we do raw insert here?
-                        # PostgresDB in postgres_client.py needs to be checked.
-                        # Assuming raw insert for safety.
+                candidate_url = item.get("url")
+
+                if not candidate_url:
+                    results["rejected"] += 1
+                    results["rejected_by_reason"]["classifier_error_fail_closed"] += 1
+                    logger.info("   - Rejected (missing URL in discovery item)")
+                    continue
+
+                if not gate_enabled:
+                    results["rejected"] += 1
+                    results["rejected_by_reason"]["batch_gate_fail_closed"] += 1
+                    logger.info("   - Rejected (batch gate): %s", candidate_url)
+                    continue
+
+                if not classifier_trusted:
+                    results["rejected"] += 1
+                    results["rejected_by_reason"]["classifier_untrusted_fail_closed"] += 1
+                    logger.info("   - Rejected (classifier unavailable): %s", candidate_url)
+                    continue
+
+                try:
+                    classification = await classifier_service.discover_url(
+                        url=candidate_url,
+                        page_text=item.get("snippet", ""),
                     )
-                    # Or use raw insert to be sure about metadata
-                    await db.create_source({
-                        'jurisdiction_id': str(jur['id']),
-                        'name': item['title'],
-                        'type': 'web',
-                        'url': item['url'],
-                        'scrape_url': item['url'],
-                        'metadata': {
-                            'category': item['category'], 
-                            'snippet': item['snippet'],
-                            'discovered_at': datetime.now().isoformat()
-                        }
-                    })
-                    results["new"] += 1
-                    logger.info(f"   + Added: {item['title']}")
+                except Exception as exc:
+                    logger.warning("Classifier failure for %s: %s", candidate_url, exc)
+                    results["rejected"] += 1
+                    results["rejected_by_reason"]["classifier_error_fail_closed"] += 1
+                    continue
+
+                if not classification.is_scrapable:
+                    results["rejected"] += 1
+                    results["rejected_by_reason"]["not_scrapable"] += 1
+                    logger.info(
+                        "   - Rejected (not scrapable): %s (confidence=%.2f)",
+                        candidate_url,
+                        classification.confidence,
+                    )
+                    continue
+
+                if classification.confidence < CLASSIFIER_MIN_CONFIDENCE:
+                    results["rejected"] += 1
+                    results["rejected_by_reason"]["low_confidence"] += 1
+                    logger.info(
+                        "   - Rejected (confidence %.2f < %.2f): %s",
+                        classification.confidence,
+                        CLASSIFIER_MIN_CONFIDENCE,
+                        candidate_url,
+                    )
+                    continue
+
+                results["accepted"] += 1
+
+                existing = await db._fetchrow(
+                    "SELECT id FROM sources WHERE jurisdiction_id = $1 AND url = $2",
+                    jur['id'],
+                    candidate_url,
+                )
+
+                if existing:
+                    results["duplicates"] += 1
+                    logger.info(f"   = Duplicate (skip): {item['title']}")
+                    continue
+
+                await db.create_source({
+                    'jurisdiction_id': str(jur['id']),
+                    'name': item.get('title') or candidate_url,
+                    'type': 'web',
+                    'url': candidate_url,
+                    'scrape_url': candidate_url,
+                    'metadata': {
+                        'category': item.get('category', ''),
+                        'snippet': item.get('snippet', ''),
+                        'discovery_query': item.get('discovery_query'),
+                        'classifier': {
+                            'is_scrapable': classification.is_scrapable,
+                            'confidence': classification.confidence,
+                            'source_type': classification.source_type,
+                            'recommended_spider': classification.recommended_spider,
+                            'reasoning': classification.reasoning,
+                        },
+                        'discovered_at': datetime.now().isoformat(),
+                    }
+                })
+                results["new"] += 1
+                logger.info(
+                    "   + Added: %s (confidence=%.2f)",
+                    item.get('title') or candidate_url,
+                    classification.confidence,
+                )
         
         # 3. Log Success
         logger.info(f"🏁 Discovery Complete. {results}")

--- a/backend/tests/cron/test_run_discovery.py
+++ b/backend/tests/cron/test_run_discovery.py
@@ -16,7 +16,7 @@ sys.modules.setdefault(
 sys.modules.setdefault("instructor", SimpleNamespace(from_openai=MagicMock()))
 sys.modules.setdefault("openai", SimpleNamespace(AsyncOpenAI=MagicMock()))
 
-from scripts.cron import run_discovery
+from scripts.cron import run_discovery  # noqa: E402
 
 
 @patch("scripts.cron.run_discovery._load_classifier_validation_contract")

--- a/backend/tests/cron/test_run_discovery.py
+++ b/backend/tests/cron/test_run_discovery.py
@@ -1,26 +1,159 @@
+import sys
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.modules.setdefault(
+    "asyncpg",
+    SimpleNamespace(Record=object, Pool=object, create_pool=MagicMock()),
+)
+sys.modules.setdefault("llm_common", SimpleNamespace(WebSearchClient=MagicMock()))
+sys.modules.setdefault("llm_common.core", SimpleNamespace(LLMConfig=MagicMock()))
+sys.modules.setdefault("llm_common.providers", SimpleNamespace(ZaiClient=MagicMock()))
+sys.modules.setdefault(
+    "llm_common.core.models",
+    SimpleNamespace(LLMMessage=MagicMock(), MessageRole=SimpleNamespace(USER="user")),
+)
+sys.modules.setdefault("instructor", SimpleNamespace(from_openai=MagicMock()))
+sys.modules.setdefault("openai", SimpleNamespace(AsyncOpenAI=MagicMock()))
 
 from scripts.cron import run_discovery
 
 
-@patch("scripts.cron.run_discovery.AutoDiscoveryService")
+@patch("scripts.cron.run_discovery._load_classifier_validation_contract")
+@patch("scripts.cron.run_discovery.DiscoveryClassifierService")
+@patch("scripts.cron.run_discovery.SearchDiscoveryService")
 @patch("scripts.cron.run_discovery.WebSearchClient")
 @patch("scripts.cron.run_discovery.PostgresDB")
-async def test_run_discovery_wires_search_client(mock_db_cls, mock_search_client_cls, mock_service_cls):
+async def test_run_discovery_wires_search_client(
+    mock_db_cls,
+    mock_search_client_cls,
+    mock_search_service_cls,
+    mock_classifier_cls,
+    mock_gate_loader,
+):
     mock_db = MagicMock()
     mock_db.create_admin_task = AsyncMock()
     mock_db._fetch = AsyncMock(return_value=[])
     mock_db.update_admin_task = AsyncMock()
     mock_db_cls.return_value = mock_db
 
-    mock_service = MagicMock()
-    mock_service.discover_sources = AsyncMock(return_value=[])
-    mock_service_cls.return_value = mock_service
+    mock_search_service = MagicMock()
+    mock_search_service.discover_sources = AsyncMock(return_value=[])
+    mock_search_service_cls.return_value = mock_search_service
+
+    mock_classifier = MagicMock()
+    mock_classifier.client = object()
+    mock_classifier_cls.return_value = mock_classifier
+    mock_gate_loader.return_value = (True, {"status": "passed", "min_confidence": 0.75})
 
     await run_discovery.main()
 
     mock_search_client_cls.assert_called_once()
-    _, kwargs = mock_service_cls.call_args
+    _, kwargs = mock_search_service_cls.call_args
     assert kwargs["search_client"] is mock_search_client_cls.return_value
     assert kwargs["db_client"] is mock_db
 
+
+@patch("scripts.cron.run_discovery._load_classifier_validation_contract")
+@patch("scripts.cron.run_discovery.DiscoveryClassifierService")
+@patch("scripts.cron.run_discovery.SearchDiscoveryService")
+@patch("scripts.cron.run_discovery.WebSearchClient")
+@patch("scripts.cron.run_discovery.PostgresDB")
+async def test_run_discovery_fail_closed_when_batch_gate_fails(
+    mock_db_cls,
+    _mock_search_client_cls,
+    mock_search_service_cls,
+    mock_classifier_cls,
+    mock_gate_loader,
+):
+    mock_db = MagicMock()
+    mock_db.create_admin_task = AsyncMock()
+    mock_db._fetch = AsyncMock(return_value=[{"id": "jur-1", "name": "San Jose", "type": "city"}])
+    mock_db._fetchrow = AsyncMock()
+    mock_db.create_source = AsyncMock()
+    mock_db.update_admin_task = AsyncMock()
+    mock_db_cls.return_value = mock_db
+
+    mock_search_service = MagicMock()
+    mock_search_service.discover_sources = AsyncMock(
+        return_value=[
+            {
+                "url": "https://example.gov/agenda",
+                "title": "Agenda Center",
+                "category": "agenda",
+                "snippet": "meeting agendas",
+            }
+        ]
+    )
+    mock_search_service_cls.return_value = mock_search_service
+
+    mock_classifier = MagicMock()
+    mock_classifier.client = object()
+    mock_classifier.discover_url = AsyncMock()
+    mock_classifier_cls.return_value = mock_classifier
+    mock_gate_loader.return_value = (False, {"status": "failed", "reason": "acceptance_gate_failed"})
+
+    await run_discovery.main()
+
+    mock_classifier.discover_url.assert_not_called()
+    mock_db.create_source.assert_not_called()
+    update_kwargs = mock_db.update_admin_task.call_args.kwargs
+    assert update_kwargs["result"]["rejected_by_reason"]["batch_gate_fail_closed"] == 1
+
+
+@patch("scripts.cron.run_discovery._load_classifier_validation_contract")
+@patch("scripts.cron.run_discovery.DiscoveryClassifierService")
+@patch("scripts.cron.run_discovery.SearchDiscoveryService")
+@patch("scripts.cron.run_discovery.WebSearchClient")
+@patch("scripts.cron.run_discovery.PostgresDB")
+async def test_run_discovery_creates_single_source_write_with_classifier_gate(
+    mock_db_cls,
+    _mock_search_client_cls,
+    mock_search_service_cls,
+    mock_classifier_cls,
+    mock_gate_loader,
+):
+    mock_db = MagicMock()
+    mock_db.create_admin_task = AsyncMock()
+    mock_db._fetch = AsyncMock(return_value=[{"id": "jur-1", "name": "San Jose", "type": "city"}])
+    mock_db._fetchrow = AsyncMock(return_value=None)
+    mock_db.get_or_create_source = AsyncMock()
+    mock_db.create_source = AsyncMock()
+    mock_db.update_admin_task = AsyncMock()
+    mock_db_cls.return_value = mock_db
+
+    mock_search_service = MagicMock()
+    mock_search_service.discover_sources = AsyncMock(
+        return_value=[
+            {
+                "url": "https://example.gov/agenda",
+                "title": "Agenda Center",
+                "category": "agenda",
+                "snippet": "meeting agendas and minutes",
+                "discovery_query": "San Jose city council meetings",
+            }
+        ]
+    )
+    mock_search_service_cls.return_value = mock_search_service
+
+    mock_classifier = MagicMock()
+    mock_classifier.client = object()
+    mock_classifier.discover_url = AsyncMock(
+        return_value=MagicMock(
+            is_scrapable=True,
+            confidence=0.91,
+            source_type="agenda",
+            recommended_spider="generic",
+            reasoning="Official agenda index",
+        )
+    )
+    mock_classifier_cls.return_value = mock_classifier
+    mock_gate_loader.return_value = (True, {"status": "passed", "min_confidence": 0.75})
+
+    await run_discovery.main()
+
+    mock_db.get_or_create_source.assert_not_called()
+    mock_db.create_source.assert_called_once()
+    create_payload = mock_db.create_source.call_args.args[0]
+    assert create_payload["url"] == "https://example.gov/agenda"
+    assert create_payload["metadata"]["classifier"]["confidence"] == 0.91


### PR DESCRIPTION
## Summary
- gate discovery source creation on classifier validation acceptance report
- enforce per-candidate gate (`is_scrapable == true` and `confidence >= 0.75`) before source creation
- fail closed when batch validation gate fails or classifier cannot be trusted
- remove duplicate-write path in discovery cron and improve accepted/rejected reporting
- add cron tests for fail-closed gating and duplicate-write regression

## Validation
- `cd backend && pytest tests/cron/test_run_discovery.py tests/services/discovery/test_validate_discovery_classifier_script.py`
- `cd backend && python scripts/verification/validate_discovery_classifier.py --fixture scripts/verification/fixtures/discovery_classifier_eval_set.json --responses scripts/verification/fixtures/discovery_classifier_stubbed_responses.json`

Agent: codex