### PR TITLE
bd-5rc5o: bounded live validation for discovery gate

### DIFF
--- a/backend/scripts/cron/run_discovery.py
+++ b/backend/scripts/cron/run_discovery.py
@@ -10,6 +10,7 @@ import os
 import logging
 import asyncio
 import json
+import argparse
 from datetime import datetime
 from pathlib import Path
 from uuid import uuid4
@@ -20,6 +21,9 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '../../'))
 from db.postgres_client import PostgresDB
 from llm_common import WebSearchClient
 from services.auto_discovery_service import AutoDiscoveryService as SearchDiscoveryService
+from services.discovery.search_discovery import (
+    SearchDiscoveryService as LegacySearchDiscoveryService,
+)
 from services.discovery.classifier_validation import (
     ClassifierAcceptanceGate,
     EvaluationMetrics,
@@ -38,6 +42,66 @@ VALIDATION_REPORT_PATH = (
     / "artifacts"
     / "discovery_classifier_validation_report.json"
 )
+
+
+class ResilientWebSearchClient:
+    """Use llm_common search first, then fail over to legacy structured discovery search."""
+
+    def __init__(self, primary_client, fallback_service=None):
+        self.primary_client = primary_client
+        self.fallback_service = fallback_service
+
+    async def search(self, query: str):
+        try:
+            primary_results = await self.primary_client.search(query)
+            if primary_results:
+                return primary_results
+            logger.warning("Primary search returned no results; trying fallback for query '%s'", query)
+        except Exception as exc:
+            logger.warning("Primary search failed for query '%s': %s", query, exc)
+
+        if not self.fallback_service:
+            return []
+
+        try:
+            return await self.fallback_service.find_urls(query, count=10)
+        except Exception as exc:
+            logger.warning("Fallback search failed for query '%s': %s", query, exc)
+            return []
+
+
+def _normalize_jurisdiction_scope(values: list[str] | None) -> set[str] | None:
+    """Normalize optional jurisdiction scope list into casefolded names."""
+    if not values:
+        return None
+    normalized = {
+        value.strip().casefold()
+        for value in values
+        if value and value.strip()
+    }
+    return normalized or None
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run discovery cron with optional bounded scope.")
+    parser.add_argument(
+        "--jurisdiction",
+        action="append",
+        default=[],
+        help="Jurisdiction name to include. Repeat for multiple jurisdictions.",
+    )
+    parser.add_argument(
+        "--jurisdictions",
+        default="",
+        help="Comma-separated jurisdiction names to include.",
+    )
+    parser.add_argument(
+        "--max-queries-per-jurisdiction",
+        type=int,
+        default=None,
+        help="Optional cap for number of discovery queries per jurisdiction (for bounded validation runs).",
+    )
+    return parser.parse_args()
 
 
 def _load_classifier_validation_contract() -> tuple[bool, dict]:
@@ -87,13 +151,23 @@ def _load_classifier_validation_contract() -> tuple[bool, dict]:
     }
 
 
-async def main():
+async def main(
+    jurisdiction_scope: set[str] | None = None,
+    max_queries_per_jurisdiction: int | None = None,
+):
     task_id = str(uuid4())
     logger.info(f"🚀 Starting Discovery (Task {task_id})")
     
     db = PostgresDB()
-    search_client = WebSearchClient(
+    primary_search_client = WebSearchClient(
         api_key=os.environ.get("ZAI_API_KEY", "mock-key"),
+    )
+    fallback_search_service = LegacySearchDiscoveryService(
+        api_key=os.environ.get("ZAI_API_KEY"),
+    )
+    search_client = ResilientWebSearchClient(
+        primary_client=primary_search_client,
+        fallback_service=fallback_search_service,
     )
     discovery_service = SearchDiscoveryService(search_client=search_client, db_client=db)
     classifier_service = DiscoveryClassifierService()
@@ -115,7 +189,15 @@ async def main():
         # 2. Get Jurisdictions
         # For now, just active ones or all. Let's do all.
         jurisdictions_rows = await db._fetch("SELECT * FROM jurisdictions")
-        jurisdictions = [dict(row) for row in jurisdictions_rows]
+        all_jurisdictions = [dict(row) for row in jurisdictions_rows]
+        if jurisdiction_scope:
+            jurisdictions = [
+                jur
+                for jur in all_jurisdictions
+                if str(jur.get("name", "")).casefold() in jurisdiction_scope
+            ]
+        else:
+            jurisdictions = all_jurisdictions
         
         results = {
             "found": 0,
@@ -133,6 +215,10 @@ async def main():
             "batch_gate": gate_contract,
             "classifier_trusted": classifier_trusted,
             "classifier_min_confidence": CLASSIFIER_MIN_CONFIDENCE,
+            "jurisdiction_scope": sorted(jurisdiction_scope) if jurisdiction_scope else "all",
+            "jurisdictions_processed": len(jurisdictions),
+            "jurisdictions_available": len(all_jurisdictions),
+            "max_queries_per_jurisdiction": max_queries_per_jurisdiction,
         }
 
         if not gate_enabled:
@@ -145,7 +231,14 @@ async def main():
             logger.info(f"🔎 Discovering for {jur['name']}...")
             
             # Run Discovery
-            discovered_items = await discovery_service.discover_sources(jur['name'], jur.get('type', 'city'))
+            discover_kwargs = {}
+            if max_queries_per_jurisdiction is not None:
+                discover_kwargs["max_queries"] = max_queries_per_jurisdiction
+            discovered_items = await discovery_service.discover_sources(
+                jur['name'],
+                jur.get('type', 'city'),
+                **discover_kwargs,
+            )
             
             for item in discovered_items:
                 results["found"] += 1
@@ -263,4 +356,14 @@ async def main():
         sys.exit(1)
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    args = _parse_args()
+    scope_values = list(args.jurisdiction)
+    if args.jurisdictions:
+        scope_values.extend(item for item in args.jurisdictions.split(","))
+    scope = _normalize_jurisdiction_scope(scope_values)
+    asyncio.run(
+        main(
+            jurisdiction_scope=scope,
+            max_queries_per_jurisdiction=args.max_queries_per_jurisdiction,
+        )
+    )

--- a/backend/services/auto_discovery_service.py
+++ b/backend/services/auto_discovery_service.py
@@ -149,7 +149,10 @@ class AutoDiscoveryService:
         return templates.get(jurisdiction_type, templates["city"])
 
     async def discover_sources(
-        self, jurisdiction_name: str, jurisdiction_type: str = "city"
+        self,
+        jurisdiction_name: str,
+        jurisdiction_type: str = "city",
+        max_queries: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """
         Discover potential sources for a given jurisdiction.
@@ -162,6 +165,8 @@ class AutoDiscoveryService:
         """
         # Generate queries using LLM
         queries = await self.generate_queries(jurisdiction_name, jurisdiction_type)
+        if max_queries is not None and max_queries > 0:
+            queries = queries[:max_queries]
         
         all_results = []
         seen_urls = set()

--- a/backend/tests/cron/test_run_discovery.py
+++ b/backend/tests/cron/test_run_discovery.py
@@ -11,7 +11,11 @@ sys.modules.setdefault("llm_common.core", SimpleNamespace(LLMConfig=MagicMock())
 sys.modules.setdefault("llm_common.providers", SimpleNamespace(ZaiClient=MagicMock()))
 sys.modules.setdefault(
     "llm_common.core.models",
-    SimpleNamespace(LLMMessage=MagicMock(), MessageRole=SimpleNamespace(USER="user")),
+    SimpleNamespace(
+        LLMMessage=MagicMock(),
+        MessageRole=SimpleNamespace(USER="user"),
+        WebSearchResult=MagicMock(),
+    ),
 )
 sys.modules.setdefault("instructor", SimpleNamespace(from_openai=MagicMock()))
 sys.modules.setdefault("openai", SimpleNamespace(AsyncOpenAI=MagicMock()))
@@ -22,11 +26,13 @@ from scripts.cron import run_discovery  # noqa: E402
 @patch("scripts.cron.run_discovery._load_classifier_validation_contract")
 @patch("scripts.cron.run_discovery.DiscoveryClassifierService")
 @patch("scripts.cron.run_discovery.SearchDiscoveryService")
+@patch("scripts.cron.run_discovery.LegacySearchDiscoveryService")
 @patch("scripts.cron.run_discovery.WebSearchClient")
 @patch("scripts.cron.run_discovery.PostgresDB")
 async def test_run_discovery_wires_search_client(
     mock_db_cls,
     mock_search_client_cls,
+    mock_legacy_search_cls,
     mock_search_service_cls,
     mock_classifier_cls,
     mock_gate_loader,
@@ -49,19 +55,24 @@ async def test_run_discovery_wires_search_client(
     await run_discovery.main()
 
     mock_search_client_cls.assert_called_once()
+    mock_legacy_search_cls.assert_called_once()
     _, kwargs = mock_search_service_cls.call_args
-    assert kwargs["search_client"] is mock_search_client_cls.return_value
+    resilient_client = kwargs["search_client"]
+    assert resilient_client.primary_client is mock_search_client_cls.return_value
+    assert resilient_client.fallback_service is mock_legacy_search_cls.return_value
     assert kwargs["db_client"] is mock_db
 
 
 @patch("scripts.cron.run_discovery._load_classifier_validation_contract")
 @patch("scripts.cron.run_discovery.DiscoveryClassifierService")
 @patch("scripts.cron.run_discovery.SearchDiscoveryService")
+@patch("scripts.cron.run_discovery.LegacySearchDiscoveryService")
 @patch("scripts.cron.run_discovery.WebSearchClient")
 @patch("scripts.cron.run_discovery.PostgresDB")
 async def test_run_discovery_fail_closed_when_batch_gate_fails(
     mock_db_cls,
     _mock_search_client_cls,
+    _mock_legacy_search_cls,
     mock_search_service_cls,
     mock_classifier_cls,
     mock_gate_loader,
@@ -104,11 +115,13 @@ async def test_run_discovery_fail_closed_when_batch_gate_fails(
 @patch("scripts.cron.run_discovery._load_classifier_validation_contract")
 @patch("scripts.cron.run_discovery.DiscoveryClassifierService")
 @patch("scripts.cron.run_discovery.SearchDiscoveryService")
+@patch("scripts.cron.run_discovery.LegacySearchDiscoveryService")
 @patch("scripts.cron.run_discovery.WebSearchClient")
 @patch("scripts.cron.run_discovery.PostgresDB")
 async def test_run_discovery_creates_single_source_write_with_classifier_gate(
     mock_db_cls,
     _mock_search_client_cls,
+    _mock_legacy_search_cls,
     mock_search_service_cls,
     mock_classifier_cls,
     mock_gate_loader,
@@ -157,3 +170,73 @@ async def test_run_discovery_creates_single_source_write_with_classifier_gate(
     create_payload = mock_db.create_source.call_args.args[0]
     assert create_payload["url"] == "https://example.gov/agenda"
     assert create_payload["metadata"]["classifier"]["confidence"] == 0.91
+
+
+@patch("scripts.cron.run_discovery._load_classifier_validation_contract")
+@patch("scripts.cron.run_discovery.DiscoveryClassifierService")
+@patch("scripts.cron.run_discovery.SearchDiscoveryService")
+@patch("scripts.cron.run_discovery.LegacySearchDiscoveryService")
+@patch("scripts.cron.run_discovery.WebSearchClient")
+@patch("scripts.cron.run_discovery.PostgresDB")
+async def test_run_discovery_respects_jurisdiction_scope_filter(
+    mock_db_cls,
+    _mock_search_client_cls,
+    _mock_legacy_search_cls,
+    mock_search_service_cls,
+    mock_classifier_cls,
+    mock_gate_loader,
+):
+    mock_db = MagicMock()
+    mock_db.create_admin_task = AsyncMock()
+    mock_db._fetch = AsyncMock(
+        return_value=[
+            {"id": "jur-1", "name": "San Jose", "type": "city"},
+            {"id": "jur-2", "name": "Milpitas", "type": "city"},
+        ]
+    )
+    mock_db._fetchrow = AsyncMock(return_value={"id": "src-1"})
+    mock_db.create_source = AsyncMock()
+    mock_db.update_admin_task = AsyncMock()
+    mock_db_cls.return_value = mock_db
+
+    mock_search_service = MagicMock()
+    mock_search_service.discover_sources = AsyncMock(
+        return_value=[
+            {
+                "url": "https://example.gov/agenda",
+                "title": "Agenda Center",
+                "category": "agenda",
+                "snippet": "meeting agendas and minutes",
+            }
+        ]
+    )
+    mock_search_service_cls.return_value = mock_search_service
+
+    mock_classifier = MagicMock()
+    mock_classifier.client = object()
+    mock_classifier.discover_url = AsyncMock(
+        return_value=MagicMock(
+            is_scrapable=True,
+            confidence=0.91,
+            source_type="agenda",
+            recommended_spider="generic",
+            reasoning="Official agenda index",
+        )
+    )
+    mock_classifier_cls.return_value = mock_classifier
+    mock_gate_loader.return_value = (True, {"status": "passed", "min_confidence": 0.75})
+
+    await run_discovery.main(
+        jurisdiction_scope={"milpitas"},
+        max_queries_per_jurisdiction=2,
+    )
+
+    mock_search_service.discover_sources.assert_awaited_once_with(
+        "Milpitas",
+        "city",
+        max_queries=2,
+    )
+    update_kwargs = mock_db.update_admin_task.call_args.kwargs
+    assert update_kwargs["result"]["jurisdictions_processed"] == 1
+    assert update_kwargs["result"]["jurisdiction_scope"] == ["milpitas"]
+    assert update_kwargs["result"]["max_queries_per_jurisdiction"] == 2

--- a/docs/specs/2026-04-07-bd-5rc5o-live-validation-closeout.md
+++ b/docs/specs/2026-04-07-bd-5rc5o-live-validation-closeout.md
@@ -1,0 +1,75 @@
+# 2026-04-07 Live Validation Closeout (bd-5rc5o)
+
+## Scope
+
+Bounded live discovery validation against dev backend runtime using:
+
+- San Jose (control city)
+- Milpitas (challenging city)
+- Alameda County (challenging county)
+
+Runtime context (non-interactive Railway):
+
+- Project: `1ed20f8a-aeb7-4de6-a02c-8851fff50d4e`
+- Environment: `dev`
+- Service: `backend`
+
+## Command Run
+
+```bash
+railway run -p 1ed20f8a-aeb7-4de6-a02c-8851fff50d4e -e dev -s backend -- \
+  bash -lc 'cd backend && poetry run python scripts/cron/run_discovery.py \
+    --jurisdiction "San Jose" \
+    --jurisdiction "Milpitas" \
+    --jurisdiction "Alameda County" \
+    --max-queries-per-jurisdiction 2'
+```
+
+## Live Outcome
+
+Final run summary:
+
+- `found=0`
+- `accepted=0`
+- `new=0`
+- `duplicates=0`
+- `rejected=0`
+- `jurisdictions_processed=3`
+- `jurisdiction_scope=["alameda county","milpitas","san jose"]`
+- `max_queries_per_jurisdiction=2`
+- classifier acceptance gate status: `passed`
+- classifier trusted: `true`
+
+Observed operational failures during candidate generation:
+
+1. Primary `WebSearchClient` failure for every query:
+   - `[zai] Search failed: [Errno 8] nodename nor servname provided, or not known`
+2. Structured fallback (`services.discovery.search_discovery.SearchDiscoveryService`) returned zero URLs for tested queries.
+3. Playwright DuckDuckGo fallback failed repeatedly:
+   - `Page.wait_for_selector(".result__body")` timeout.
+
+Additional non-blocking runtime issue:
+
+- `admin_tasks` insert fails because `task_type='discovery'` violates DB check constraint (current allowed enum excludes `discovery`).
+
+## Interpretation
+
+This bounded live run completed but is **not operationally useful yet** for evaluating classifier gate quality on real candidates because upstream candidate generation produced zero candidates across all three jurisdictions.
+
+The gate itself did not fail; it was never meaningfully exercised (`found=0` means no accepted/rejected/duplicate path execution).
+
+## In-PR Non-Strategic Fixes Applied
+
+1. Added bounded jurisdiction scope controls to discovery cron:
+   - `--jurisdiction ...` (repeatable)
+   - `--jurisdictions "a,b,c"` (comma-separated)
+2. Added optional bounded query cap:
+   - `--max-queries-per-jurisdiction <N>`
+3. Added resilient search adapter in cron wiring:
+   - primary `llm_common.WebSearchClient`
+   - fallback to existing structured-search service when primary fails/returns empty
+4. Added/updated focused tests in `backend/tests/cron/test_run_discovery.py`.
+
+## Next Implication
+
+Immediate next work should target candidate-generation transport reliability (primary DNS failure and fallback search extraction reliability) before any policy judgment on discovery classifier threshold strictness.


### PR DESCRIPTION
## Summary
- add bounded jurisdiction controls for discovery cron live validation runs
- add resilient search fallback wiring and bounded query cap control
- execute bounded live validation in Railway dev runtime and document outcomes

## Validation
- cd backend && poetry run pytest tests/cron/test_run_discovery.py -q
- railway run -p 1ed20f8a-aeb7-4de6-a02c-8851fff50d4e -e dev -s backend -- bash -lc 'cd backend && poetry run python scripts/cron/run_discovery.py --jurisdiction "San Jose" --jurisdiction "Milpitas" --jurisdiction "Alameda County" --max-queries-per-jurisdiction 2'

Agent: codex