### PR TITLE
bd-ss6db: phase 1 provider-light discovery resilience

### DIFF
--- a/backend/db/postgres_client.py
+++ b/backend/db/postgres_client.py
@@ -377,6 +377,147 @@ class PostgresDB:
         row = await self._fetchrow(query, *insert_data.values())
         return dict(row)
 
+    async def get_discovery_query_cache(
+        self,
+        jurisdiction_name: str,
+        jurisdiction_type: str,
+        prompt_version: str,
+    ) -> Optional[List[str]]:
+        """Return cached discovery queries when available and not expired."""
+        try:
+            row = await self._fetchrow(
+                """
+                SELECT queries
+                FROM discovery_query_cache
+                WHERE jurisdiction_name = $1
+                  AND jurisdiction_type = $2
+                  AND prompt_version = $3
+                  AND expires_at > NOW()
+                LIMIT 1
+                """,
+                jurisdiction_name,
+                jurisdiction_type,
+                prompt_version,
+            )
+        except Exception as e:
+            logger.warning("Discovery query cache read skipped: %s", e)
+            return None
+
+        if not row:
+            return None
+
+        queries = row["queries"]
+        if isinstance(queries, str):
+            try:
+                queries = json.loads(queries)
+            except json.JSONDecodeError:
+                return None
+        if isinstance(queries, list) and all(isinstance(item, str) for item in queries):
+            return queries
+        return None
+
+    async def upsert_discovery_query_cache(
+        self,
+        jurisdiction_name: str,
+        jurisdiction_type: str,
+        prompt_version: str,
+        queries: List[str],
+        ttl_hours: int = 72,
+    ) -> bool:
+        """Persist discovery query cache with TTL."""
+        if not queries:
+            return False
+        try:
+            await self._execute(
+                """
+                INSERT INTO discovery_query_cache (
+                    jurisdiction_name,
+                    jurisdiction_type,
+                    prompt_version,
+                    queries,
+                    expires_at
+                )
+                VALUES ($1, $2, $3, $4::jsonb, NOW() + ($5::text || ' hours')::interval)
+                ON CONFLICT (jurisdiction_name, jurisdiction_type, prompt_version)
+                DO UPDATE SET
+                    queries = EXCLUDED.queries,
+                    expires_at = EXCLUDED.expires_at,
+                    updated_at = NOW()
+                """,
+                jurisdiction_name,
+                jurisdiction_type,
+                prompt_version,
+                json.dumps(queries),
+                str(max(ttl_hours, 1)),
+            )
+            return True
+        except Exception as e:
+            logger.warning("Discovery query cache write skipped: %s", e)
+            return False
+
+    async def get_discovery_classifier_cache(
+        self,
+        normalized_url: str,
+        classifier_version: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Return cached classifier decision for an exact normalized URL."""
+        try:
+            row = await self._fetchrow(
+                """
+                SELECT normalized_url, classifier_version, decision
+                FROM discovery_classifier_cache
+                WHERE normalized_url = $1
+                  AND classifier_version = $2
+                LIMIT 1
+                """,
+                normalized_url,
+                classifier_version,
+            )
+        except Exception as e:
+            logger.warning("Discovery classifier cache read skipped: %s", e)
+            return None
+
+        if not row:
+            return None
+
+        payload = row["decision"]
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload)
+            except json.JSONDecodeError:
+                return None
+        return payload if isinstance(payload, dict) else None
+
+    async def upsert_discovery_classifier_cache(
+        self,
+        normalized_url: str,
+        classifier_version: str,
+        decision: Dict[str, Any],
+    ) -> bool:
+        """Persist a classifier decision for exact URL cache lookups."""
+        try:
+            await self._execute(
+                """
+                INSERT INTO discovery_classifier_cache (
+                    normalized_url,
+                    classifier_version,
+                    decision
+                )
+                VALUES ($1, $2, $3::jsonb)
+                ON CONFLICT (normalized_url, classifier_version)
+                DO UPDATE SET
+                    decision = EXCLUDED.decision,
+                    updated_at = NOW()
+                """,
+                normalized_url,
+                classifier_version,
+                json.dumps(decision),
+            )
+            return True
+        except Exception as e:
+            logger.warning("Discovery classifier cache write skipped: %s", e)
+            return False
+
     async def update_source(
         self, source_id: str, data: Dict[str, Any]
     ) -> Dict[str, Any]:

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -1,0 +1,25 @@
+-- Discovery resilience cache tables (Phase 1: bd-ss6db)
+-- Keep schema reference aligned with migration 008.
+
+CREATE TABLE IF NOT EXISTS public.discovery_query_cache (
+  jurisdiction_name text NOT NULL,
+  jurisdiction_type text NOT NULL,
+  prompt_version text NOT NULL,
+  queries jsonb NOT NULL,
+  expires_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (jurisdiction_name, jurisdiction_type, prompt_version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_discovery_query_cache_expires_at
+  ON public.discovery_query_cache (expires_at);
+
+CREATE TABLE IF NOT EXISTS public.discovery_classifier_cache (
+  normalized_url text NOT NULL,
+  classifier_version text NOT NULL,
+  decision jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (normalized_url, classifier_version)
+);

--- a/backend/migrations/008_add_discovery_resilience_caches.sql
+++ b/backend/migrations/008_add_discovery_resilience_caches.sql
@@ -1,0 +1,25 @@
+-- Phase 1 discovery resilience caches (bd-ss6db).
+-- Keeps provider-heavy query generation/classification work bounded per run.
+
+CREATE TABLE IF NOT EXISTS public.discovery_query_cache (
+  jurisdiction_name text NOT NULL,
+  jurisdiction_type text NOT NULL,
+  prompt_version text NOT NULL,
+  queries jsonb NOT NULL,
+  expires_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (jurisdiction_name, jurisdiction_type, prompt_version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_discovery_query_cache_expires_at
+  ON public.discovery_query_cache (expires_at);
+
+CREATE TABLE IF NOT EXISTS public.discovery_classifier_cache (
+  normalized_url text NOT NULL,
+  classifier_version text NOT NULL,
+  decision jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (normalized_url, classifier_version)
+);

--- a/backend/scripts/cron/run_discovery.py
+++ b/backend/scripts/cron/run_discovery.py
@@ -11,8 +11,10 @@ import logging
 import asyncio
 import json
 import argparse
+import inspect
 from datetime import datetime
 from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from uuid import uuid4
 
 # Add backend to path
@@ -36,6 +38,9 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 logger = logging.getLogger("discovery")
 
 CLASSIFIER_MIN_CONFIDENCE = 0.75
+DEFAULT_QUERY_PROVIDER_BUDGET = 5
+DEFAULT_CLASSIFIER_PROVIDER_BUDGET = 50
+DEFAULT_QUERY_CACHE_TTL_HOURS = 72
 VALIDATION_REPORT_PATH = (
     Path(__file__).resolve().parents[1]
     / "verification"
@@ -70,6 +75,42 @@ class ResilientWebSearchClient:
             return []
 
 
+_OBVIOUS_JUNK_DOMAINS = {
+    "facebook.com",
+    "instagram.com",
+    "x.com",
+    "twitter.com",
+    "youtube.com",
+    "tiktok.com",
+    "reddit.com",
+    "linkedin.com",
+    "yelp.com",
+    "zillow.com",
+}
+
+
+def _normalize_url_for_cache(url: str) -> str:
+    """Normalize URL to maximize exact-cache hits without changing authority/path semantics."""
+    parts = urlsplit((url or "").strip())
+    scheme = (parts.scheme or "https").lower()
+    netloc = parts.netloc.lower()
+    path = parts.path.rstrip("/") or "/"
+    query_pairs = parse_qsl(parts.query, keep_blank_values=False)
+    filtered_pairs = [
+        (k, v)
+        for k, v in query_pairs
+        if not k.lower().startswith("utm_")
+    ]
+    normalized_query = urlencode(sorted(filtered_pairs))
+    return urlunsplit((scheme, netloc, path, normalized_query, ""))
+
+
+def _is_obvious_junk_candidate(url: str) -> bool:
+    netloc = urlsplit((url or "").strip()).netloc.lower()
+    host = netloc.split(":")[0]
+    return any(host == domain or host.endswith(f".{domain}") for domain in _OBVIOUS_JUNK_DOMAINS)
+
+
 def _normalize_jurisdiction_scope(values: list[str] | None) -> set[str] | None:
     """Normalize optional jurisdiction scope list into casefolded names."""
     if not values:
@@ -100,6 +141,18 @@ def _parse_args() -> argparse.Namespace:
         type=int,
         default=None,
         help="Optional cap for number of discovery queries per jurisdiction (for bounded validation runs).",
+    )
+    parser.add_argument(
+        "--query-provider-budget",
+        type=int,
+        default=None,
+        help="Max count of provider-backed query-generation calls allowed per invocation.",
+    )
+    parser.add_argument(
+        "--classifier-provider-budget",
+        type=int,
+        default=None,
+        help="Max count of provider-backed classifier calls allowed per invocation.",
     )
     return parser.parse_args()
 
@@ -154,6 +207,8 @@ def _load_classifier_validation_contract() -> tuple[bool, dict]:
 async def main(
     jurisdiction_scope: set[str] | None = None,
     max_queries_per_jurisdiction: int | None = None,
+    query_provider_budget: int | None = None,
+    classifier_provider_budget: int | None = None,
 ):
     task_id = str(uuid4())
     logger.info(f"🚀 Starting Discovery (Task {task_id})")
@@ -173,6 +228,23 @@ async def main(
     classifier_service = DiscoveryClassifierService()
     gate_enabled, gate_contract = _load_classifier_validation_contract()
     classifier_trusted = classifier_service.client is not None
+    query_provider_budget_limit = (
+        query_provider_budget
+        if query_provider_budget is not None
+        else int(os.environ.get("DISCOVERY_QUERY_PROVIDER_BUDGET", str(DEFAULT_QUERY_PROVIDER_BUDGET)))
+    )
+    classifier_provider_budget_limit = (
+        classifier_provider_budget
+        if classifier_provider_budget is not None
+        else int(
+            os.environ.get(
+                "DISCOVERY_CLASSIFIER_PROVIDER_BUDGET",
+                str(DEFAULT_CLASSIFIER_PROVIDER_BUDGET),
+            )
+        )
+    )
+    query_provider_calls_used = 0
+    classifier_provider_calls_used = 0
     
     # 1. Log Start
     try:
@@ -205,12 +277,17 @@ async def main(
             "new": 0,
             "duplicates": 0,
             "rejected": 0,
+            "query_cache_hits": 0,
+            "classifier_cache_hits": 0,
+            "classifier_cache_positive_reuse": 0,
             "rejected_by_reason": {
                 "batch_gate_fail_closed": 0,
                 "classifier_untrusted_fail_closed": 0,
                 "classifier_error_fail_closed": 0,
                 "not_scrapable": 0,
                 "low_confidence": 0,
+                "heuristic_obvious_junk": 0,
+                "provider_budget_exhausted": 0,
             },
             "batch_gate": gate_contract,
             "classifier_trusted": classifier_trusted,
@@ -219,6 +296,10 @@ async def main(
             "jurisdictions_processed": len(jurisdictions),
             "jurisdictions_available": len(all_jurisdictions),
             "max_queries_per_jurisdiction": max_queries_per_jurisdiction,
+            "query_provider_budget_limit": query_provider_budget_limit,
+            "query_provider_calls_used": 0,
+            "classifier_provider_budget_limit": classifier_provider_budget_limit,
+            "classifier_provider_calls_used": 0,
         }
 
         if not gate_enabled:
@@ -232,7 +313,19 @@ async def main(
             jurisdiction_id = str(jur["id"])
             
             # Run Discovery
-            discover_kwargs = {}
+            allow_provider_query_generation = query_provider_calls_used < max(
+                query_provider_budget_limit,
+                0,
+            )
+            discover_kwargs = {
+                "allow_provider_query_generation": allow_provider_query_generation,
+                "query_cache_ttl_hours": int(
+                    os.environ.get(
+                        "DISCOVERY_QUERY_CACHE_TTL_HOURS",
+                        str(DEFAULT_QUERY_CACHE_TTL_HOURS),
+                    )
+                ),
+            }
             if max_queries_per_jurisdiction is not None:
                 discover_kwargs["max_queries"] = max_queries_per_jurisdiction
             discovered_items = await discovery_service.discover_sources(
@@ -240,6 +333,11 @@ async def main(
                 jur.get('type', 'city'),
                 **discover_kwargs,
             )
+            discovery_stats = getattr(discovery_service, "last_discovery_stats", {}) or {}
+            if discovery_stats.get("query_cache_hit"):
+                results["query_cache_hits"] += 1
+            if discovery_stats.get("query_provider_used"):
+                query_provider_calls_used += 1
             
             for item in discovered_items:
                 results["found"] += 1
@@ -249,6 +347,12 @@ async def main(
                     results["rejected"] += 1
                     results["rejected_by_reason"]["classifier_error_fail_closed"] += 1
                     logger.info("   - Rejected (missing URL in discovery item)")
+                    continue
+
+                if _is_obvious_junk_candidate(candidate_url):
+                    results["rejected"] += 1
+                    results["rejected_by_reason"]["heuristic_obvious_junk"] += 1
+                    logger.info("   - Rejected (heuristic obvious junk): %s", candidate_url)
                     continue
 
                 if not gate_enabled:
@@ -263,11 +367,48 @@ async def main(
                     logger.info("   - Rejected (classifier unavailable): %s", candidate_url)
                     continue
 
-                try:
-                    classification = await classifier_service.discover_url(
-                        url=candidate_url,
-                        page_text=item.get("snippet", ""),
+                normalized_url = _normalize_url_for_cache(candidate_url)
+                classification = None
+                cached_payload = None
+                cache_reader = getattr(db, "get_discovery_classifier_cache", None)
+                if cache_reader and inspect.iscoroutinefunction(cache_reader):
+                    cached_payload = await cache_reader(
+                        normalized_url=normalized_url,
+                        classifier_version=classifier_service.classifier_version,
                     )
+                if cached_payload:
+                    cached_decision = classifier_service.response_from_cache_payload(cached_payload)
+                    if cached_decision:
+                        classification = cached_decision
+                        results["classifier_cache_hits"] += 1
+                        if (
+                            classification.is_scrapable
+                            and classification.confidence >= CLASSIFIER_MIN_CONFIDENCE
+                        ):
+                            results["classifier_cache_positive_reuse"] += 1
+
+                try:
+                    if classification is None:
+                        if classifier_provider_calls_used >= max(classifier_provider_budget_limit, 0):
+                            results["rejected"] += 1
+                            results["rejected_by_reason"]["provider_budget_exhausted"] += 1
+                            logger.info(
+                                "   - Rejected (classifier provider budget exhausted): %s",
+                                candidate_url,
+                            )
+                            continue
+                        classification = await classifier_service.discover_url(
+                            url=candidate_url,
+                            page_text=item.get("snippet", ""),
+                        )
+                        classifier_provider_calls_used += 1
+                        cache_writer = getattr(db, "upsert_discovery_classifier_cache", None)
+                        if cache_writer and inspect.iscoroutinefunction(cache_writer):
+                            await cache_writer(
+                                normalized_url=normalized_url,
+                                classifier_version=classifier_service.classifier_version,
+                                decision=classifier_service.response_to_cache_payload(classification),
+                            )
                 except Exception as exc:
                     logger.warning("Classifier failure for %s: %s", candidate_url, exc)
                     results["rejected"] += 1
@@ -336,6 +477,8 @@ async def main(
                 )
         
         # 3. Log Success
+        results["query_provider_calls_used"] = query_provider_calls_used
+        results["classifier_provider_calls_used"] = classifier_provider_calls_used
         logger.info(f"🏁 Discovery Complete. {results}")
         
         await db.update_admin_task(
@@ -366,5 +509,7 @@ if __name__ == "__main__":
         main(
             jurisdiction_scope=scope,
             max_queries_per_jurisdiction=args.max_queries_per_jurisdiction,
+            query_provider_budget=args.query_provider_budget,
+            classifier_provider_budget=args.classifier_provider_budget,
         )
     )

--- a/backend/services/auto_discovery_service.py
+++ b/backend/services/auto_discovery_service.py
@@ -7,6 +7,7 @@ government sources. Discovery prompts are stored in the database for admin editi
 import os
 import json
 import logging
+import inspect
 from typing import List, Dict, Any, Optional
 
 from llm_common.core import LLMConfig
@@ -14,6 +15,8 @@ from llm_common.providers import ZaiClient
 from llm_common.core.models import LLMMessage, MessageRole
 
 logger = logging.getLogger(__name__)
+DEFAULT_QUERY_CACHE_TTL_HOURS = 72
+DEFAULT_QUERY_PROMPT_VERSION = "default-v1"
 
 
 # Default discovery prompt (seeded to DB on first run)
@@ -67,39 +70,71 @@ class AutoDiscoveryService:
             else:
                 self.llm_client = None
                 logger.warning("No LLM client configured - falling back to static templates")
+        self.last_discovery_stats: Dict[str, Any] = {}
     
-    async def get_discovery_prompt(self) -> str:
-        """Fetch discovery prompt from DB, or use default if not found."""
+    async def get_discovery_prompt_payload(self) -> tuple[str, str]:
+        """Fetch discovery prompt and version marker from DB, or defaults."""
         if self.db:
             try:
                 prompt_record = await self.db.get_system_prompt("discovery_query_generator")
                 if prompt_record:
-                    return prompt_record.get("system_prompt", DEFAULT_DISCOVERY_PROMPT)
+                    version = prompt_record.get("version")
+                    prompt_version = f"db-v{version}" if version is not None else "db-v0"
+                    return (
+                        prompt_record.get("system_prompt", DEFAULT_DISCOVERY_PROMPT),
+                        prompt_version,
+                    )
             except Exception as e:
                 logger.warning(f"Failed to fetch discovery prompt from DB: {e}")
         
-        return DEFAULT_DISCOVERY_PROMPT
+        return DEFAULT_DISCOVERY_PROMPT, DEFAULT_QUERY_PROMPT_VERSION
     
     async def generate_queries(
         self, 
         jurisdiction_name: str, 
-        jurisdiction_type: str = "city"
+        jurisdiction_type: str = "city",
+        *,
+        allow_provider_query_generation: bool = True,
+        query_cache_ttl_hours: int = DEFAULT_QUERY_CACHE_TTL_HOURS,
     ) -> List[str]:
         """
         Generate search queries using GLM-4.7.
         
         Returns a list of search query strings optimized for the jurisdiction.
         """
-        if not self.llm_client:
-            # Fallback to static templates
-            return self._static_queries(jurisdiction_name, jurisdiction_type)
+        prompt_template, prompt_version = await self.get_discovery_prompt_payload()
+        normalized_type = jurisdiction_type if jurisdiction_type in {"city", "county"} else "city"
+        cache_hit = False
+        used_provider = False
+
+        cache_reader = getattr(self.db, "get_discovery_query_cache", None) if self.db else None
+        if cache_reader and inspect.iscoroutinefunction(cache_reader):
+            cached = await cache_reader(
+                jurisdiction_name=jurisdiction_name,
+                jurisdiction_type=normalized_type,
+                prompt_version=prompt_version,
+            )
+            if cached:
+                self.last_discovery_stats = {
+                    "query_cache_hit": True,
+                    "query_prompt_version": prompt_version,
+                    "query_provider_used": False,
+                }
+                return cached
+
+        if not self.llm_client or not allow_provider_query_generation:
+            queries = self._static_queries(jurisdiction_name, normalized_type)
+            self.last_discovery_stats = {
+                "query_cache_hit": cache_hit,
+                "query_prompt_version": prompt_version,
+                "query_provider_used": used_provider,
+            }
+            return queries
         
         try:
-            # Fetch prompt from DB
-            prompt_template = await self.get_discovery_prompt()
             prompt = prompt_template.format(
                 jurisdiction=jurisdiction_name,
-                jurisdiction_type=jurisdiction_type
+                jurisdiction_type=normalized_type
             )
             
             logger.info(f"🧠 Generating discovery queries for {jurisdiction_name} using GLM-4.7...")
@@ -122,14 +157,43 @@ class AutoDiscoveryService:
             
             if isinstance(queries, list) and all(isinstance(q, str) for q in queries):
                 logger.info(f"✅ Generated {len(queries)} queries for {jurisdiction_name}")
+                used_provider = True
+                cache_writer = (
+                    getattr(self.db, "upsert_discovery_query_cache", None) if self.db else None
+                )
+                if cache_writer and inspect.iscoroutinefunction(cache_writer):
+                    await cache_writer(
+                        jurisdiction_name=jurisdiction_name,
+                        jurisdiction_type=normalized_type,
+                        prompt_version=prompt_version,
+                        queries=queries,
+                        ttl_hours=query_cache_ttl_hours,
+                    )
+                self.last_discovery_stats = {
+                    "query_cache_hit": cache_hit,
+                    "query_prompt_version": prompt_version,
+                    "query_provider_used": used_provider,
+                }
                 return queries
             else:
                 logger.warning("LLM returned invalid query format, using fallback")
-                return self._static_queries(jurisdiction_name, jurisdiction_type)
+                queries = self._static_queries(jurisdiction_name, normalized_type)
+                self.last_discovery_stats = {
+                    "query_cache_hit": cache_hit,
+                    "query_prompt_version": prompt_version,
+                    "query_provider_used": used_provider,
+                }
+                return queries
                 
         except Exception as e:
             logger.error(f"LLM query generation failed: {e}")
-            return self._static_queries(jurisdiction_name, jurisdiction_type)
+            queries = self._static_queries(jurisdiction_name, normalized_type)
+            self.last_discovery_stats = {
+                "query_cache_hit": cache_hit,
+                "query_prompt_version": prompt_version,
+                "query_provider_used": used_provider,
+            }
+            return queries
     
     def _static_queries(self, jurisdiction_name: str, jurisdiction_type: str) -> List[str]:
         """Fallback static query templates."""
@@ -153,6 +217,9 @@ class AutoDiscoveryService:
         jurisdiction_name: str,
         jurisdiction_type: str = "city",
         max_queries: Optional[int] = None,
+        *,
+        allow_provider_query_generation: bool = True,
+        query_cache_ttl_hours: int = DEFAULT_QUERY_CACHE_TTL_HOURS,
     ) -> List[Dict[str, Any]]:
         """
         Discover potential sources for a given jurisdiction.
@@ -163,8 +230,13 @@ class AutoDiscoveryService:
         :param jurisdiction_type: The type of jurisdiction ("city" or "county").
         :return: A list of potential sources, each a dictionary with search result info.
         """
-        # Generate queries using LLM
-        queries = await self.generate_queries(jurisdiction_name, jurisdiction_type)
+        # Generate queries using LLM/static fallback with cache and budget controls.
+        queries = await self.generate_queries(
+            jurisdiction_name,
+            jurisdiction_type,
+            allow_provider_query_generation=allow_provider_query_generation,
+            query_cache_ttl_hours=query_cache_ttl_hours,
+        )
         if max_queries is not None and max_queries > 0:
             queries = queries[:max_queries]
         

--- a/backend/services/discovery/service.py
+++ b/backend/services/discovery/service.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 ZAI_CODING_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
+DISCOVERY_CLASSIFIER_VERSION = "discovery-classifier-v1"
 
 class DiscoveryResponse(BaseModel):
     is_scrapable: bool = Field(..., description="Whether the URL looks like a valid source for scraping")
@@ -41,6 +42,7 @@ class AutoDiscoveryService:
             self.model = "x-ai/grok-4.1-fast:free" # Default fast model
         else:
             logger.warning("AutoDiscoveryService: No LLM API keys found. Discovery will fail.")
+        self.classifier_version = DISCOVERY_CLASSIFIER_VERSION
 
     async def discover_url(self, url: str, page_text: str = "") -> DiscoveryResponse:
         """
@@ -97,6 +99,21 @@ class AutoDiscoveryService:
                 confidence=0.0,
                 reasoning=str(e)
             )
+
+    @staticmethod
+    def response_to_cache_payload(response: DiscoveryResponse) -> dict:
+        """Serialize classifier response into DB-cache-safe payload."""
+        return response.model_dump()
+
+    @staticmethod
+    def response_from_cache_payload(payload: dict) -> DiscoveryResponse | None:
+        """Deserialize a cached classifier payload."""
+        if not isinstance(payload, dict):
+            return None
+        try:
+            return DiscoveryResponse.model_validate(payload)
+        except Exception:
+            return None
 
     @staticmethod
     def _is_malformed_model_output_error(exc: Exception) -> bool:

--- a/backend/tests/cron/test_run_discovery.py
+++ b/backend/tests/cron/test_run_discovery.py
@@ -156,6 +156,8 @@ async def test_run_discovery_creates_single_source_write_with_classifier_gate(
         return_value=[{"id": uuid.UUID("a23f2953-8ade-4c43-a287-eb03f06b2501"), "name": "San Jose", "type": "city"}]
     )
     mock_db._fetchrow = AsyncMock(return_value=None)
+    mock_db.get_discovery_classifier_cache = AsyncMock(return_value=None)
+    mock_db.upsert_discovery_classifier_cache = AsyncMock(return_value=True)
     mock_db.get_or_create_source = AsyncMock()
     mock_db.create_source = AsyncMock()
     mock_db.update_admin_task = AsyncMock()
@@ -197,6 +199,8 @@ async def test_run_discovery_creates_single_source_write_with_classifier_gate(
         "a23f2953-8ade-4c43-a287-eb03f06b2501",
         "https://example.gov/agenda",
     )
+    mock_db.get_discovery_classifier_cache.assert_awaited_once()
+    mock_db.upsert_discovery_classifier_cache.assert_awaited_once()
     mock_db.create_source.assert_called_once()
     create_payload = mock_db.create_source.call_args.args[0]
     assert create_payload["url"] == "https://example.gov/agenda"
@@ -266,8 +270,131 @@ async def test_run_discovery_respects_jurisdiction_scope_filter(
         "Milpitas",
         "city",
         max_queries=2,
+        allow_provider_query_generation=True,
+        query_cache_ttl_hours=72,
     )
     update_kwargs = mock_db.update_admin_task.call_args.kwargs
     assert update_kwargs["result"]["jurisdictions_processed"] == 1
     assert update_kwargs["result"]["jurisdiction_scope"] == ["milpitas"]
     assert update_kwargs["result"]["max_queries_per_jurisdiction"] == 2
+
+
+@patch("scripts.cron.run_discovery._load_classifier_validation_contract")
+@patch("scripts.cron.run_discovery.DiscoveryClassifierService")
+@patch("scripts.cron.run_discovery.SearchDiscoveryService")
+@patch("scripts.cron.run_discovery.LegacySearchDiscoveryService")
+@patch("scripts.cron.run_discovery.WebSearchClient")
+@patch("scripts.cron.run_discovery.PostgresDB")
+async def test_run_discovery_rejects_obvious_junk_before_classifier(
+    mock_db_cls,
+    _mock_search_client_cls,
+    _mock_legacy_search_cls,
+    mock_search_service_cls,
+    mock_classifier_cls,
+    mock_gate_loader,
+):
+    mock_db = MagicMock()
+    mock_db.create_admin_task = AsyncMock()
+    mock_db._fetch = AsyncMock(
+        return_value=[{"id": "jur-1", "name": "San Jose", "type": "city"}]
+    )
+    mock_db._fetchrow = AsyncMock(return_value=None)
+    mock_db.create_source = AsyncMock()
+    mock_db.update_admin_task = AsyncMock()
+    mock_db_cls.return_value = mock_db
+
+    mock_search_service = MagicMock()
+    mock_search_service.last_discovery_stats = {}
+    mock_search_service.discover_sources = AsyncMock(
+        return_value=[
+            {"url": "https://www.youtube.com/watch?v=123", "title": "junk", "snippet": "video"}
+        ]
+    )
+    mock_search_service_cls.return_value = mock_search_service
+
+    mock_classifier = MagicMock()
+    mock_classifier.client = object()
+    mock_classifier.discover_url = AsyncMock()
+    mock_classifier_cls.return_value = mock_classifier
+    mock_gate_loader.return_value = (True, {"status": "passed", "min_confidence": 0.75})
+
+    await run_discovery.main()
+
+    mock_classifier.discover_url.assert_not_called()
+    update_kwargs = mock_db.update_admin_task.call_args.kwargs
+    assert update_kwargs["result"]["rejected_by_reason"]["heuristic_obvious_junk"] == 1
+
+
+@patch("scripts.cron.run_discovery._load_classifier_validation_contract")
+@patch("scripts.cron.run_discovery.DiscoveryClassifierService")
+@patch("scripts.cron.run_discovery.SearchDiscoveryService")
+@patch("scripts.cron.run_discovery.LegacySearchDiscoveryService")
+@patch("scripts.cron.run_discovery.WebSearchClient")
+@patch("scripts.cron.run_discovery.PostgresDB")
+async def test_run_discovery_uses_cached_positive_classifier_without_provider_call(
+    mock_db_cls,
+    _mock_search_client_cls,
+    _mock_legacy_search_cls,
+    mock_search_service_cls,
+    mock_classifier_cls,
+    mock_gate_loader,
+):
+    mock_db = MagicMock()
+    mock_db.create_admin_task = AsyncMock()
+    mock_db._fetch = AsyncMock(
+        return_value=[{"id": "jur-1", "name": "San Jose", "type": "city"}]
+    )
+    mock_db._fetchrow = AsyncMock(return_value=None)
+    mock_db.get_discovery_classifier_cache = AsyncMock(
+        return_value={
+            "is_scrapable": True,
+            "jurisdiction_name": "San Jose",
+            "source_type": "agenda",
+            "recommended_spider": "generic",
+            "confidence": 0.99,
+            "reasoning": "cached pass",
+        }
+    )
+    mock_db.upsert_discovery_classifier_cache = AsyncMock(return_value=True)
+    mock_db.create_source = AsyncMock()
+    mock_db.update_admin_task = AsyncMock()
+    mock_db_cls.return_value = mock_db
+
+    mock_search_service = MagicMock()
+    mock_search_service.last_discovery_stats = {}
+    mock_search_service.discover_sources = AsyncMock(
+        return_value=[
+            {
+                "url": "https://example.gov/agenda",
+                "title": "Agenda Center",
+                "category": "agenda",
+                "snippet": "meeting agendas",
+            }
+        ]
+    )
+    mock_search_service_cls.return_value = mock_search_service
+
+    mock_classifier = MagicMock()
+    mock_classifier.client = object()
+    mock_classifier.classifier_version = "discovery-classifier-v1"
+    mock_classifier.response_from_cache_payload = MagicMock(
+        return_value=MagicMock(
+            is_scrapable=True,
+            confidence=0.99,
+            source_type="agenda",
+            recommended_spider="generic",
+            reasoning="cached pass",
+        )
+    )
+    mock_classifier.response_to_cache_payload = MagicMock(return_value={})
+    mock_classifier.discover_url = AsyncMock()
+    mock_classifier_cls.return_value = mock_classifier
+    mock_gate_loader.return_value = (True, {"status": "passed", "min_confidence": 0.75})
+
+    await run_discovery.main(classifier_provider_budget=0)
+
+    mock_classifier.discover_url.assert_not_called()
+    mock_db.create_source.assert_called_once()
+    update_kwargs = mock_db.update_admin_task.call_args.kwargs
+    assert update_kwargs["result"]["classifier_cache_hits"] == 1
+    assert update_kwargs["result"]["classifier_provider_calls_used"] == 0

--- a/backend/tests/cron/test_run_discovery.py
+++ b/backend/tests/cron/test_run_discovery.py
@@ -398,3 +398,113 @@ async def test_run_discovery_uses_cached_positive_classifier_without_provider_ca
     update_kwargs = mock_db.update_admin_task.call_args.kwargs
     assert update_kwargs["result"]["classifier_cache_hits"] == 1
     assert update_kwargs["result"]["classifier_provider_calls_used"] == 0
+
+
+@patch("scripts.cron.run_discovery._load_classifier_validation_contract")
+@patch("scripts.cron.run_discovery.DiscoveryClassifierService")
+@patch("scripts.cron.run_discovery.SearchDiscoveryService")
+@patch("scripts.cron.run_discovery.LegacySearchDiscoveryService")
+@patch("scripts.cron.run_discovery.WebSearchClient")
+@patch("scripts.cron.run_discovery.PostgresDB")
+async def test_run_discovery_rejects_when_classifier_budget_exhausted(
+    mock_db_cls,
+    _mock_search_client_cls,
+    _mock_legacy_search_cls,
+    mock_search_service_cls,
+    mock_classifier_cls,
+    mock_gate_loader,
+):
+    mock_db = MagicMock()
+    mock_db.create_admin_task = AsyncMock()
+    mock_db._fetch = AsyncMock(
+        return_value=[{"id": "jur-1", "name": "San Jose", "type": "city"}]
+    )
+    mock_db._fetchrow = AsyncMock(return_value=None)
+    mock_db.get_discovery_classifier_cache = AsyncMock(return_value=None)
+    mock_db.upsert_discovery_classifier_cache = AsyncMock(return_value=True)
+    mock_db.create_source = AsyncMock()
+    mock_db.update_admin_task = AsyncMock()
+    mock_db_cls.return_value = mock_db
+
+    mock_search_service = MagicMock()
+    mock_search_service.last_discovery_stats = {}
+    mock_search_service.discover_sources = AsyncMock(
+        return_value=[
+            {
+                "url": "https://example.gov/agenda",
+                "title": "Agenda Center",
+                "category": "agenda",
+                "snippet": "meeting agendas",
+            }
+        ]
+    )
+    mock_search_service_cls.return_value = mock_search_service
+
+    mock_classifier = MagicMock()
+    mock_classifier.client = object()
+    mock_classifier.classifier_version = "discovery-classifier-v1"
+    mock_classifier.response_from_cache_payload = MagicMock(return_value=None)
+    mock_classifier.response_to_cache_payload = MagicMock(return_value={})
+    mock_classifier.discover_url = AsyncMock()
+    mock_classifier_cls.return_value = mock_classifier
+    mock_gate_loader.return_value = (True, {"status": "passed", "min_confidence": 0.75})
+
+    await run_discovery.main(classifier_provider_budget=0)
+
+    mock_classifier.discover_url.assert_not_called()
+    mock_db.create_source.assert_not_called()
+    update_kwargs = mock_db.update_admin_task.call_args.kwargs
+    assert update_kwargs["result"]["rejected_by_reason"]["provider_budget_exhausted"] == 1
+    assert update_kwargs["result"]["classifier_provider_calls_used"] == 0
+
+
+@patch("scripts.cron.run_discovery._load_classifier_validation_contract")
+@patch("scripts.cron.run_discovery.DiscoveryClassifierService")
+@patch("scripts.cron.run_discovery.SearchDiscoveryService")
+@patch("scripts.cron.run_discovery.LegacySearchDiscoveryService")
+@patch("scripts.cron.run_discovery.WebSearchClient")
+@patch("scripts.cron.run_discovery.PostgresDB")
+async def test_run_discovery_query_provider_budget_blocks_llm_generation_after_cap(
+    mock_db_cls,
+    _mock_search_client_cls,
+    _mock_legacy_search_cls,
+    mock_search_service_cls,
+    mock_classifier_cls,
+    mock_gate_loader,
+):
+    mock_db = MagicMock()
+    mock_db.create_admin_task = AsyncMock()
+    mock_db._fetch = AsyncMock(
+        return_value=[
+            {"id": "jur-1", "name": "San Jose", "type": "city"},
+            {"id": "jur-2", "name": "Milpitas", "type": "city"},
+        ]
+    )
+    mock_db._fetchrow = AsyncMock(return_value=None)
+    mock_db.get_discovery_classifier_cache = AsyncMock(return_value=None)
+    mock_db.upsert_discovery_classifier_cache = AsyncMock(return_value=True)
+    mock_db.create_source = AsyncMock()
+    mock_db.update_admin_task = AsyncMock()
+    mock_db_cls.return_value = mock_db
+
+    mock_search_service = MagicMock()
+    mock_search_service.discover_sources = AsyncMock(return_value=[])
+    mock_search_service.last_discovery_stats = {"query_provider_used": True, "query_cache_hit": False}
+    mock_search_service_cls.return_value = mock_search_service
+
+    mock_classifier = MagicMock()
+    mock_classifier.client = object()
+    mock_classifier.classifier_version = "discovery-classifier-v1"
+    mock_classifier.response_from_cache_payload = MagicMock(return_value=None)
+    mock_classifier.response_to_cache_payload = MagicMock(return_value={})
+    mock_classifier.discover_url = AsyncMock()
+    mock_classifier_cls.return_value = mock_classifier
+    mock_gate_loader.return_value = (True, {"status": "passed", "min_confidence": 0.75})
+
+    await run_discovery.main(query_provider_budget=1)
+
+    assert mock_search_service.discover_sources.await_count == 2
+    first_kwargs = mock_search_service.discover_sources.await_args_list[0].kwargs
+    second_kwargs = mock_search_service.discover_sources.await_args_list[1].kwargs
+    assert first_kwargs["allow_provider_query_generation"] is True
+    assert second_kwargs["allow_provider_query_generation"] is False

--- a/backend/tests/services/discovery/test_auto_discovery_service.py
+++ b/backend/tests/services/discovery/test_auto_discovery_service.py
@@ -1,0 +1,73 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.modules.setdefault("llm_common.core", SimpleNamespace(LLMConfig=MagicMock()))
+sys.modules.setdefault("llm_common.providers", SimpleNamespace(ZaiClient=MagicMock()))
+sys.modules.setdefault(
+    "llm_common.core.models",
+    SimpleNamespace(
+        LLMMessage=lambda **kwargs: kwargs,
+        MessageRole=SimpleNamespace(USER="user"),
+    ),
+)
+
+from services.auto_discovery_service import AutoDiscoveryService  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_generate_queries_uses_cache_before_provider():
+    llm_client = MagicMock()
+    llm_client.chat_completion = AsyncMock()
+    db = MagicMock()
+    db.get_system_prompt = AsyncMock(return_value={"system_prompt": "{jurisdiction}", "version": 3})
+    db.get_discovery_query_cache = AsyncMock(return_value=["cached query"])
+
+    service = AutoDiscoveryService(search_client=MagicMock(), llm_client=llm_client, db_client=db)
+
+    queries = await service.generate_queries("San Jose", "city")
+
+    assert queries == ["cached query"]
+    llm_client.chat_completion.assert_not_called()
+    assert service.last_discovery_stats["query_cache_hit"] is True
+
+
+@pytest.mark.asyncio
+async def test_generate_queries_respects_provider_budget_disable():
+    llm_client = MagicMock()
+    llm_client.chat_completion = AsyncMock()
+    db = MagicMock()
+    db.get_system_prompt = AsyncMock(return_value={"system_prompt": "{jurisdiction}", "version": 1})
+    db.get_discovery_query_cache = AsyncMock(return_value=None)
+
+    service = AutoDiscoveryService(search_client=MagicMock(), llm_client=llm_client, db_client=db)
+
+    queries = await service.generate_queries(
+        "San Jose",
+        "city",
+        allow_provider_query_generation=False,
+    )
+
+    assert queries
+    llm_client.chat_completion.assert_not_called()
+    assert service.last_discovery_stats["query_provider_used"] is False
+
+
+@pytest.mark.asyncio
+async def test_generate_queries_writes_cache_on_provider_success():
+    llm_client = MagicMock()
+    llm_client.chat_completion = AsyncMock(return_value=SimpleNamespace(content='["q1", "q2"]'))
+    db = MagicMock()
+    db.get_system_prompt = AsyncMock(return_value={"system_prompt": "{jurisdiction}", "version": 2})
+    db.get_discovery_query_cache = AsyncMock(return_value=None)
+    db.upsert_discovery_query_cache = AsyncMock(return_value=True)
+
+    service = AutoDiscoveryService(search_client=MagicMock(), llm_client=llm_client, db_client=db)
+
+    queries = await service.generate_queries("San Jose", "city")
+
+    assert queries == ["q1", "q2"]
+    db.upsert_discovery_query_cache.assert_awaited_once()
+    assert service.last_discovery_stats["query_provider_used"] is True

--- a/backend/tests/services/discovery/test_discovery.py
+++ b/backend/tests/services/discovery/test_discovery.py
@@ -134,3 +134,21 @@ async def test_discover_url_non_malformed_error_returns_error_response():
         assert result.is_scrapable is False
         assert result.source_type == "error"
         assert result.confidence == 0.0
+
+
+def test_discovery_response_cache_payload_roundtrip():
+    response = DiscoveryResponse(
+        is_scrapable=True,
+        jurisdiction_name="San Jose",
+        source_type="agenda",
+        recommended_spider="generic",
+        confidence=0.9,
+        reasoning="test",
+    )
+
+    payload = AutoDiscoveryService.response_to_cache_payload(response)
+    restored = AutoDiscoveryService.response_from_cache_payload(payload)
+
+    assert restored is not None
+    assert restored.is_scrapable is True
+    assert restored.confidence == 0.9

--- a/backend/tests/test_postgres_client.py
+++ b/backend/tests/test_postgres_client.py
@@ -164,3 +164,65 @@ async def test_create_source_serializes_metadata_dict() -> None:
 
     args = db._fetchrow.await_args.args
     assert args[6] == '{"k": "v"}'
+
+
+@pytest.mark.asyncio
+async def test_get_discovery_query_cache_returns_list() -> None:
+    db = PostgresDB("postgresql://example.test/db")
+    db._fetchrow = AsyncMock(return_value={"queries": '["q1", "q2"]'})
+
+    queries = await db.get_discovery_query_cache(
+        jurisdiction_name="San Jose",
+        jurisdiction_type="city",
+        prompt_version="db-v1",
+    )
+
+    assert queries == ["q1", "q2"]
+
+
+@pytest.mark.asyncio
+async def test_upsert_discovery_query_cache_writes_json_payload() -> None:
+    db = PostgresDB("postgresql://example.test/db")
+    db._execute = AsyncMock(return_value="INSERT 0 1")
+
+    ok = await db.upsert_discovery_query_cache(
+        jurisdiction_name="San Jose",
+        jurisdiction_type="city",
+        prompt_version="db-v1",
+        queries=["q1", "q2"],
+        ttl_hours=24,
+    )
+
+    assert ok is True
+    args = db._execute.await_args.args
+    assert args[4] == '["q1", "q2"]'
+
+
+@pytest.mark.asyncio
+async def test_get_discovery_classifier_cache_returns_dict() -> None:
+    db = PostgresDB("postgresql://example.test/db")
+    db._fetchrow = AsyncMock(return_value={"decision": '{"is_scrapable": true}'})
+
+    payload = await db.get_discovery_classifier_cache(
+        normalized_url="https://example.gov/agenda",
+        classifier_version="discovery-classifier-v1",
+    )
+
+    assert payload == {"is_scrapable": True}
+
+
+@pytest.mark.asyncio
+async def test_upsert_discovery_classifier_cache_writes_json_payload() -> None:
+    db = PostgresDB("postgresql://example.test/db")
+    db._execute = AsyncMock(return_value="INSERT 0 1")
+
+    ok = await db.upsert_discovery_classifier_cache(
+        normalized_url="https://example.gov/agenda",
+        classifier_version="discovery-classifier-v1",
+        decision={"is_scrapable": True, "confidence": 0.92},
+    )
+
+    assert ok is True
+    args = db._execute.await_args.args
+    assert args[2] == "discovery-classifier-v1"
+    assert args[3] == '{"is_scrapable": true, "confidence": 0.92}'


### PR DESCRIPTION
## Summary
- add Phase 1 discovery resilience on top of bd-esety
- add DB-backed query cache and classifier cache
- add heuristic junk prefilter and per-run provider budgets
- keep promotion fail-closed semantics intact
- add focused backend tests for cache + budget behavior

## Validation
- pytest -q backend/tests/cron/test_run_discovery.py backend/tests/services/discovery/test_discovery.py backend/tests/services/discovery/test_auto_discovery_service.py backend/tests/test_postgres_client.py
- ruff check ... (blocked: ruff not installed in runtime)

Agent: codex
Feature-Key: bd-ss6db