### PR TITLE
bd-ro2cx: complete phase 2 deferred discovery retry queue

### DIFF
--- a/backend/db/postgres_client.py
+++ b/backend/db/postgres_client.py
@@ -518,6 +518,160 @@ class PostgresDB:
             logger.warning("Discovery classifier cache write skipped: %s", e)
             return False
 
+    async def upsert_discovery_deferred_item(
+        self,
+        jurisdiction_id: str,
+        jurisdiction_name: str,
+        stage: str,
+        reason_code: str,
+        payload: Dict[str, Any],
+        retry_count: int = 0,
+        next_attempt_at: Optional[datetime] = None,
+        last_error: Optional[str] = None,
+    ) -> bool:
+        """Insert or update deferred provider-limited discovery work."""
+        if not payload:
+            return False
+        try:
+            await self._execute(
+                """
+                INSERT INTO discovery_deferred_queue (
+                    jurisdiction_id,
+                    jurisdiction_name,
+                    stage,
+                    reason_code,
+                    payload,
+                    retry_count,
+                    next_attempt_at,
+                    last_error
+                )
+                VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8)
+                ON CONFLICT (jurisdiction_id, stage, reason_code, payload)
+                DO UPDATE SET
+                    retry_count = GREATEST(discovery_deferred_queue.retry_count, EXCLUDED.retry_count),
+                    next_attempt_at = GREATEST(discovery_deferred_queue.next_attempt_at, EXCLUDED.next_attempt_at),
+                    last_error = EXCLUDED.last_error,
+                    updated_at = NOW()
+                """,
+                jurisdiction_id,
+                jurisdiction_name,
+                stage,
+                reason_code,
+                json.dumps(payload),
+                max(retry_count, 0),
+                next_attempt_at or datetime.now(timezone.utc),
+                last_error,
+            )
+            return True
+        except Exception as e:
+            logger.warning("Discovery deferred queue write skipped: %s", e)
+            return False
+
+    async def get_due_discovery_deferred_items(
+        self,
+        limit: int,
+        as_of: Optional[datetime] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return deferred items that are due for retry."""
+        if limit <= 0:
+            return []
+        try:
+            rows = await self._fetch(
+                """
+                SELECT
+                    id::text AS id,
+                    jurisdiction_id,
+                    jurisdiction_name,
+                    stage,
+                    reason_code,
+                    payload,
+                    retry_count,
+                    next_attempt_at,
+                    last_error
+                FROM discovery_deferred_queue
+                WHERE next_attempt_at <= $1
+                ORDER BY next_attempt_at ASC, created_at ASC
+                LIMIT $2
+                """,
+                as_of or datetime.now(timezone.utc),
+                limit,
+            )
+        except Exception as e:
+            logger.warning("Discovery deferred queue read skipped: %s", e)
+            return []
+
+        items: List[Dict[str, Any]] = []
+        for row in rows:
+            item = dict(row)
+            payload = item.get("payload")
+            if isinstance(payload, str):
+                try:
+                    payload = json.loads(payload)
+                except json.JSONDecodeError:
+                    payload = {}
+            item["payload"] = payload if isinstance(payload, dict) else {}
+            items.append(item)
+        return items
+
+    async def resolve_discovery_deferred_item(self, item_id: str) -> bool:
+        """Delete a deferred queue item after successful processing or terminal outcome."""
+        try:
+            await self._execute(
+                "DELETE FROM discovery_deferred_queue WHERE id::text = $1",
+                item_id,
+            )
+            return True
+        except Exception as e:
+            logger.warning("Discovery deferred queue delete skipped: %s", e)
+            return False
+
+    async def reschedule_discovery_deferred_item(
+        self,
+        item_id: str,
+        retry_count: int,
+        next_attempt_at: datetime,
+        last_error: str,
+        reason_code: Optional[str] = None,
+    ) -> bool:
+        """Reschedule a deferred queue item with updated retry metadata."""
+        try:
+            if reason_code:
+                await self._execute(
+                    """
+                    UPDATE discovery_deferred_queue
+                    SET retry_count = $1,
+                        next_attempt_at = $2,
+                        last_error = $3,
+                        reason_code = $4,
+                        updated_at = NOW()
+                    WHERE id::text = $5
+                    """,
+                    max(retry_count, 0),
+                    next_attempt_at,
+                    last_error,
+                    reason_code,
+                    item_id,
+                )
+            else:
+                await self._execute(
+                    """
+                    UPDATE discovery_deferred_queue
+                    SET retry_count = $1,
+                        next_attempt_at = $2,
+                        last_error = $3,
+                        updated_at = NOW()
+                    WHERE id::text = $4
+                    """,
+                    max(retry_count, 0),
+                    next_attempt_at,
+                    last_error,
+                    item_id,
+                )
+            return True
+        except Exception as e:
+            logger.warning("Discovery deferred queue reschedule skipped: %s", e)
+            return False
+
     async def update_source(
         self, source_id: str, data: Dict[str, Any]
     ) -> Dict[str, Any]:

--- a/backend/db/postgres_client.py
+++ b/backend/db/postgres_client.py
@@ -366,10 +366,15 @@ class PostgresDB:
 
     async def create_source(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """Create a new source."""
-        columns = ", ".join(data.keys())
-        placeholders = ", ".join([f"${i + 1}" for i in range(len(data))])
+        insert_data = dict(data)
+        metadata = insert_data.get("metadata")
+        if isinstance(metadata, (dict, list)):
+            insert_data["metadata"] = json.dumps(metadata)
+
+        columns = ", ".join(insert_data.keys())
+        placeholders = ", ".join([f"${i + 1}" for i in range(len(insert_data))])
         query = f"INSERT INTO sources ({columns}) VALUES ({placeholders}) RETURNING *"
-        row = await self._fetchrow(query, *data.values())
+        row = await self._fetchrow(query, *insert_data.values())
         return dict(row)
 
     async def update_source(

--- a/backend/db/postgres_client.py
+++ b/backend/db/postgres_client.py
@@ -377,6 +377,147 @@ class PostgresDB:
         row = await self._fetchrow(query, *insert_data.values())
         return dict(row)
 
+    async def get_discovery_query_cache(
+        self,
+        jurisdiction_name: str,
+        jurisdiction_type: str,
+        prompt_version: str,
+    ) -> Optional[List[str]]:
+        """Return cached discovery queries when available and not expired."""
+        try:
+            row = await self._fetchrow(
+                """
+                SELECT queries
+                FROM discovery_query_cache
+                WHERE jurisdiction_name = $1
+                  AND jurisdiction_type = $2
+                  AND prompt_version = $3
+                  AND expires_at > NOW()
+                LIMIT 1
+                """,
+                jurisdiction_name,
+                jurisdiction_type,
+                prompt_version,
+            )
+        except Exception as e:
+            logger.warning("Discovery query cache read skipped: %s", e)
+            return None
+
+        if not row:
+            return None
+
+        queries = row["queries"]
+        if isinstance(queries, str):
+            try:
+                queries = json.loads(queries)
+            except json.JSONDecodeError:
+                return None
+        if isinstance(queries, list) and all(isinstance(item, str) for item in queries):
+            return queries
+        return None
+
+    async def upsert_discovery_query_cache(
+        self,
+        jurisdiction_name: str,
+        jurisdiction_type: str,
+        prompt_version: str,
+        queries: List[str],
+        ttl_hours: int = 72,
+    ) -> bool:
+        """Persist discovery query cache with TTL."""
+        if not queries:
+            return False
+        try:
+            await self._execute(
+                """
+                INSERT INTO discovery_query_cache (
+                    jurisdiction_name,
+                    jurisdiction_type,
+                    prompt_version,
+                    queries,
+                    expires_at
+                )
+                VALUES ($1, $2, $3, $4::jsonb, NOW() + ($5::text || ' hours')::interval)
+                ON CONFLICT (jurisdiction_name, jurisdiction_type, prompt_version)
+                DO UPDATE SET
+                    queries = EXCLUDED.queries,
+                    expires_at = EXCLUDED.expires_at,
+                    updated_at = NOW()
+                """,
+                jurisdiction_name,
+                jurisdiction_type,
+                prompt_version,
+                json.dumps(queries),
+                str(max(ttl_hours, 1)),
+            )
+            return True
+        except Exception as e:
+            logger.warning("Discovery query cache write skipped: %s", e)
+            return False
+
+    async def get_discovery_classifier_cache(
+        self,
+        normalized_url: str,
+        classifier_version: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Return cached classifier decision for an exact normalized URL."""
+        try:
+            row = await self._fetchrow(
+                """
+                SELECT normalized_url, classifier_version, decision
+                FROM discovery_classifier_cache
+                WHERE normalized_url = $1
+                  AND classifier_version = $2
+                LIMIT 1
+                """,
+                normalized_url,
+                classifier_version,
+            )
+        except Exception as e:
+            logger.warning("Discovery classifier cache read skipped: %s", e)
+            return None
+
+        if not row:
+            return None
+
+        payload = row["decision"]
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload)
+            except json.JSONDecodeError:
+                return None
+        return payload if isinstance(payload, dict) else None
+
+    async def upsert_discovery_classifier_cache(
+        self,
+        normalized_url: str,
+        classifier_version: str,
+        decision: Dict[str, Any],
+    ) -> bool:
+        """Persist a classifier decision for exact URL cache lookups."""
+        try:
+            await self._execute(
+                """
+                INSERT INTO discovery_classifier_cache (
+                    normalized_url,
+                    classifier_version,
+                    decision
+                )
+                VALUES ($1, $2, $3::jsonb)
+                ON CONFLICT (normalized_url, classifier_version)
+                DO UPDATE SET
+                    decision = EXCLUDED.decision,
+                    updated_at = NOW()
+                """,
+                normalized_url,
+                classifier_version,
+                json.dumps(decision),
+            )
+            return True
+        except Exception as e:
+            logger.warning("Discovery classifier cache write skipped: %s", e)
+            return False
+
     async def update_source(
         self, source_id: str, data: Dict[str, Any]
     ) -> Dict[str, Any]:

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -1,0 +1,25 @@
+-- Discovery resilience cache tables (Phase 1: bd-ss6db)
+-- Keep schema reference aligned with migration 008.
+
+CREATE TABLE IF NOT EXISTS public.discovery_query_cache (
+  jurisdiction_name text NOT NULL,
+  jurisdiction_type text NOT NULL,
+  prompt_version text NOT NULL,
+  queries jsonb NOT NULL,
+  expires_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (jurisdiction_name, jurisdiction_type, prompt_version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_discovery_query_cache_expires_at
+  ON public.discovery_query_cache (expires_at);
+
+CREATE TABLE IF NOT EXISTS public.discovery_classifier_cache (
+  normalized_url text NOT NULL,
+  classifier_version text NOT NULL,
+  decision jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (normalized_url, classifier_version)
+);

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -23,3 +23,21 @@ CREATE TABLE IF NOT EXISTS public.discovery_classifier_cache (
   updated_at timestamptz NOT NULL DEFAULT now(),
   PRIMARY KEY (normalized_url, classifier_version)
 );
+
+CREATE TABLE IF NOT EXISTS public.discovery_deferred_queue (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  jurisdiction_id text NOT NULL,
+  jurisdiction_name text NOT NULL,
+  stage text NOT NULL CHECK (stage IN ('query_generation', 'search', 'classification')),
+  reason_code text NOT NULL CHECK (reason_code IN ('rate_limit', 'dns_failure', 'provider_unavailable', 'provider_budget_exhausted')),
+  payload jsonb NOT NULL,
+  retry_count integer NOT NULL DEFAULT 0,
+  next_attempt_at timestamptz NOT NULL DEFAULT now(),
+  last_error text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (jurisdiction_id, stage, reason_code, payload)
+);
+
+CREATE INDEX IF NOT EXISTS idx_discovery_deferred_queue_due
+  ON public.discovery_deferred_queue (next_attempt_at);

--- a/backend/migrations/008_add_discovery_resilience_caches.sql
+++ b/backend/migrations/008_add_discovery_resilience_caches.sql
@@ -1,0 +1,25 @@
+-- Phase 1 discovery resilience caches (bd-ss6db).
+-- Keeps provider-heavy query generation/classification work bounded per run.
+
+CREATE TABLE IF NOT EXISTS public.discovery_query_cache (
+  jurisdiction_name text NOT NULL,
+  jurisdiction_type text NOT NULL,
+  prompt_version text NOT NULL,
+  queries jsonb NOT NULL,
+  expires_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (jurisdiction_name, jurisdiction_type, prompt_version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_discovery_query_cache_expires_at
+  ON public.discovery_query_cache (expires_at);
+
+CREATE TABLE IF NOT EXISTS public.discovery_classifier_cache (
+  normalized_url text NOT NULL,
+  classifier_version text NOT NULL,
+  decision jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (normalized_url, classifier_version)
+);

--- a/backend/migrations/009_add_discovery_deferred_queue.sql
+++ b/backend/migrations/009_add_discovery_deferred_queue.sql
@@ -1,0 +1,19 @@
+-- Phase 2 deferred queue for provider-limited discovery stages (bd-ro2cx).
+
+CREATE TABLE IF NOT EXISTS public.discovery_deferred_queue (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  jurisdiction_id text NOT NULL,
+  jurisdiction_name text NOT NULL,
+  stage text NOT NULL CHECK (stage IN ('query_generation', 'search', 'classification')),
+  reason_code text NOT NULL CHECK (reason_code IN ('rate_limit', 'dns_failure', 'provider_unavailable', 'provider_budget_exhausted')),
+  payload jsonb NOT NULL,
+  retry_count integer NOT NULL DEFAULT 0,
+  next_attempt_at timestamptz NOT NULL DEFAULT now(),
+  last_error text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (jurisdiction_id, stage, reason_code, payload)
+);
+
+CREATE INDEX IF NOT EXISTS idx_discovery_deferred_queue_due
+  ON public.discovery_deferred_queue (next_attempt_at);

--- a/backend/scripts/cron/run_discovery.py
+++ b/backend/scripts/cron/run_discovery.py
@@ -178,7 +178,7 @@ async def main(
     try:
         await db.create_admin_task(
             task_id=task_id,
-            task_type='discovery',
+            task_type='research',
             jurisdiction='all',
             status='running'
         )
@@ -229,6 +229,7 @@ async def main(
 
         for jur in jurisdictions:
             logger.info(f"🔎 Discovering for {jur['name']}...")
+            jurisdiction_id = str(jur["id"])
             
             # Run Discovery
             discover_kwargs = {}
@@ -298,7 +299,7 @@ async def main(
 
                 existing = await db._fetchrow(
                     "SELECT id FROM sources WHERE jurisdiction_id = $1 AND url = $2",
-                    jur['id'],
+                    jurisdiction_id,
                     candidate_url,
                 )
 
@@ -308,7 +309,7 @@ async def main(
                     continue
 
                 await db.create_source({
-                    'jurisdiction_id': str(jur['id']),
+                    'jurisdiction_id': jurisdiction_id,
                     'name': item.get('title') or candidate_url,
                     'type': 'web',
                     'url': candidate_url,

--- a/backend/scripts/cron/run_discovery.py
+++ b/backend/scripts/cron/run_discovery.py
@@ -11,8 +11,10 @@ import logging
 import asyncio
 import json
 import argparse
+import inspect
 from datetime import datetime
 from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from uuid import uuid4
 
 # Add backend to path
@@ -36,6 +38,9 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 logger = logging.getLogger("discovery")
 
 CLASSIFIER_MIN_CONFIDENCE = 0.75
+DEFAULT_QUERY_PROVIDER_BUDGET = 5
+DEFAULT_CLASSIFIER_PROVIDER_BUDGET = 50
+DEFAULT_QUERY_CACHE_TTL_HOURS = 72
 VALIDATION_REPORT_PATH = (
     Path(__file__).resolve().parents[1]
     / "verification"
@@ -70,6 +75,42 @@ class ResilientWebSearchClient:
             return []
 
 
+_OBVIOUS_JUNK_DOMAINS = {
+    "facebook.com",
+    "instagram.com",
+    "x.com",
+    "twitter.com",
+    "youtube.com",
+    "tiktok.com",
+    "reddit.com",
+    "linkedin.com",
+    "yelp.com",
+    "zillow.com",
+}
+
+
+def _normalize_url_for_cache(url: str) -> str:
+    """Normalize URL to maximize exact-cache hits without changing authority/path semantics."""
+    parts = urlsplit((url or "").strip())
+    scheme = (parts.scheme or "https").lower()
+    netloc = parts.netloc.lower()
+    path = parts.path.rstrip("/") or "/"
+    query_pairs = parse_qsl(parts.query, keep_blank_values=False)
+    filtered_pairs = [
+        (k, v)
+        for k, v in query_pairs
+        if not k.lower().startswith("utm_")
+    ]
+    normalized_query = urlencode(sorted(filtered_pairs))
+    return urlunsplit((scheme, netloc, path, normalized_query, ""))
+
+
+def _is_obvious_junk_candidate(url: str) -> bool:
+    netloc = urlsplit((url or "").strip()).netloc.lower()
+    host = netloc.split(":")[0]
+    return any(host == domain or host.endswith(f".{domain}") for domain in _OBVIOUS_JUNK_DOMAINS)
+
+
 def _normalize_jurisdiction_scope(values: list[str] | None) -> set[str] | None:
     """Normalize optional jurisdiction scope list into casefolded names."""
     if not values:
@@ -100,6 +141,18 @@ def _parse_args() -> argparse.Namespace:
         type=int,
         default=None,
         help="Optional cap for number of discovery queries per jurisdiction (for bounded validation runs).",
+    )
+    parser.add_argument(
+        "--query-provider-budget",
+        type=int,
+        default=None,
+        help="Max count of provider-backed query-generation calls allowed per invocation.",
+    )
+    parser.add_argument(
+        "--classifier-provider-budget",
+        type=int,
+        default=None,
+        help="Max count of provider-backed classifier calls allowed per invocation.",
     )
     return parser.parse_args()
 
@@ -154,6 +207,8 @@ def _load_classifier_validation_contract() -> tuple[bool, dict]:
 async def main(
     jurisdiction_scope: set[str] | None = None,
     max_queries_per_jurisdiction: int | None = None,
+    query_provider_budget: int | None = None,
+    classifier_provider_budget: int | None = None,
 ):
     task_id = str(uuid4())
     logger.info(f"🚀 Starting Discovery (Task {task_id})")
@@ -173,6 +228,23 @@ async def main(
     classifier_service = DiscoveryClassifierService()
     gate_enabled, gate_contract = _load_classifier_validation_contract()
     classifier_trusted = classifier_service.client is not None
+    query_provider_budget_limit = (
+        query_provider_budget
+        if query_provider_budget is not None
+        else int(os.environ.get("DISCOVERY_QUERY_PROVIDER_BUDGET", str(DEFAULT_QUERY_PROVIDER_BUDGET)))
+    )
+    classifier_provider_budget_limit = (
+        classifier_provider_budget
+        if classifier_provider_budget is not None
+        else int(
+            os.environ.get(
+                "DISCOVERY_CLASSIFIER_PROVIDER_BUDGET",
+                str(DEFAULT_CLASSIFIER_PROVIDER_BUDGET),
+            )
+        )
+    )
+    query_provider_calls_used = 0
+    classifier_provider_calls_used = 0
     
     # 1. Log Start
     try:
@@ -205,12 +277,17 @@ async def main(
             "new": 0,
             "duplicates": 0,
             "rejected": 0,
+            "query_cache_hits": 0,
+            "classifier_cache_hits": 0,
+            "classifier_cache_positive_reuse": 0,
             "rejected_by_reason": {
                 "batch_gate_fail_closed": 0,
                 "classifier_untrusted_fail_closed": 0,
                 "classifier_error_fail_closed": 0,
                 "not_scrapable": 0,
                 "low_confidence": 0,
+                "heuristic_obvious_junk": 0,
+                "provider_budget_exhausted": 0,
             },
             "batch_gate": gate_contract,
             "classifier_trusted": classifier_trusted,
@@ -219,6 +296,10 @@ async def main(
             "jurisdictions_processed": len(jurisdictions),
             "jurisdictions_available": len(all_jurisdictions),
             "max_queries_per_jurisdiction": max_queries_per_jurisdiction,
+            "query_provider_budget_limit": query_provider_budget_limit,
+            "query_provider_calls_used": 0,
+            "classifier_provider_budget_limit": classifier_provider_budget_limit,
+            "classifier_provider_calls_used": 0,
         }
 
         if not gate_enabled:
@@ -232,7 +313,19 @@ async def main(
             jurisdiction_id = str(jur["id"])
             
             # Run Discovery
-            discover_kwargs = {}
+            allow_provider_query_generation = query_provider_calls_used < max(
+                query_provider_budget_limit,
+                0,
+            )
+            discover_kwargs = {
+                "allow_provider_query_generation": allow_provider_query_generation,
+                "query_cache_ttl_hours": int(
+                    os.environ.get(
+                        "DISCOVERY_QUERY_CACHE_TTL_HOURS",
+                        str(DEFAULT_QUERY_CACHE_TTL_HOURS),
+                    )
+                ),
+            }
             if max_queries_per_jurisdiction is not None:
                 discover_kwargs["max_queries"] = max_queries_per_jurisdiction
             discovered_items = await discovery_service.discover_sources(
@@ -240,6 +333,11 @@ async def main(
                 jur.get('type', 'city'),
                 **discover_kwargs,
             )
+            discovery_stats = getattr(discovery_service, "last_discovery_stats", {}) or {}
+            if discovery_stats.get("query_cache_hit"):
+                results["query_cache_hits"] += 1
+            if discovery_stats.get("query_provider_used"):
+                query_provider_calls_used += 1
             
             for item in discovered_items:
                 results["found"] += 1
@@ -249,6 +347,12 @@ async def main(
                     results["rejected"] += 1
                     results["rejected_by_reason"]["classifier_error_fail_closed"] += 1
                     logger.info("   - Rejected (missing URL in discovery item)")
+                    continue
+
+                if _is_obvious_junk_candidate(candidate_url):
+                    results["rejected"] += 1
+                    results["rejected_by_reason"]["heuristic_obvious_junk"] += 1
+                    logger.info("   - Rejected (heuristic obvious junk): %s", candidate_url)
                     continue
 
                 if not gate_enabled:
@@ -263,11 +367,48 @@ async def main(
                     logger.info("   - Rejected (classifier unavailable): %s", candidate_url)
                     continue
 
-                try:
-                    classification = await classifier_service.discover_url(
-                        url=candidate_url,
-                        page_text=item.get("snippet", ""),
+                normalized_url = _normalize_url_for_cache(candidate_url)
+                classification = None
+                cached_payload = None
+                cache_reader = getattr(db, "get_discovery_classifier_cache", None)
+                if cache_reader and inspect.iscoroutinefunction(cache_reader):
+                    cached_payload = await cache_reader(
+                        normalized_url=normalized_url,
+                        classifier_version=classifier_service.classifier_version,
                     )
+                if cached_payload:
+                    cached_decision = classifier_service.response_from_cache_payload(cached_payload)
+                    if cached_decision:
+                        classification = cached_decision
+                        results["classifier_cache_hits"] += 1
+                        if (
+                            classification.is_scrapable
+                            and classification.confidence >= CLASSIFIER_MIN_CONFIDENCE
+                        ):
+                            results["classifier_cache_positive_reuse"] += 1
+
+                try:
+                    if classification is None:
+                        if classifier_provider_calls_used >= max(classifier_provider_budget_limit, 0):
+                            results["rejected"] += 1
+                            results["rejected_by_reason"]["provider_budget_exhausted"] += 1
+                            logger.info(
+                                "   - Rejected (classifier provider budget exhausted): %s",
+                                candidate_url,
+                            )
+                            continue
+                        classification = await classifier_service.discover_url(
+                            url=candidate_url,
+                            page_text=item.get("snippet", ""),
+                        )
+                        classifier_provider_calls_used += 1
+                        cache_writer = getattr(db, "upsert_discovery_classifier_cache", None)
+                        if cache_writer and inspect.iscoroutinefunction(cache_writer):
+                            await cache_writer(
+                                normalized_url=normalized_url,
+                                classifier_version=classifier_service.classifier_version,
+                                decision=classifier_service.response_to_cache_payload(classification),
+                            )
                 except Exception as exc:
                     logger.warning("Classifier failure for %s: %s", candidate_url, exc)
                     results["rejected"] += 1
@@ -336,6 +477,8 @@ async def main(
                 )
         
         # 3. Log Success
+        results["query_provider_calls_used"] = query_provider_calls_used
+        results["classifier_provider_calls_used"] = classifier_provider_calls_used
         logger.info(f"🏁 Discovery Complete. {results}")
         
         await db.update_admin_task(
@@ -366,5 +509,7 @@ if __name__ == "__main__":
         main(
             jurisdiction_scope=scope,
             max_queries_per_jurisdiction=args.max_queries_per_jurisdiction,
+            query_provider_budget=args.query_provider_budget,
+            classifier_provider_budget=args.classifier_provider_budget,
         )
     )

--- a/backend/scripts/cron/run_discovery.py
+++ b/backend/scripts/cron/run_discovery.py
@@ -12,7 +12,7 @@ import asyncio
 import json
 import argparse
 import inspect
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from uuid import uuid4
@@ -40,7 +40,11 @@ logger = logging.getLogger("discovery")
 CLASSIFIER_MIN_CONFIDENCE = 0.75
 DEFAULT_QUERY_PROVIDER_BUDGET = 5
 DEFAULT_CLASSIFIER_PROVIDER_BUDGET = 50
+DEFAULT_DEFERRED_RETRY_BUDGET = 20
 DEFAULT_QUERY_CACHE_TTL_HOURS = 72
+DEFAULT_DEFERRED_BASE_BACKOFF_MINUTES = 5
+DEFAULT_DEFERRED_MAX_BACKOFF_MINUTES = 360
+DEFAULT_DEFERRED_MAX_RETRIES = 6
 VALIDATION_REPORT_PATH = (
     Path(__file__).resolve().parents[1]
     / "verification"
@@ -123,6 +127,62 @@ def _normalize_jurisdiction_scope(values: list[str] | None) -> set[str] | None:
     return normalized or None
 
 
+def _supports_async_method(obj, method_name: str) -> bool:
+    method = getattr(obj, method_name, None)
+    return bool(method and inspect.iscoroutinefunction(method))
+
+
+def _summarize_error(error_text: str, max_chars: int = 280) -> str:
+    value = (error_text or "").strip()
+    return value[:max_chars]
+
+
+def _classify_provider_limited_reason(error_text: str) -> str | None:
+    lowered = (error_text or "").lower()
+    if not lowered:
+        return None
+    if "budget" in lowered and "exhausted" in lowered:
+        return "provider_budget_exhausted"
+    if "429" in lowered or "rate limit" in lowered:
+        return "rate_limit"
+    if (
+        "dns" in lowered
+        or "name resolution" in lowered
+        or "nodename nor servname" in lowered
+        or "temporary failure in name resolution" in lowered
+    ):
+        return "dns_failure"
+    if (
+        "unavailable" in lowered
+        or "timeout" in lowered
+        or "timed out" in lowered
+        or "connection reset" in lowered
+        or "connection refused" in lowered
+        or "bad gateway" in lowered
+        or "503" in lowered
+    ):
+        return "provider_unavailable"
+    return None
+
+
+def _compute_next_attempt_at(retry_count: int) -> datetime:
+    base_minutes = int(
+        os.environ.get(
+            "DISCOVERY_DEFERRED_BASE_BACKOFF_MINUTES",
+            str(DEFAULT_DEFERRED_BASE_BACKOFF_MINUTES),
+        )
+    )
+    max_minutes = int(
+        os.environ.get(
+            "DISCOVERY_DEFERRED_MAX_BACKOFF_MINUTES",
+            str(DEFAULT_DEFERRED_MAX_BACKOFF_MINUTES),
+        )
+    )
+    bounded_retry = max(retry_count, 0)
+    wait_minutes = min(max(base_minutes, 1) * (2 ** bounded_retry), max(max_minutes, 1))
+    return datetime.now(timezone.utc) + timedelta(minutes=wait_minutes)
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run discovery cron with optional bounded scope.")
     parser.add_argument(
@@ -153,6 +213,12 @@ def _parse_args() -> argparse.Namespace:
         type=int,
         default=None,
         help="Max count of provider-backed classifier calls allowed per invocation.",
+    )
+    parser.add_argument(
+        "--deferred-retry-budget",
+        type=int,
+        default=None,
+        help="Max count of due deferred queue items to process per invocation.",
     )
     return parser.parse_args()
 
@@ -209,6 +275,7 @@ async def main(
     max_queries_per_jurisdiction: int | None = None,
     query_provider_budget: int | None = None,
     classifier_provider_budget: int | None = None,
+    deferred_retry_budget: int | None = None,
 ):
     task_id = str(uuid4())
     logger.info(f"🚀 Starting Discovery (Task {task_id})")
@@ -240,6 +307,16 @@ async def main(
             os.environ.get(
                 "DISCOVERY_CLASSIFIER_PROVIDER_BUDGET",
                 str(DEFAULT_CLASSIFIER_PROVIDER_BUDGET),
+            )
+        )
+    )
+    deferred_retry_budget_limit = (
+        deferred_retry_budget
+        if deferred_retry_budget is not None
+        else int(
+            os.environ.get(
+                "DISCOVERY_DEFERRED_RETRY_BUDGET",
+                str(DEFAULT_DEFERRED_RETRY_BUDGET),
             )
         )
     )
@@ -289,6 +366,27 @@ async def main(
                 "heuristic_obvious_junk": 0,
                 "provider_budget_exhausted": 0,
             },
+            "deferred": {
+                "retry_budget_limit": deferred_retry_budget_limit,
+                "due_loaded": 0,
+                "processed": 0,
+                "resolved": 0,
+                "rescheduled": 0,
+                "enqueued": 0,
+                "dropped_max_retries": 0,
+                "terminal_failures": 0,
+                "enqueued_by_stage": {
+                    "query_generation": 0,
+                    "search": 0,
+                    "classification": 0,
+                },
+                "enqueued_by_reason": {
+                    "rate_limit": 0,
+                    "dns_failure": 0,
+                    "provider_unavailable": 0,
+                    "provider_budget_exhausted": 0,
+                },
+            },
             "batch_gate": gate_contract,
             "classifier_trusted": classifier_trusted,
             "classifier_min_confidence": CLASSIFIER_MIN_CONFIDENCE,
@@ -301,6 +399,314 @@ async def main(
             "classifier_provider_budget_limit": classifier_provider_budget_limit,
             "classifier_provider_calls_used": 0,
         }
+        max_deferred_retries = int(
+            os.environ.get(
+                "DISCOVERY_DEFERRED_MAX_RETRIES",
+                str(DEFAULT_DEFERRED_MAX_RETRIES),
+            )
+        )
+        query_cache_ttl_hours = int(
+            os.environ.get(
+                "DISCOVERY_QUERY_CACHE_TTL_HOURS",
+                str(DEFAULT_QUERY_CACHE_TTL_HOURS),
+            )
+        )
+
+        async def _enqueue_deferred_item(
+            *,
+            jurisdiction_id: str,
+            jurisdiction_name: str,
+            stage: str,
+            reason_code: str,
+            payload: dict,
+            retry_count: int = 0,
+            last_error: str | None = None,
+        ) -> bool:
+            writer = getattr(db, "upsert_discovery_deferred_item", None)
+            if not (writer and inspect.iscoroutinefunction(writer)):
+                return False
+            ok = await writer(
+                jurisdiction_id=jurisdiction_id,
+                jurisdiction_name=jurisdiction_name,
+                stage=stage,
+                reason_code=reason_code,
+                payload=payload,
+                retry_count=max(retry_count, 0),
+                next_attempt_at=_compute_next_attempt_at(max(retry_count, 0)),
+                last_error=last_error,
+            )
+            if ok:
+                results["deferred"]["enqueued"] += 1
+                if stage in results["deferred"]["enqueued_by_stage"]:
+                    results["deferred"]["enqueued_by_stage"][stage] += 1
+                if reason_code in results["deferred"]["enqueued_by_reason"]:
+                    results["deferred"]["enqueued_by_reason"][reason_code] += 1
+            return ok
+
+        async def _resolve_deferred_item(item_id: str) -> None:
+            resolver = getattr(db, "resolve_discovery_deferred_item", None)
+            if resolver and inspect.iscoroutinefunction(resolver):
+                if await resolver(item_id):
+                    results["deferred"]["resolved"] += 1
+
+        async def _reschedule_deferred_item(
+            *,
+            item_id: str,
+            retry_count: int,
+            last_error: str,
+            reason_code: str | None = None,
+        ) -> None:
+            if retry_count > max_deferred_retries:
+                await _resolve_deferred_item(item_id)
+                results["deferred"]["dropped_max_retries"] += 1
+                return
+
+            rescheduler = getattr(db, "reschedule_discovery_deferred_item", None)
+            if not (rescheduler and inspect.iscoroutinefunction(rescheduler)):
+                await _resolve_deferred_item(item_id)
+                results["deferred"]["terminal_failures"] += 1
+                return
+            ok = await rescheduler(
+                item_id=item_id,
+                retry_count=retry_count,
+                next_attempt_at=_compute_next_attempt_at(retry_count),
+                last_error=last_error,
+                reason_code=reason_code,
+            )
+            if ok:
+                results["deferred"]["rescheduled"] += 1
+
+        def _apply_discovery_stats() -> None:
+            nonlocal query_provider_calls_used
+            discovery_stats = getattr(discovery_service, "last_discovery_stats", {}) or {}
+            if discovery_stats.get("query_cache_hit"):
+                results["query_cache_hits"] += 1
+            if discovery_stats.get("query_provider_used"):
+                query_provider_calls_used += 1
+
+        async def _process_discovered_item(
+            *,
+            jurisdiction_id: str,
+            jurisdiction_name: str,
+            jurisdiction_type: str,
+            item: dict,
+            deferred_item: dict | None = None,
+        ) -> None:
+            nonlocal classifier_provider_calls_used
+            candidate_url = item.get("url")
+
+            if not candidate_url:
+                results["rejected"] += 1
+                results["rejected_by_reason"]["classifier_error_fail_closed"] += 1
+                logger.info("   - Rejected (missing URL in discovery item)")
+                if deferred_item:
+                    await _resolve_deferred_item(str(deferred_item["id"]))
+                return
+
+            if _is_obvious_junk_candidate(candidate_url):
+                results["rejected"] += 1
+                results["rejected_by_reason"]["heuristic_obvious_junk"] += 1
+                logger.info("   - Rejected (heuristic obvious junk): %s", candidate_url)
+                if deferred_item:
+                    await _resolve_deferred_item(str(deferred_item["id"]))
+                return
+
+            if not gate_enabled:
+                results["rejected"] += 1
+                results["rejected_by_reason"]["batch_gate_fail_closed"] += 1
+                logger.info("   - Rejected (batch gate): %s", candidate_url)
+                if deferred_item:
+                    await _resolve_deferred_item(str(deferred_item["id"]))
+                return
+
+            if not classifier_trusted:
+                results["rejected"] += 1
+                results["rejected_by_reason"]["classifier_untrusted_fail_closed"] += 1
+                logger.info("   - Rejected (classifier unavailable): %s", candidate_url)
+                if deferred_item:
+                    await _resolve_deferred_item(str(deferred_item["id"]))
+                return
+
+            normalized_url = _normalize_url_for_cache(candidate_url)
+            classification = None
+            cached_payload = None
+            cache_reader = getattr(db, "get_discovery_classifier_cache", None)
+            if cache_reader and inspect.iscoroutinefunction(cache_reader):
+                cached_payload = await cache_reader(
+                    normalized_url=normalized_url,
+                    classifier_version=classifier_service.classifier_version,
+                )
+            if cached_payload:
+                cached_decision = classifier_service.response_from_cache_payload(cached_payload)
+                if cached_decision:
+                    classification = cached_decision
+                    results["classifier_cache_hits"] += 1
+                    if (
+                        classification.is_scrapable
+                        and classification.confidence >= CLASSIFIER_MIN_CONFIDENCE
+                    ):
+                        results["classifier_cache_positive_reuse"] += 1
+
+            try:
+                if classification is None:
+                    if classifier_provider_calls_used >= max(classifier_provider_budget_limit, 0):
+                        budget_reason = "provider_budget_exhausted"
+                        summary = "classifier provider budget exhausted"
+                        payload = {
+                            "url": candidate_url,
+                            "title": item.get("title"),
+                            "snippet": item.get("snippet", ""),
+                            "category": item.get("category", ""),
+                            "discovery_query": item.get("discovery_query"),
+                            "jurisdiction_type": jurisdiction_type,
+                        }
+                        if deferred_item:
+                            next_retry = int(deferred_item.get("retry_count", 0)) + 1
+                            await _reschedule_deferred_item(
+                                item_id=str(deferred_item["id"]),
+                                retry_count=next_retry,
+                                last_error=summary,
+                                reason_code=budget_reason,
+                            )
+                        else:
+                            queued = await _enqueue_deferred_item(
+                                jurisdiction_id=jurisdiction_id,
+                                jurisdiction_name=jurisdiction_name,
+                                stage="classification",
+                                reason_code=budget_reason,
+                                payload=payload,
+                                retry_count=0,
+                                last_error=summary,
+                            )
+                            if not queued:
+                                results["rejected"] += 1
+                                results["rejected_by_reason"]["provider_budget_exhausted"] += 1
+                        logger.info("   ~ Deferred (classifier budget exhausted): %s", candidate_url)
+                        return
+
+                    classification = await classifier_service.discover_url(
+                        url=candidate_url,
+                        page_text=item.get("snippet", ""),
+                    )
+                    classifier_provider_calls_used += 1
+                    cache_writer = getattr(db, "upsert_discovery_classifier_cache", None)
+                    if cache_writer and inspect.iscoroutinefunction(cache_writer):
+                        await cache_writer(
+                            normalized_url=normalized_url,
+                            classifier_version=classifier_service.classifier_version,
+                            decision=classifier_service.response_to_cache_payload(classification),
+                        )
+            except Exception as exc:
+                reason_code = _classify_provider_limited_reason(str(exc))
+                if reason_code:
+                    payload = {
+                        "url": candidate_url,
+                        "title": item.get("title"),
+                        "snippet": item.get("snippet", ""),
+                        "category": item.get("category", ""),
+                        "discovery_query": item.get("discovery_query"),
+                        "jurisdiction_type": jurisdiction_type,
+                    }
+                    error_summary = _summarize_error(str(exc))
+                    if deferred_item:
+                        next_retry = int(deferred_item.get("retry_count", 0)) + 1
+                        await _reschedule_deferred_item(
+                            item_id=str(deferred_item["id"]),
+                            retry_count=next_retry,
+                            last_error=error_summary,
+                            reason_code=reason_code,
+                        )
+                    else:
+                        queued = await _enqueue_deferred_item(
+                            jurisdiction_id=jurisdiction_id,
+                            jurisdiction_name=jurisdiction_name,
+                            stage="classification",
+                            reason_code=reason_code,
+                            payload=payload,
+                            retry_count=0,
+                            last_error=error_summary,
+                        )
+                        if not queued:
+                            results["rejected"] += 1
+                            results["rejected_by_reason"]["classifier_error_fail_closed"] += 1
+                    logger.info("   ~ Deferred (classifier provider-limited): %s", candidate_url)
+                    return
+
+                logger.warning("Classifier failure for %s: %s", candidate_url, exc)
+                results["rejected"] += 1
+                results["rejected_by_reason"]["classifier_error_fail_closed"] += 1
+                if deferred_item:
+                    await _resolve_deferred_item(str(deferred_item["id"]))
+                return
+
+            if not classification.is_scrapable:
+                results["rejected"] += 1
+                results["rejected_by_reason"]["not_scrapable"] += 1
+                logger.info(
+                    "   - Rejected (not scrapable): %s (confidence=%.2f)",
+                    candidate_url,
+                    classification.confidence,
+                )
+                if deferred_item:
+                    await _resolve_deferred_item(str(deferred_item["id"]))
+                return
+
+            if classification.confidence < CLASSIFIER_MIN_CONFIDENCE:
+                results["rejected"] += 1
+                results["rejected_by_reason"]["low_confidence"] += 1
+                logger.info(
+                    "   - Rejected (confidence %.2f < %.2f): %s",
+                    classification.confidence,
+                    CLASSIFIER_MIN_CONFIDENCE,
+                    candidate_url,
+                )
+                if deferred_item:
+                    await _resolve_deferred_item(str(deferred_item["id"]))
+                return
+
+            results["accepted"] += 1
+
+            existing = await db._fetchrow(
+                "SELECT id FROM sources WHERE jurisdiction_id = $1 AND url = $2",
+                jurisdiction_id,
+                candidate_url,
+            )
+
+            if existing:
+                results["duplicates"] += 1
+                logger.info("   = Duplicate (skip): %s", item.get("title") or candidate_url)
+                if deferred_item:
+                    await _resolve_deferred_item(str(deferred_item["id"]))
+                return
+
+            await db.create_source({
+                "jurisdiction_id": jurisdiction_id,
+                "name": item.get("title") or candidate_url,
+                "type": "web",
+                "url": candidate_url,
+                "scrape_url": candidate_url,
+                "metadata": {
+                    "category": item.get("category", ""),
+                    "snippet": item.get("snippet", ""),
+                    "discovery_query": item.get("discovery_query"),
+                    "classifier": {
+                        "is_scrapable": classification.is_scrapable,
+                        "confidence": classification.confidence,
+                        "source_type": classification.source_type,
+                        "recommended_spider": classification.recommended_spider,
+                        "reasoning": classification.reasoning,
+                    },
+                    "discovered_at": datetime.now().isoformat(),
+                },
+            })
+            results["new"] += 1
+            logger.info(
+                "   + Added: %s (confidence=%.2f)",
+                item.get("title") or candidate_url,
+                classification.confidence,
+            )
+            if deferred_item:
+                await _resolve_deferred_item(str(deferred_item["id"]))
 
         if not gate_enabled:
             logger.error("Discovery source creation fail-closed: validation gate not satisfied")
@@ -308,9 +714,102 @@ async def main(
         if not classifier_trusted:
             logger.error("Discovery source creation fail-closed: classifier client unavailable")
 
+        due_reader = getattr(db, "get_due_discovery_deferred_items", None)
+        due_items: list[dict] = []
+        if (
+            deferred_retry_budget_limit > 0
+            and due_reader
+            and inspect.iscoroutinefunction(due_reader)
+        ):
+            due_items = await due_reader(limit=deferred_retry_budget_limit)
+        results["deferred"]["due_loaded"] = len(due_items)
+
+        for deferred_item in due_items:
+            results["deferred"]["processed"] += 1
+            retry_count = int(deferred_item.get("retry_count", 0))
+            if retry_count >= max_deferred_retries:
+                await _resolve_deferred_item(str(deferred_item["id"]))
+                results["deferred"]["dropped_max_retries"] += 1
+                continue
+
+            stage = str(deferred_item.get("stage", ""))
+            reason_code = str(deferred_item.get("reason_code", "provider_unavailable"))
+            payload = deferred_item.get("payload") if isinstance(deferred_item.get("payload"), dict) else {}
+            jurisdiction_id = str(deferred_item.get("jurisdiction_id"))
+            jurisdiction_name = str(deferred_item.get("jurisdiction_name"))
+            jurisdiction_type = str(payload.get("jurisdiction_type", "city"))
+
+            if stage == "classification":
+                item = {
+                    "url": payload.get("url"),
+                    "title": payload.get("title"),
+                    "snippet": payload.get("snippet", ""),
+                    "category": payload.get("category", ""),
+                    "discovery_query": payload.get("discovery_query"),
+                }
+                await _process_discovered_item(
+                    jurisdiction_id=jurisdiction_id,
+                    jurisdiction_name=jurisdiction_name,
+                    jurisdiction_type=jurisdiction_type,
+                    item=item,
+                    deferred_item=deferred_item,
+                )
+                continue
+
+            allow_provider_query_generation = query_provider_calls_used < max(
+                query_provider_budget_limit,
+                0,
+            )
+            discover_kwargs = {
+                "allow_provider_query_generation": allow_provider_query_generation,
+                "query_cache_ttl_hours": query_cache_ttl_hours,
+            }
+            if max_queries_per_jurisdiction is not None:
+                discover_kwargs["max_queries"] = max_queries_per_jurisdiction
+
+            try:
+                discovered_items = await discovery_service.discover_sources(
+                    jurisdiction_name,
+                    jurisdiction_type,
+                    **discover_kwargs,
+                )
+                _apply_discovery_stats()
+                await _resolve_deferred_item(str(deferred_item["id"]))
+            except Exception as exc:
+                classified_reason = _classify_provider_limited_reason(str(exc))
+                if classified_reason:
+                    next_retry = retry_count + 1
+                    await _reschedule_deferred_item(
+                        item_id=str(deferred_item["id"]),
+                        retry_count=next_retry,
+                        last_error=_summarize_error(str(exc)),
+                        reason_code=classified_reason,
+                    )
+                else:
+                    logger.warning(
+                        "Deferred replay failed with terminal error (stage=%s reason=%s): %s",
+                        stage,
+                        reason_code,
+                        exc,
+                    )
+                    await _resolve_deferred_item(str(deferred_item["id"]))
+                    results["deferred"]["terminal_failures"] += 1
+                continue
+
+            for item in discovered_items:
+                results["found"] += 1
+                await _process_discovered_item(
+                    jurisdiction_id=jurisdiction_id,
+                    jurisdiction_name=jurisdiction_name,
+                    jurisdiction_type=jurisdiction_type,
+                    item=item,
+                )
+
         for jur in jurisdictions:
             logger.info(f"🔎 Discovering for {jur['name']}...")
             jurisdiction_id = str(jur["id"])
+            jurisdiction_name = str(jur["name"])
+            jurisdiction_type = str(jur.get("type", "city"))
             
             # Run Discovery
             allow_provider_query_generation = query_provider_calls_used < max(
@@ -319,161 +818,51 @@ async def main(
             )
             discover_kwargs = {
                 "allow_provider_query_generation": allow_provider_query_generation,
-                "query_cache_ttl_hours": int(
-                    os.environ.get(
-                        "DISCOVERY_QUERY_CACHE_TTL_HOURS",
-                        str(DEFAULT_QUERY_CACHE_TTL_HOURS),
-                    )
-                ),
+                "query_cache_ttl_hours": query_cache_ttl_hours,
             }
             if max_queries_per_jurisdiction is not None:
                 discover_kwargs["max_queries"] = max_queries_per_jurisdiction
-            discovered_items = await discovery_service.discover_sources(
-                jur['name'],
-                jur.get('type', 'city'),
-                **discover_kwargs,
-            )
-            discovery_stats = getattr(discovery_service, "last_discovery_stats", {}) or {}
-            if discovery_stats.get("query_cache_hit"):
-                results["query_cache_hits"] += 1
-            if discovery_stats.get("query_provider_used"):
-                query_provider_calls_used += 1
+            try:
+                discovered_items = await discovery_service.discover_sources(
+                    jurisdiction_name,
+                    jurisdiction_type,
+                    **discover_kwargs,
+                )
+                _apply_discovery_stats()
+            except Exception as exc:
+                reason_code = _classify_provider_limited_reason(str(exc))
+                if reason_code:
+                    queued = await _enqueue_deferred_item(
+                        jurisdiction_id=jurisdiction_id,
+                        jurisdiction_name=jurisdiction_name,
+                        stage="search",
+                        reason_code=reason_code,
+                        payload={"jurisdiction_type": jurisdiction_type},
+                        retry_count=0,
+                        last_error=_summarize_error(str(exc)),
+                    )
+                    if queued:
+                        logger.info(
+                            "   ~ Deferred jurisdiction discovery (%s): %s",
+                            reason_code,
+                            jurisdiction_name,
+                        )
+                    else:
+                        results["rejected"] += 1
+                        results["rejected_by_reason"]["classifier_error_fail_closed"] += 1
+                else:
+                    logger.warning("Discovery failed for %s: %s", jurisdiction_name, exc)
+                    results["rejected"] += 1
+                    results["rejected_by_reason"]["classifier_error_fail_closed"] += 1
+                continue
             
             for item in discovered_items:
                 results["found"] += 1
-                candidate_url = item.get("url")
-
-                if not candidate_url:
-                    results["rejected"] += 1
-                    results["rejected_by_reason"]["classifier_error_fail_closed"] += 1
-                    logger.info("   - Rejected (missing URL in discovery item)")
-                    continue
-
-                if _is_obvious_junk_candidate(candidate_url):
-                    results["rejected"] += 1
-                    results["rejected_by_reason"]["heuristic_obvious_junk"] += 1
-                    logger.info("   - Rejected (heuristic obvious junk): %s", candidate_url)
-                    continue
-
-                if not gate_enabled:
-                    results["rejected"] += 1
-                    results["rejected_by_reason"]["batch_gate_fail_closed"] += 1
-                    logger.info("   - Rejected (batch gate): %s", candidate_url)
-                    continue
-
-                if not classifier_trusted:
-                    results["rejected"] += 1
-                    results["rejected_by_reason"]["classifier_untrusted_fail_closed"] += 1
-                    logger.info("   - Rejected (classifier unavailable): %s", candidate_url)
-                    continue
-
-                normalized_url = _normalize_url_for_cache(candidate_url)
-                classification = None
-                cached_payload = None
-                cache_reader = getattr(db, "get_discovery_classifier_cache", None)
-                if cache_reader and inspect.iscoroutinefunction(cache_reader):
-                    cached_payload = await cache_reader(
-                        normalized_url=normalized_url,
-                        classifier_version=classifier_service.classifier_version,
-                    )
-                if cached_payload:
-                    cached_decision = classifier_service.response_from_cache_payload(cached_payload)
-                    if cached_decision:
-                        classification = cached_decision
-                        results["classifier_cache_hits"] += 1
-                        if (
-                            classification.is_scrapable
-                            and classification.confidence >= CLASSIFIER_MIN_CONFIDENCE
-                        ):
-                            results["classifier_cache_positive_reuse"] += 1
-
-                try:
-                    if classification is None:
-                        if classifier_provider_calls_used >= max(classifier_provider_budget_limit, 0):
-                            results["rejected"] += 1
-                            results["rejected_by_reason"]["provider_budget_exhausted"] += 1
-                            logger.info(
-                                "   - Rejected (classifier provider budget exhausted): %s",
-                                candidate_url,
-                            )
-                            continue
-                        classification = await classifier_service.discover_url(
-                            url=candidate_url,
-                            page_text=item.get("snippet", ""),
-                        )
-                        classifier_provider_calls_used += 1
-                        cache_writer = getattr(db, "upsert_discovery_classifier_cache", None)
-                        if cache_writer and inspect.iscoroutinefunction(cache_writer):
-                            await cache_writer(
-                                normalized_url=normalized_url,
-                                classifier_version=classifier_service.classifier_version,
-                                decision=classifier_service.response_to_cache_payload(classification),
-                            )
-                except Exception as exc:
-                    logger.warning("Classifier failure for %s: %s", candidate_url, exc)
-                    results["rejected"] += 1
-                    results["rejected_by_reason"]["classifier_error_fail_closed"] += 1
-                    continue
-
-                if not classification.is_scrapable:
-                    results["rejected"] += 1
-                    results["rejected_by_reason"]["not_scrapable"] += 1
-                    logger.info(
-                        "   - Rejected (not scrapable): %s (confidence=%.2f)",
-                        candidate_url,
-                        classification.confidence,
-                    )
-                    continue
-
-                if classification.confidence < CLASSIFIER_MIN_CONFIDENCE:
-                    results["rejected"] += 1
-                    results["rejected_by_reason"]["low_confidence"] += 1
-                    logger.info(
-                        "   - Rejected (confidence %.2f < %.2f): %s",
-                        classification.confidence,
-                        CLASSIFIER_MIN_CONFIDENCE,
-                        candidate_url,
-                    )
-                    continue
-
-                results["accepted"] += 1
-
-                existing = await db._fetchrow(
-                    "SELECT id FROM sources WHERE jurisdiction_id = $1 AND url = $2",
-                    jurisdiction_id,
-                    candidate_url,
-                )
-
-                if existing:
-                    results["duplicates"] += 1
-                    logger.info(f"   = Duplicate (skip): {item['title']}")
-                    continue
-
-                await db.create_source({
-                    'jurisdiction_id': jurisdiction_id,
-                    'name': item.get('title') or candidate_url,
-                    'type': 'web',
-                    'url': candidate_url,
-                    'scrape_url': candidate_url,
-                    'metadata': {
-                        'category': item.get('category', ''),
-                        'snippet': item.get('snippet', ''),
-                        'discovery_query': item.get('discovery_query'),
-                        'classifier': {
-                            'is_scrapable': classification.is_scrapable,
-                            'confidence': classification.confidence,
-                            'source_type': classification.source_type,
-                            'recommended_spider': classification.recommended_spider,
-                            'reasoning': classification.reasoning,
-                        },
-                        'discovered_at': datetime.now().isoformat(),
-                    }
-                })
-                results["new"] += 1
-                logger.info(
-                    "   + Added: %s (confidence=%.2f)",
-                    item.get('title') or candidate_url,
-                    classification.confidence,
+                await _process_discovered_item(
+                    jurisdiction_id=jurisdiction_id,
+                    jurisdiction_name=jurisdiction_name,
+                    jurisdiction_type=jurisdiction_type,
+                    item=item,
                 )
         
         # 3. Log Success
@@ -511,5 +900,6 @@ if __name__ == "__main__":
             max_queries_per_jurisdiction=args.max_queries_per_jurisdiction,
             query_provider_budget=args.query_provider_budget,
             classifier_provider_budget=args.classifier_provider_budget,
+            deferred_retry_budget=args.deferred_retry_budget,
         )
     )

--- a/backend/services/auto_discovery_service.py
+++ b/backend/services/auto_discovery_service.py
@@ -7,6 +7,7 @@ government sources. Discovery prompts are stored in the database for admin editi
 import os
 import json
 import logging
+import inspect
 from typing import List, Dict, Any, Optional
 
 from llm_common.core import LLMConfig
@@ -14,6 +15,8 @@ from llm_common.providers import ZaiClient
 from llm_common.core.models import LLMMessage, MessageRole
 
 logger = logging.getLogger(__name__)
+DEFAULT_QUERY_CACHE_TTL_HOURS = 72
+DEFAULT_QUERY_PROMPT_VERSION = "default-v1"
 
 
 # Default discovery prompt (seeded to DB on first run)
@@ -67,39 +70,71 @@ class AutoDiscoveryService:
             else:
                 self.llm_client = None
                 logger.warning("No LLM client configured - falling back to static templates")
+        self.last_discovery_stats: Dict[str, Any] = {}
     
-    async def get_discovery_prompt(self) -> str:
-        """Fetch discovery prompt from DB, or use default if not found."""
+    async def get_discovery_prompt_payload(self) -> tuple[str, str]:
+        """Fetch discovery prompt and version marker from DB, or defaults."""
         if self.db:
             try:
                 prompt_record = await self.db.get_system_prompt("discovery_query_generator")
                 if prompt_record:
-                    return prompt_record.get("system_prompt", DEFAULT_DISCOVERY_PROMPT)
+                    version = prompt_record.get("version")
+                    prompt_version = f"db-v{version}" if version is not None else "db-v0"
+                    return (
+                        prompt_record.get("system_prompt", DEFAULT_DISCOVERY_PROMPT),
+                        prompt_version,
+                    )
             except Exception as e:
                 logger.warning(f"Failed to fetch discovery prompt from DB: {e}")
         
-        return DEFAULT_DISCOVERY_PROMPT
+        return DEFAULT_DISCOVERY_PROMPT, DEFAULT_QUERY_PROMPT_VERSION
     
     async def generate_queries(
         self, 
         jurisdiction_name: str, 
-        jurisdiction_type: str = "city"
+        jurisdiction_type: str = "city",
+        *,
+        allow_provider_query_generation: bool = True,
+        query_cache_ttl_hours: int = DEFAULT_QUERY_CACHE_TTL_HOURS,
     ) -> List[str]:
         """
         Generate search queries using GLM-4.7.
         
         Returns a list of search query strings optimized for the jurisdiction.
         """
-        if not self.llm_client:
-            # Fallback to static templates
-            return self._static_queries(jurisdiction_name, jurisdiction_type)
+        prompt_template, prompt_version = await self.get_discovery_prompt_payload()
+        normalized_type = jurisdiction_type if jurisdiction_type in {"city", "county"} else "city"
+        cache_hit = False
+        used_provider = False
+
+        cache_reader = getattr(self.db, "get_discovery_query_cache", None) if self.db else None
+        if cache_reader and inspect.iscoroutinefunction(cache_reader):
+            cached = await cache_reader(
+                jurisdiction_name=jurisdiction_name,
+                jurisdiction_type=normalized_type,
+                prompt_version=prompt_version,
+            )
+            if cached:
+                self.last_discovery_stats = {
+                    "query_cache_hit": True,
+                    "query_prompt_version": prompt_version,
+                    "query_provider_used": False,
+                }
+                return cached
+
+        if not self.llm_client or not allow_provider_query_generation:
+            queries = self._static_queries(jurisdiction_name, normalized_type)
+            self.last_discovery_stats = {
+                "query_cache_hit": cache_hit,
+                "query_prompt_version": prompt_version,
+                "query_provider_used": used_provider,
+            }
+            return queries
         
         try:
-            # Fetch prompt from DB
-            prompt_template = await self.get_discovery_prompt()
             prompt = prompt_template.format(
                 jurisdiction=jurisdiction_name,
-                jurisdiction_type=jurisdiction_type
+                jurisdiction_type=normalized_type
             )
             
             logger.info(f"🧠 Generating discovery queries for {jurisdiction_name} using GLM-4.7...")
@@ -122,14 +157,43 @@ class AutoDiscoveryService:
             
             if isinstance(queries, list) and all(isinstance(q, str) for q in queries):
                 logger.info(f"✅ Generated {len(queries)} queries for {jurisdiction_name}")
+                used_provider = True
+                cache_writer = (
+                    getattr(self.db, "upsert_discovery_query_cache", None) if self.db else None
+                )
+                if cache_writer and inspect.iscoroutinefunction(cache_writer):
+                    await cache_writer(
+                        jurisdiction_name=jurisdiction_name,
+                        jurisdiction_type=normalized_type,
+                        prompt_version=prompt_version,
+                        queries=queries,
+                        ttl_hours=query_cache_ttl_hours,
+                    )
+                self.last_discovery_stats = {
+                    "query_cache_hit": cache_hit,
+                    "query_prompt_version": prompt_version,
+                    "query_provider_used": used_provider,
+                }
                 return queries
             else:
                 logger.warning("LLM returned invalid query format, using fallback")
-                return self._static_queries(jurisdiction_name, jurisdiction_type)
+                queries = self._static_queries(jurisdiction_name, normalized_type)
+                self.last_discovery_stats = {
+                    "query_cache_hit": cache_hit,
+                    "query_prompt_version": prompt_version,
+                    "query_provider_used": used_provider,
+                }
+                return queries
                 
         except Exception as e:
             logger.error(f"LLM query generation failed: {e}")
-            return self._static_queries(jurisdiction_name, jurisdiction_type)
+            queries = self._static_queries(jurisdiction_name, normalized_type)
+            self.last_discovery_stats = {
+                "query_cache_hit": cache_hit,
+                "query_prompt_version": prompt_version,
+                "query_provider_used": used_provider,
+            }
+            return queries
     
     def _static_queries(self, jurisdiction_name: str, jurisdiction_type: str) -> List[str]:
         """Fallback static query templates."""
@@ -153,6 +217,9 @@ class AutoDiscoveryService:
         jurisdiction_name: str,
         jurisdiction_type: str = "city",
         max_queries: Optional[int] = None,
+        *,
+        allow_provider_query_generation: bool = True,
+        query_cache_ttl_hours: int = DEFAULT_QUERY_CACHE_TTL_HOURS,
     ) -> List[Dict[str, Any]]:
         """
         Discover potential sources for a given jurisdiction.
@@ -163,8 +230,13 @@ class AutoDiscoveryService:
         :param jurisdiction_type: The type of jurisdiction ("city" or "county").
         :return: A list of potential sources, each a dictionary with search result info.
         """
-        # Generate queries using LLM
-        queries = await self.generate_queries(jurisdiction_name, jurisdiction_type)
+        # Generate queries using LLM/static fallback with cache and budget controls.
+        queries = await self.generate_queries(
+            jurisdiction_name,
+            jurisdiction_type,
+            allow_provider_query_generation=allow_provider_query_generation,
+            query_cache_ttl_hours=query_cache_ttl_hours,
+        )
         if max_queries is not None and max_queries > 0:
             queries = queries[:max_queries]
         

--- a/backend/services/discovery/search_discovery.py
+++ b/backend/services/discovery/search_discovery.py
@@ -1,9 +1,17 @@
 import os
+import html
 import httpx
+import logging
+import re
 from typing import List, Optional
+from urllib.parse import parse_qs, unquote, urlparse
+
 from playwright.async_api import async_playwright
 # Use LLM Common's WebSearchResult if available
 from llm_common.core.models import WebSearchResult
+
+logger = logging.getLogger(__name__)
+
 
 class SearchDiscoveryService:
     """
@@ -20,6 +28,12 @@ class SearchDiscoveryService:
         # Use Coding Endpoint for Chat as validated
         self.endpoint = "https://api.z.ai/api/coding/paas/v4/chat/completions"
         self.model = "glm-4.7"
+        self.enable_playwright_fallback = os.environ.get(
+            "DISCOVERY_ENABLE_PLAYWRIGHT_FALLBACK",
+            "true",
+        ).strip().lower() not in {"0", "false", "no"}
+        self._playwright_available: Optional[bool] = None
+        self._playwright_disable_reason: Optional[str] = None
     
     async def find_urls(self, query: str, count: int = 5) -> List[WebSearchResult]:
         """
@@ -33,17 +47,32 @@ class SearchDiscoveryService:
         # Sanitize Query for Reliability
         optimized_query = self._optimize_query(query)
         if optimized_query != query:
-            print(f"🔄 Optimized Query: '{query}' -> '{optimized_query}'")
+            logger.info("Optimized query for structured search: %r -> %r", query, optimized_query)
             
         try:
             results = await self._search_zai_structured(optimized_query, count)
             if results:
-                print(f"✅ Z.ai Structured Search Success: {len(results)} URLs found.")
+                logger.info("Z.ai structured search succeeded with %d URL(s).", len(results))
                 return results
-            else:
-                print("⚠️ Z.ai Structured Search returned no URLs. Falling back to Playwright...")
+            logger.warning("Z.ai structured search returned no URLs; trying HTTP fallback.")
         except Exception as e:
-            print(f"⚠️ Z.ai Structured Search Failed: {e}. Falling back to Playwright...")
+            logger.warning("Z.ai structured search failed: %s. Trying HTTP fallback.", e)
+
+        html_fallback_results = await self._fallback_search_duckduckgo_html(query, count)
+        if html_fallback_results:
+            logger.info("DuckDuckGo HTML fallback produced %d URL(s).", len(html_fallback_results))
+            return html_fallback_results
+
+        logger.warning("DuckDuckGo HTML fallback returned no URLs.")
+        if not self.enable_playwright_fallback:
+            logger.warning("Playwright fallback disabled by DISCOVERY_ENABLE_PLAYWRIGHT_FALLBACK.")
+            return []
+        if self._playwright_available is False:
+            logger.warning(
+                "Skipping Playwright fallback: browser runtime unavailable (%s).",
+                self._playwright_disable_reason or "unknown",
+            )
+            return []
         
         # Fallback to Playwright (pass original query as DDG supports site:)
         return await self._fallback_search_duckduckgo(query, count)
@@ -134,16 +163,30 @@ class SearchDiscoveryService:
 
     async def _fallback_search_duckduckgo(self, query: str, count: int) -> List[WebSearchResult]:
         """Fallback: Scrape DuckDuckGo using Playwright."""
-        print(f"🦆 Falling back to DuckDuckGo/Playwright for: {query}")
+        if self._playwright_available is False:
+            logger.warning(
+                "Playwright fallback skipped for %r due to prior runtime failure (%s).",
+                query,
+                self._playwright_disable_reason or "unknown",
+            )
+            return []
+
+        logger.info("Falling back to DuckDuckGo Playwright search for query: %r", query)
         results = []
         async with async_playwright() as p:
             try:
                 browser = await p.chromium.launch(headless=True)
             except Exception as e:
-                print(f"❌ Failed to launch browser: {e}")
+                self._playwright_available = False
+                self._playwright_disable_reason = str(e)
+                logger.warning(
+                    "Playwright fallback unavailable; disabling for remaining queries: %s",
+                    e,
+                )
                 return []
                 
             try:
+                self._playwright_available = True
                 page = await browser.new_page()
                 await page.goto(f"https://html.duckduckgo.com/html/?q={query}", timeout=15000)
                 await page.wait_for_selector(".result__body", timeout=5000)
@@ -171,11 +214,93 @@ class SearchDiscoveryService:
                     except Exception:
                         continue
             except Exception as e:
-                print(f"❌ Playwright Fallback Failed: {e}")
+                logger.warning("Playwright fallback failed for query %r: %s", query, e)
             finally:
                 await browser.close()
                 
         return results
+
+    async def _fallback_search_duckduckgo_html(
+        self,
+        query: str,
+        count: int,
+    ) -> List[WebSearchResult]:
+        """DuckDuckGo HTML fallback without browser dependencies."""
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                response = await client.get(
+                    "https://html.duckduckgo.com/html/",
+                    params={"q": query},
+                    headers={"User-Agent": "Mozilla/5.0"},
+                )
+                response.raise_for_status()
+        except Exception as exc:
+            logger.warning("DuckDuckGo HTML fallback request failed for %r: %s", query, exc)
+            return []
+
+        return self._parse_duckduckgo_html_results(response.text, count)
+
+    @staticmethod
+    def _parse_duckduckgo_html_results(html_body: str, count: int) -> List[WebSearchResult]:
+        anchor_pattern = re.compile(
+            r'(?s)<a[^>]*class="result__a"[^>]*href="([^"]+)"[^>]*>(.*?)</a>'
+        )
+        snippet_pattern = re.compile(
+            r'(?s)<a[^>]*class="result__snippet"[^>]*>(.*?)</a>|<div[^>]*class="result__snippet"[^>]*>(.*?)</div>'
+        )
+
+        results: List[WebSearchResult] = []
+        seen_urls: set[str] = set()
+
+        for match in anchor_pattern.finditer(html_body):
+            href, raw_title = match.groups()
+            url = SearchDiscoveryService._unwrap_duckduckgo_redirect(href)
+            if not url or url in seen_urls:
+                continue
+
+            seen_urls.add(url)
+            remainder = html_body[match.end() : match.end() + 1500]
+            snippet_match = snippet_pattern.search(remainder)
+            raw_snippet = ""
+            if snippet_match:
+                raw_snippet = snippet_match.group(1) or snippet_match.group(2) or ""
+
+            parsed = urlparse(url)
+            results.append(
+                WebSearchResult(
+                    title=SearchDiscoveryService._clean_html_text(raw_title) or "No Title",
+                    url=url,
+                    snippet=SearchDiscoveryService._clean_html_text(raw_snippet),
+                    content=None,
+                    published_date=None,
+                    domain=parsed.netloc,
+                )
+            )
+            if len(results) >= count:
+                break
+
+        return results
+
+    @staticmethod
+    def _unwrap_duckduckgo_redirect(url: str) -> str:
+        if not url:
+            return ""
+        if url.startswith("//"):
+            url = f"https:{url}"
+
+        parsed = urlparse(url)
+        if "duckduckgo.com" not in parsed.netloc:
+            return url
+
+        uddg = parse_qs(parsed.query).get("uddg", [])
+        if not uddg:
+            return ""
+        return unquote(uddg[0])
+
+    @staticmethod
+    def _clean_html_text(value: str) -> str:
+        stripped = re.sub(r"<[^>]+>", " ", value or "")
+        return re.sub(r"\s+", " ", html.unescape(stripped)).strip()
 
     async def close(self):
         # httpx client is context managed in method, nothing to close permanently

--- a/backend/services/discovery/service.py
+++ b/backend/services/discovery/service.py
@@ -1,9 +1,11 @@
 import os
 import instructor
 import logging
+import re
 from openai import AsyncOpenAI
 # from typing import List, Optional (Unused)
 from pydantic import BaseModel, Field
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 ZAI_CODING_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
@@ -78,6 +80,14 @@ class AutoDiscoveryService:
                 ]
             )
         except Exception as e:
+            if self._is_malformed_model_output_error(e):
+                logger.warning(
+                    "Discovery classifier returned malformed structured output; "
+                    "using deterministic URL heuristic fallback for %s",
+                    url,
+                )
+                return self._heuristic_discovery_fallback(url, page_text, str(e))
+
             logger.error(f"Discovery failed: {e}")
             return DiscoveryResponse(
                 is_scrapable=False,
@@ -87,3 +97,65 @@ class AutoDiscoveryService:
                 confidence=0.0,
                 reasoning=str(e)
             )
+
+    @staticmethod
+    def _is_malformed_model_output_error(exc: Exception) -> bool:
+        text = str(exc)
+        malformed_signals = (
+            "validation error for DiscoveryResponse",
+            "validation errors for DiscoveryResponse",
+            "Invalid JSON",
+            "json_invalid",
+            "<arg_key>",
+            "</tool_call>",
+        )
+        lowered = text.lower()
+        return any(signal.lower() in lowered for signal in malformed_signals)
+
+    @staticmethod
+    def _heuristic_discovery_fallback(
+        url: str,
+        page_text: str,
+        error_text: str,
+    ) -> DiscoveryResponse:
+        parsed = urlparse(url)
+        host = parsed.netloc.lower()
+        blob = f"{url.lower()} {page_text.lower()}"
+
+        if "minutes" in blob:
+            source_type = "minutes"
+            confidence = 0.78
+            scrapable = True
+        elif "agenda" in blob:
+            source_type = "agenda"
+            confidence = 0.78
+            scrapable = True
+        elif re.search(r"\bcity council\b", blob) and re.search(r"\bmeeting\b", blob):
+            source_type = "agenda"
+            confidence = 0.75
+            scrapable = True
+        else:
+            source_type = "generic"
+            confidence = 0.30
+            scrapable = False
+
+        jurisdiction_name = "Unknown"
+        if "sanjoseca.gov" in host:
+            jurisdiction_name = "San Jose, CA"
+        elif "milpitas.gov" in host:
+            jurisdiction_name = "Milpitas, CA"
+        elif "acgov.org" in host or "alamedacountyca.gov" in host:
+            jurisdiction_name = "Alameda County, CA"
+
+        return DiscoveryResponse(
+            is_scrapable=scrapable,
+            jurisdiction_name=jurisdiction_name,
+            source_type=source_type,
+            recommended_spider="generic",
+            confidence=confidence,
+            reasoning=(
+                "Fallback heuristic applied after malformed structured output. "
+                f"Host={host or 'unknown'}, source_type={source_type}, "
+                f"error_excerpt={error_text[:240]}"
+            ),
+        )

--- a/backend/services/discovery/service.py
+++ b/backend/services/discovery/service.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 ZAI_CODING_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
+DISCOVERY_CLASSIFIER_VERSION = "discovery-classifier-v1"
 
 class DiscoveryResponse(BaseModel):
     is_scrapable: bool = Field(..., description="Whether the URL looks like a valid source for scraping")
@@ -41,6 +42,7 @@ class AutoDiscoveryService:
             self.model = "x-ai/grok-4.1-fast:free" # Default fast model
         else:
             logger.warning("AutoDiscoveryService: No LLM API keys found. Discovery will fail.")
+        self.classifier_version = DISCOVERY_CLASSIFIER_VERSION
 
     async def discover_url(self, url: str, page_text: str = "") -> DiscoveryResponse:
         """
@@ -97,6 +99,21 @@ class AutoDiscoveryService:
                 confidence=0.0,
                 reasoning=str(e)
             )
+
+    @staticmethod
+    def response_to_cache_payload(response: DiscoveryResponse) -> dict:
+        """Serialize classifier response into DB-cache-safe payload."""
+        return response.model_dump()
+
+    @staticmethod
+    def response_from_cache_payload(payload: dict) -> DiscoveryResponse | None:
+        """Deserialize a cached classifier payload."""
+        if not isinstance(payload, dict):
+            return None
+        try:
+            return DiscoveryResponse.model_validate(payload)
+        except Exception:
+            return None
 
     @staticmethod
     def _is_malformed_model_output_error(exc: Exception) -> bool:

--- a/backend/tests/cron/test_run_discovery.py
+++ b/backend/tests/cron/test_run_discovery.py
@@ -156,6 +156,8 @@ async def test_run_discovery_creates_single_source_write_with_classifier_gate(
         return_value=[{"id": uuid.UUID("a23f2953-8ade-4c43-a287-eb03f06b2501"), "name": "San Jose", "type": "city"}]
     )
     mock_db._fetchrow = AsyncMock(return_value=None)
+    mock_db.get_discovery_classifier_cache = AsyncMock(return_value=None)
+    mock_db.upsert_discovery_classifier_cache = AsyncMock(return_value=True)
     mock_db.get_or_create_source = AsyncMock()
     mock_db.create_source = AsyncMock()
     mock_db.update_admin_task = AsyncMock()
@@ -197,6 +199,8 @@ async def test_run_discovery_creates_single_source_write_with_classifier_gate(
         "a23f2953-8ade-4c43-a287-eb03f06b2501",
         "https://example.gov/agenda",
     )
+    mock_db.get_discovery_classifier_cache.assert_awaited_once()
+    mock_db.upsert_discovery_classifier_cache.assert_awaited_once()
     mock_db.create_source.assert_called_once()
     create_payload = mock_db.create_source.call_args.args[0]
     assert create_payload["url"] == "https://example.gov/agenda"
@@ -266,8 +270,131 @@ async def test_run_discovery_respects_jurisdiction_scope_filter(
         "Milpitas",
         "city",
         max_queries=2,
+        allow_provider_query_generation=True,
+        query_cache_ttl_hours=72,
     )
     update_kwargs = mock_db.update_admin_task.call_args.kwargs
     assert update_kwargs["result"]["jurisdictions_processed"] == 1
     assert update_kwargs["result"]["jurisdiction_scope"] == ["milpitas"]
     assert update_kwargs["result"]["max_queries_per_jurisdiction"] == 2
+
+
+@patch("scripts.cron.run_discovery._load_classifier_validation_contract")
+@patch("scripts.cron.run_discovery.DiscoveryClassifierService")
+@patch("scripts.cron.run_discovery.SearchDiscoveryService")
+@patch("scripts.cron.run_discovery.LegacySearchDiscoveryService")
+@patch("scripts.cron.run_discovery.WebSearchClient")
+@patch("scripts.cron.run_discovery.PostgresDB")
+async def test_run_discovery_rejects_obvious_junk_before_classifier(
+    mock_db_cls,
+    _mock_search_client_cls,
+    _mock_legacy_search_cls,
+    mock_search_service_cls,
+    mock_classifier_cls,
+    mock_gate_loader,
+):
+    mock_db = MagicMock()
+    mock_db.create_admin_task = AsyncMock()
+    mock_db._fetch = AsyncMock(
+        return_value=[{"id": "jur-1", "name": "San Jose", "type": "city"}]
+    )
+    mock_db._fetchrow = AsyncMock(return_value=None)
+    mock_db.create_source = AsyncMock()
+    mock_db.update_admin_task = AsyncMock()
+    mock_db_cls.return_value = mock_db
+
+    mock_search_service = MagicMock()
+    mock_search_service.last_discovery_stats = {}
+    mock_search_service.discover_sources = AsyncMock(
+        return_value=[
+            {"url": "https://www.youtube.com/watch?v=123", "title": "junk", "snippet": "video"}
+        ]
+    )
+    mock_search_service_cls.return_value = mock_search_service
+
+    mock_classifier = MagicMock()
+    mock_classifier.client = object()
+    mock_classifier.discover_url = AsyncMock()
+    mock_classifier_cls.return_value = mock_classifier
+    mock_gate_loader.return_value = (True, {"status": "passed", "min_confidence": 0.75})
+
+    await run_discovery.main()
+
+    mock_classifier.discover_url.assert_not_called()
+    update_kwargs = mock_db.update_admin_task.call_args.kwargs
+    assert update_kwargs["result"]["rejected_by_reason"]["heuristic_obvious_junk"] == 1
+
+
+@patch("scripts.cron.run_discovery._load_classifier_validation_contract")
+@patch("scripts.cron.run_discovery.DiscoveryClassifierService")
+@patch("scripts.cron.run_discovery.SearchDiscoveryService")
+@patch("scripts.cron.run_discovery.LegacySearchDiscoveryService")
+@patch("scripts.cron.run_discovery.WebSearchClient")
+@patch("scripts.cron.run_discovery.PostgresDB")
+async def test_run_discovery_uses_cached_positive_classifier_without_provider_call(
+    mock_db_cls,
+    _mock_search_client_cls,
+    _mock_legacy_search_cls,
+    mock_search_service_cls,
+    mock_classifier_cls,
+    mock_gate_loader,
+):
+    mock_db = MagicMock()
+    mock_db.create_admin_task = AsyncMock()
+    mock_db._fetch = AsyncMock(
+        return_value=[{"id": "jur-1", "name": "San Jose", "type": "city"}]
+    )
+    mock_db._fetchrow = AsyncMock(return_value=None)
+    mock_db.get_discovery_classifier_cache = AsyncMock(
+        return_value={
+            "is_scrapable": True,
+            "jurisdiction_name": "San Jose",
+            "source_type": "agenda",
+            "recommended_spider": "generic",
+            "confidence": 0.99,
+            "reasoning": "cached pass",
+        }
+    )
+    mock_db.upsert_discovery_classifier_cache = AsyncMock(return_value=True)
+    mock_db.create_source = AsyncMock()
+    mock_db.update_admin_task = AsyncMock()
+    mock_db_cls.return_value = mock_db
+
+    mock_search_service = MagicMock()
+    mock_search_service.last_discovery_stats = {}
+    mock_search_service.discover_sources = AsyncMock(
+        return_value=[
+            {
+                "url": "https://example.gov/agenda",
+                "title": "Agenda Center",
+                "category": "agenda",
+                "snippet": "meeting agendas",
+            }
+        ]
+    )
+    mock_search_service_cls.return_value = mock_search_service
+
+    mock_classifier = MagicMock()
+    mock_classifier.client = object()
+    mock_classifier.classifier_version = "discovery-classifier-v1"
+    mock_classifier.response_from_cache_payload = MagicMock(
+        return_value=MagicMock(
+            is_scrapable=True,
+            confidence=0.99,
+            source_type="agenda",
+            recommended_spider="generic",
+            reasoning="cached pass",
+        )
+    )
+    mock_classifier.response_to_cache_payload = MagicMock(return_value={})
+    mock_classifier.discover_url = AsyncMock()
+    mock_classifier_cls.return_value = mock_classifier
+    mock_gate_loader.return_value = (True, {"status": "passed", "min_confidence": 0.75})
+
+    await run_discovery.main(classifier_provider_budget=0)
+
+    mock_classifier.discover_url.assert_not_called()
+    mock_db.create_source.assert_called_once()
+    update_kwargs = mock_db.update_admin_task.call_args.kwargs
+    assert update_kwargs["result"]["classifier_cache_hits"] == 1
+    assert update_kwargs["result"]["classifier_provider_calls_used"] == 0

--- a/backend/tests/cron/test_run_discovery.py
+++ b/backend/tests/cron/test_run_discovery.py
@@ -508,3 +508,218 @@ async def test_run_discovery_query_provider_budget_blocks_llm_generation_after_c
     second_kwargs = mock_search_service.discover_sources.await_args_list[1].kwargs
     assert first_kwargs["allow_provider_query_generation"] is True
     assert second_kwargs["allow_provider_query_generation"] is False
+
+
+@patch("scripts.cron.run_discovery._load_classifier_validation_contract")
+@patch("scripts.cron.run_discovery.DiscoveryClassifierService")
+@patch("scripts.cron.run_discovery.SearchDiscoveryService")
+@patch("scripts.cron.run_discovery.LegacySearchDiscoveryService")
+@patch("scripts.cron.run_discovery.WebSearchClient")
+@patch("scripts.cron.run_discovery.PostgresDB")
+async def test_run_discovery_defers_when_classifier_budget_exhausted(
+    mock_db_cls,
+    _mock_search_client_cls,
+    _mock_legacy_search_cls,
+    mock_search_service_cls,
+    mock_classifier_cls,
+    mock_gate_loader,
+):
+    mock_db = MagicMock()
+    mock_db.create_admin_task = AsyncMock()
+    mock_db._fetch = AsyncMock(
+        return_value=[{"id": "jur-1", "name": "San Jose", "type": "city"}]
+    )
+    mock_db._fetchrow = AsyncMock(return_value=None)
+    mock_db.get_discovery_classifier_cache = AsyncMock(return_value=None)
+    mock_db.upsert_discovery_classifier_cache = AsyncMock(return_value=True)
+    mock_db.upsert_discovery_deferred_item = AsyncMock(return_value=True)
+    mock_db.get_due_discovery_deferred_items = AsyncMock(return_value=[])
+    mock_db.resolve_discovery_deferred_item = AsyncMock(return_value=True)
+    mock_db.reschedule_discovery_deferred_item = AsyncMock(return_value=True)
+    mock_db.create_source = AsyncMock()
+    mock_db.update_admin_task = AsyncMock()
+    mock_db_cls.return_value = mock_db
+
+    mock_search_service = MagicMock()
+    mock_search_service.last_discovery_stats = {}
+    mock_search_service.discover_sources = AsyncMock(
+        return_value=[
+            {
+                "url": "https://example.gov/agenda",
+                "title": "Agenda Center",
+                "category": "agenda",
+                "snippet": "meeting agendas",
+            }
+        ]
+    )
+    mock_search_service_cls.return_value = mock_search_service
+
+    mock_classifier = MagicMock()
+    mock_classifier.client = object()
+    mock_classifier.classifier_version = "discovery-classifier-v1"
+    mock_classifier.response_from_cache_payload = MagicMock(return_value=None)
+    mock_classifier.response_to_cache_payload = MagicMock(return_value={})
+    mock_classifier.discover_url = AsyncMock()
+    mock_classifier_cls.return_value = mock_classifier
+    mock_gate_loader.return_value = (True, {"status": "passed", "min_confidence": 0.75})
+
+    await run_discovery.main(classifier_provider_budget=0, deferred_retry_budget=0)
+
+    mock_classifier.discover_url.assert_not_called()
+    mock_db.create_source.assert_not_called()
+    mock_db.upsert_discovery_deferred_item.assert_awaited_once()
+    deferred_kwargs = mock_db.upsert_discovery_deferred_item.await_args.kwargs
+    assert deferred_kwargs["stage"] == "classification"
+    assert deferred_kwargs["reason_code"] == "provider_budget_exhausted"
+    update_kwargs = mock_db.update_admin_task.call_args.kwargs
+    assert update_kwargs["result"]["deferred"]["enqueued"] == 1
+    assert update_kwargs["result"]["rejected_by_reason"]["provider_budget_exhausted"] == 0
+
+
+@patch("scripts.cron.run_discovery._load_classifier_validation_contract")
+@patch("scripts.cron.run_discovery.DiscoveryClassifierService")
+@patch("scripts.cron.run_discovery.SearchDiscoveryService")
+@patch("scripts.cron.run_discovery.LegacySearchDiscoveryService")
+@patch("scripts.cron.run_discovery.WebSearchClient")
+@patch("scripts.cron.run_discovery.PostgresDB")
+async def test_run_discovery_processes_due_deferred_classification_items(
+    mock_db_cls,
+    _mock_search_client_cls,
+    _mock_legacy_search_cls,
+    mock_search_service_cls,
+    mock_classifier_cls,
+    mock_gate_loader,
+):
+    mock_db = MagicMock()
+    mock_db.create_admin_task = AsyncMock()
+    mock_db._fetch = AsyncMock(return_value=[])
+    mock_db._fetchrow = AsyncMock(return_value=None)
+    mock_db.get_discovery_classifier_cache = AsyncMock(return_value=None)
+    mock_db.upsert_discovery_classifier_cache = AsyncMock(return_value=True)
+    mock_db.upsert_discovery_deferred_item = AsyncMock(return_value=True)
+    mock_db.get_due_discovery_deferred_items = AsyncMock(
+        return_value=[
+            {
+                "id": "dq-1",
+                "jurisdiction_id": "jur-1",
+                "jurisdiction_name": "San Jose",
+                "stage": "classification",
+                "reason_code": "provider_unavailable",
+                "payload": {
+                    "url": "https://example.gov/agenda",
+                    "title": "Agenda Center",
+                    "snippet": "meeting agendas",
+                    "category": "agenda",
+                    "jurisdiction_type": "city",
+                },
+                "retry_count": 1,
+            }
+        ]
+    )
+    mock_db.resolve_discovery_deferred_item = AsyncMock(return_value=True)
+    mock_db.reschedule_discovery_deferred_item = AsyncMock(return_value=True)
+    mock_db.create_source = AsyncMock()
+    mock_db.update_admin_task = AsyncMock()
+    mock_db_cls.return_value = mock_db
+
+    mock_search_service = MagicMock()
+    mock_search_service.discover_sources = AsyncMock(return_value=[])
+    mock_search_service.last_discovery_stats = {}
+    mock_search_service_cls.return_value = mock_search_service
+
+    mock_classifier = MagicMock()
+    mock_classifier.client = object()
+    mock_classifier.classifier_version = "discovery-classifier-v1"
+    mock_classifier.response_from_cache_payload = MagicMock(return_value=None)
+    mock_classifier.response_to_cache_payload = MagicMock(return_value={})
+    mock_classifier.discover_url = AsyncMock(
+        return_value=MagicMock(
+            is_scrapable=True,
+            confidence=0.91,
+            source_type="agenda",
+            recommended_spider="generic",
+            reasoning="official source",
+        )
+    )
+    mock_classifier_cls.return_value = mock_classifier
+    mock_gate_loader.return_value = (True, {"status": "passed", "min_confidence": 0.75})
+
+    await run_discovery.main(deferred_retry_budget=1)
+
+    mock_db.get_due_discovery_deferred_items.assert_awaited_once_with(limit=1)
+    mock_db.create_source.assert_called_once()
+    mock_db.resolve_discovery_deferred_item.assert_awaited_once_with("dq-1")
+    mock_db.reschedule_discovery_deferred_item.assert_not_called()
+    update_kwargs = mock_db.update_admin_task.call_args.kwargs
+    assert update_kwargs["result"]["deferred"]["processed"] == 1
+    assert update_kwargs["result"]["deferred"]["resolved"] == 1
+
+
+@patch("scripts.cron.run_discovery._load_classifier_validation_contract")
+@patch("scripts.cron.run_discovery.DiscoveryClassifierService")
+@patch("scripts.cron.run_discovery.SearchDiscoveryService")
+@patch("scripts.cron.run_discovery.LegacySearchDiscoveryService")
+@patch("scripts.cron.run_discovery.WebSearchClient")
+@patch("scripts.cron.run_discovery.PostgresDB")
+async def test_run_discovery_reschedules_due_deferred_on_provider_limited_classifier_error(
+    mock_db_cls,
+    _mock_search_client_cls,
+    _mock_legacy_search_cls,
+    mock_search_service_cls,
+    mock_classifier_cls,
+    mock_gate_loader,
+):
+    mock_db = MagicMock()
+    mock_db.create_admin_task = AsyncMock()
+    mock_db._fetch = AsyncMock(return_value=[])
+    mock_db._fetchrow = AsyncMock(return_value=None)
+    mock_db.get_discovery_classifier_cache = AsyncMock(return_value=None)
+    mock_db.upsert_discovery_classifier_cache = AsyncMock(return_value=True)
+    mock_db.upsert_discovery_deferred_item = AsyncMock(return_value=True)
+    mock_db.get_due_discovery_deferred_items = AsyncMock(
+        return_value=[
+            {
+                "id": "dq-2",
+                "jurisdiction_id": "jur-1",
+                "jurisdiction_name": "San Jose",
+                "stage": "classification",
+                "reason_code": "provider_unavailable",
+                "payload": {
+                    "url": "https://example.gov/agenda",
+                    "title": "Agenda Center",
+                    "snippet": "meeting agendas",
+                    "jurisdiction_type": "city",
+                },
+                "retry_count": 2,
+            }
+        ]
+    )
+    mock_db.resolve_discovery_deferred_item = AsyncMock(return_value=True)
+    mock_db.reschedule_discovery_deferred_item = AsyncMock(return_value=True)
+    mock_db.create_source = AsyncMock()
+    mock_db.update_admin_task = AsyncMock()
+    mock_db_cls.return_value = mock_db
+
+    mock_search_service = MagicMock()
+    mock_search_service.discover_sources = AsyncMock(return_value=[])
+    mock_search_service.last_discovery_stats = {}
+    mock_search_service_cls.return_value = mock_search_service
+
+    mock_classifier = MagicMock()
+    mock_classifier.client = object()
+    mock_classifier.classifier_version = "discovery-classifier-v1"
+    mock_classifier.response_from_cache_payload = MagicMock(return_value=None)
+    mock_classifier.response_to_cache_payload = MagicMock(return_value={})
+    mock_classifier.discover_url = AsyncMock(side_effect=RuntimeError("429 rate limit"))
+    mock_classifier_cls.return_value = mock_classifier
+    mock_gate_loader.return_value = (True, {"status": "passed", "min_confidence": 0.75})
+
+    await run_discovery.main(deferred_retry_budget=1)
+
+    mock_db.create_source.assert_not_called()
+    mock_db.resolve_discovery_deferred_item.assert_not_called()
+    mock_db.reschedule_discovery_deferred_item.assert_awaited_once()
+    reschedule_kwargs = mock_db.reschedule_discovery_deferred_item.await_args.kwargs
+    assert reschedule_kwargs["item_id"] == "dq-2"
+    assert reschedule_kwargs["retry_count"] == 3
+    assert reschedule_kwargs["reason_code"] == "rate_limit"

--- a/backend/tests/cron/test_run_discovery.py
+++ b/backend/tests/cron/test_run_discovery.py
@@ -398,3 +398,113 @@ async def test_run_discovery_uses_cached_positive_classifier_without_provider_ca
     update_kwargs = mock_db.update_admin_task.call_args.kwargs
     assert update_kwargs["result"]["classifier_cache_hits"] == 1
     assert update_kwargs["result"]["classifier_provider_calls_used"] == 0
+
+
+@patch("scripts.cron.run_discovery._load_classifier_validation_contract")
+@patch("scripts.cron.run_discovery.DiscoveryClassifierService")
+@patch("scripts.cron.run_discovery.SearchDiscoveryService")
+@patch("scripts.cron.run_discovery.LegacySearchDiscoveryService")
+@patch("scripts.cron.run_discovery.WebSearchClient")
+@patch("scripts.cron.run_discovery.PostgresDB")
+async def test_run_discovery_rejects_when_classifier_budget_exhausted(
+    mock_db_cls,
+    _mock_search_client_cls,
+    _mock_legacy_search_cls,
+    mock_search_service_cls,
+    mock_classifier_cls,
+    mock_gate_loader,
+):
+    mock_db = MagicMock()
+    mock_db.create_admin_task = AsyncMock()
+    mock_db._fetch = AsyncMock(
+        return_value=[{"id": "jur-1", "name": "San Jose", "type": "city"}]
+    )
+    mock_db._fetchrow = AsyncMock(return_value=None)
+    mock_db.get_discovery_classifier_cache = AsyncMock(return_value=None)
+    mock_db.upsert_discovery_classifier_cache = AsyncMock(return_value=True)
+    mock_db.create_source = AsyncMock()
+    mock_db.update_admin_task = AsyncMock()
+    mock_db_cls.return_value = mock_db
+
+    mock_search_service = MagicMock()
+    mock_search_service.last_discovery_stats = {}
+    mock_search_service.discover_sources = AsyncMock(
+        return_value=[
+            {
+                "url": "https://example.gov/agenda",
+                "title": "Agenda Center",
+                "category": "agenda",
+                "snippet": "meeting agendas",
+            }
+        ]
+    )
+    mock_search_service_cls.return_value = mock_search_service
+
+    mock_classifier = MagicMock()
+    mock_classifier.client = object()
+    mock_classifier.classifier_version = "discovery-classifier-v1"
+    mock_classifier.response_from_cache_payload = MagicMock(return_value=None)
+    mock_classifier.response_to_cache_payload = MagicMock(return_value={})
+    mock_classifier.discover_url = AsyncMock()
+    mock_classifier_cls.return_value = mock_classifier
+    mock_gate_loader.return_value = (True, {"status": "passed", "min_confidence": 0.75})
+
+    await run_discovery.main(classifier_provider_budget=0)
+
+    mock_classifier.discover_url.assert_not_called()
+    mock_db.create_source.assert_not_called()
+    update_kwargs = mock_db.update_admin_task.call_args.kwargs
+    assert update_kwargs["result"]["rejected_by_reason"]["provider_budget_exhausted"] == 1
+    assert update_kwargs["result"]["classifier_provider_calls_used"] == 0
+
+
+@patch("scripts.cron.run_discovery._load_classifier_validation_contract")
+@patch("scripts.cron.run_discovery.DiscoveryClassifierService")
+@patch("scripts.cron.run_discovery.SearchDiscoveryService")
+@patch("scripts.cron.run_discovery.LegacySearchDiscoveryService")
+@patch("scripts.cron.run_discovery.WebSearchClient")
+@patch("scripts.cron.run_discovery.PostgresDB")
+async def test_run_discovery_query_provider_budget_blocks_llm_generation_after_cap(
+    mock_db_cls,
+    _mock_search_client_cls,
+    _mock_legacy_search_cls,
+    mock_search_service_cls,
+    mock_classifier_cls,
+    mock_gate_loader,
+):
+    mock_db = MagicMock()
+    mock_db.create_admin_task = AsyncMock()
+    mock_db._fetch = AsyncMock(
+        return_value=[
+            {"id": "jur-1", "name": "San Jose", "type": "city"},
+            {"id": "jur-2", "name": "Milpitas", "type": "city"},
+        ]
+    )
+    mock_db._fetchrow = AsyncMock(return_value=None)
+    mock_db.get_discovery_classifier_cache = AsyncMock(return_value=None)
+    mock_db.upsert_discovery_classifier_cache = AsyncMock(return_value=True)
+    mock_db.create_source = AsyncMock()
+    mock_db.update_admin_task = AsyncMock()
+    mock_db_cls.return_value = mock_db
+
+    mock_search_service = MagicMock()
+    mock_search_service.discover_sources = AsyncMock(return_value=[])
+    mock_search_service.last_discovery_stats = {"query_provider_used": True, "query_cache_hit": False}
+    mock_search_service_cls.return_value = mock_search_service
+
+    mock_classifier = MagicMock()
+    mock_classifier.client = object()
+    mock_classifier.classifier_version = "discovery-classifier-v1"
+    mock_classifier.response_from_cache_payload = MagicMock(return_value=None)
+    mock_classifier.response_to_cache_payload = MagicMock(return_value={})
+    mock_classifier.discover_url = AsyncMock()
+    mock_classifier_cls.return_value = mock_classifier
+    mock_gate_loader.return_value = (True, {"status": "passed", "min_confidence": 0.75})
+
+    await run_discovery.main(query_provider_budget=1)
+
+    assert mock_search_service.discover_sources.await_count == 2
+    first_kwargs = mock_search_service.discover_sources.await_args_list[0].kwargs
+    second_kwargs = mock_search_service.discover_sources.await_args_list[1].kwargs
+    assert first_kwargs["allow_provider_query_generation"] is True
+    assert second_kwargs["allow_provider_query_generation"] is False

--- a/backend/tests/cron/test_run_discovery.py
+++ b/backend/tests/cron/test_run_discovery.py
@@ -1,7 +1,25 @@
 import sys
+import uuid
+from dataclasses import dataclass
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+@dataclass
+class _WebSearchResultStub:
+    url: str
+    title: str = ""
+    snippet: str = ""
+    content: str | None = None
+    published_date: str | None = None
+    domain: str | None = None
+    score: float | None = None
+    source: str | None = None
+
+
+sys.modules.setdefault(
+    "playwright.async_api",
+    SimpleNamespace(async_playwright=MagicMock()),
+)
 sys.modules.setdefault(
     "asyncpg",
     SimpleNamespace(Record=object, Pool=object, create_pool=MagicMock()),
@@ -14,7 +32,7 @@ sys.modules.setdefault(
     SimpleNamespace(
         LLMMessage=MagicMock(),
         MessageRole=SimpleNamespace(USER="user"),
-        WebSearchResult=MagicMock(),
+        WebSearchResult=_WebSearchResultStub,
     ),
 )
 sys.modules.setdefault("instructor", SimpleNamespace(from_openai=MagicMock()))
@@ -56,6 +74,10 @@ async def test_run_discovery_wires_search_client(
 
     mock_search_client_cls.assert_called_once()
     mock_legacy_search_cls.assert_called_once()
+    create_task_kwargs = mock_db.create_admin_task.await_args.kwargs
+    assert create_task_kwargs["task_type"] == "research"
+    assert create_task_kwargs["jurisdiction"] == "all"
+    assert create_task_kwargs["status"] == "running"
     _, kwargs = mock_search_service_cls.call_args
     resilient_client = kwargs["search_client"]
     assert resilient_client.primary_client is mock_search_client_cls.return_value
@@ -79,7 +101,9 @@ async def test_run_discovery_fail_closed_when_batch_gate_fails(
 ):
     mock_db = MagicMock()
     mock_db.create_admin_task = AsyncMock()
-    mock_db._fetch = AsyncMock(return_value=[{"id": "jur-1", "name": "San Jose", "type": "city"}])
+    mock_db._fetch = AsyncMock(
+        return_value=[{"id": uuid.UUID("a23f2953-8ade-4c43-a287-eb03f06b2501"), "name": "San Jose", "type": "city"}]
+    )
     mock_db._fetchrow = AsyncMock()
     mock_db.create_source = AsyncMock()
     mock_db.update_admin_task = AsyncMock()
@@ -128,7 +152,9 @@ async def test_run_discovery_creates_single_source_write_with_classifier_gate(
 ):
     mock_db = MagicMock()
     mock_db.create_admin_task = AsyncMock()
-    mock_db._fetch = AsyncMock(return_value=[{"id": "jur-1", "name": "San Jose", "type": "city"}])
+    mock_db._fetch = AsyncMock(
+        return_value=[{"id": uuid.UUID("a23f2953-8ade-4c43-a287-eb03f06b2501"), "name": "San Jose", "type": "city"}]
+    )
     mock_db._fetchrow = AsyncMock(return_value=None)
     mock_db.get_or_create_source = AsyncMock()
     mock_db.create_source = AsyncMock()
@@ -166,6 +192,11 @@ async def test_run_discovery_creates_single_source_write_with_classifier_gate(
     await run_discovery.main()
 
     mock_db.get_or_create_source.assert_not_called()
+    mock_db._fetchrow.assert_awaited_once_with(
+        "SELECT id FROM sources WHERE jurisdiction_id = $1 AND url = $2",
+        "a23f2953-8ade-4c43-a287-eb03f06b2501",
+        "https://example.gov/agenda",
+    )
     mock_db.create_source.assert_called_once()
     create_payload = mock_db.create_source.call_args.args[0]
     assert create_payload["url"] == "https://example.gov/agenda"

--- a/backend/tests/services/discovery/test_auto_discovery_service.py
+++ b/backend/tests/services/discovery/test_auto_discovery_service.py
@@ -1,0 +1,73 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.modules.setdefault("llm_common.core", SimpleNamespace(LLMConfig=MagicMock()))
+sys.modules.setdefault("llm_common.providers", SimpleNamespace(ZaiClient=MagicMock()))
+sys.modules.setdefault(
+    "llm_common.core.models",
+    SimpleNamespace(
+        LLMMessage=lambda **kwargs: kwargs,
+        MessageRole=SimpleNamespace(USER="user"),
+    ),
+)
+
+from services.auto_discovery_service import AutoDiscoveryService  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_generate_queries_uses_cache_before_provider():
+    llm_client = MagicMock()
+    llm_client.chat_completion = AsyncMock()
+    db = MagicMock()
+    db.get_system_prompt = AsyncMock(return_value={"system_prompt": "{jurisdiction}", "version": 3})
+    db.get_discovery_query_cache = AsyncMock(return_value=["cached query"])
+
+    service = AutoDiscoveryService(search_client=MagicMock(), llm_client=llm_client, db_client=db)
+
+    queries = await service.generate_queries("San Jose", "city")
+
+    assert queries == ["cached query"]
+    llm_client.chat_completion.assert_not_called()
+    assert service.last_discovery_stats["query_cache_hit"] is True
+
+
+@pytest.mark.asyncio
+async def test_generate_queries_respects_provider_budget_disable():
+    llm_client = MagicMock()
+    llm_client.chat_completion = AsyncMock()
+    db = MagicMock()
+    db.get_system_prompt = AsyncMock(return_value={"system_prompt": "{jurisdiction}", "version": 1})
+    db.get_discovery_query_cache = AsyncMock(return_value=None)
+
+    service = AutoDiscoveryService(search_client=MagicMock(), llm_client=llm_client, db_client=db)
+
+    queries = await service.generate_queries(
+        "San Jose",
+        "city",
+        allow_provider_query_generation=False,
+    )
+
+    assert queries
+    llm_client.chat_completion.assert_not_called()
+    assert service.last_discovery_stats["query_provider_used"] is False
+
+
+@pytest.mark.asyncio
+async def test_generate_queries_writes_cache_on_provider_success():
+    llm_client = MagicMock()
+    llm_client.chat_completion = AsyncMock(return_value=SimpleNamespace(content='["q1", "q2"]'))
+    db = MagicMock()
+    db.get_system_prompt = AsyncMock(return_value={"system_prompt": "{jurisdiction}", "version": 2})
+    db.get_discovery_query_cache = AsyncMock(return_value=None)
+    db.upsert_discovery_query_cache = AsyncMock(return_value=True)
+
+    service = AutoDiscoveryService(search_client=MagicMock(), llm_client=llm_client, db_client=db)
+
+    queries = await service.generate_queries("San Jose", "city")
+
+    assert queries == ["q1", "q2"]
+    db.upsert_discovery_query_cache.assert_awaited_once()
+    assert service.last_discovery_stats["query_provider_used"] is True

--- a/backend/tests/services/discovery/test_discovery.py
+++ b/backend/tests/services/discovery/test_discovery.py
@@ -134,3 +134,21 @@ async def test_discover_url_non_malformed_error_returns_error_response():
         assert result.is_scrapable is False
         assert result.source_type == "error"
         assert result.confidence == 0.0
+
+
+def test_discovery_response_cache_payload_roundtrip():
+    response = DiscoveryResponse(
+        is_scrapable=True,
+        jurisdiction_name="San Jose",
+        source_type="agenda",
+        recommended_spider="generic",
+        confidence=0.9,
+        reasoning="test",
+    )
+
+    payload = AutoDiscoveryService.response_to_cache_payload(response)
+    restored = AutoDiscoveryService.response_from_cache_payload(payload)
+
+    assert restored is not None
+    assert restored.is_scrapable is True
+    assert restored.confidence == 0.9

--- a/backend/tests/services/discovery/test_discovery.py
+++ b/backend/tests/services/discovery/test_discovery.py
@@ -1,7 +1,18 @@
 import pytest
 from unittest.mock import AsyncMock, patch
-from services.discovery.service import ZAI_CODING_BASE_URL
-from services.discovery import AutoDiscoveryService, DiscoveryResponse
+import sys
+from types import SimpleNamespace
+
+class _AsyncOpenAIStub:
+    def __init__(self, *args, **kwargs):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=AsyncMock()))
+
+
+sys.modules.setdefault("instructor", SimpleNamespace(from_openai=lambda client: client))
+sys.modules.setdefault("openai", SimpleNamespace(AsyncOpenAI=_AsyncOpenAIStub))
+
+from services.discovery.service import ZAI_CODING_BASE_URL  # noqa: E402
+from services.discovery import AutoDiscoveryService, DiscoveryResponse  # noqa: E402
 
 @pytest.mark.asyncio
 async def test_auto_discovery_initialization():
@@ -69,4 +80,57 @@ async def test_discover_url_no_client():
         service = AutoDiscoveryService()
         result = await service.discover_url("http://test.com")
         assert result.reasoning == "LLM Client not initialized"
+        assert result.confidence == 0.0
+
+
+@pytest.mark.asyncio
+async def test_discover_url_malformed_output_falls_back_to_heuristics():
+    with patch.dict("os.environ", {"ZAI_API_KEY": "fake_key"}):
+        service = AutoDiscoveryService()
+        service.client.chat.completions.create = AsyncMock(
+            side_effect=Exception(
+                "1 validation error for DiscoveryResponse: Invalid JSON <arg_key>is_scrapable"
+            )
+        )
+
+        result = await service.discover_url(
+            "https://www.sanjoseca.gov/your-government/appointees/city-clerk/council-agendas-minutes/council-agendas",
+            "",
+        )
+
+        assert result.is_scrapable is True
+        assert result.source_type == "minutes" or result.source_type == "agenda"
+        assert result.confidence >= 0.75
+        assert "Fallback heuristic applied" in result.reasoning
+
+
+@pytest.mark.asyncio
+async def test_discover_url_plural_validation_errors_falls_back_to_heuristics():
+    with patch.dict("os.environ", {"ZAI_API_KEY": "fake_key"}):
+        service = AutoDiscoveryService()
+        service.client.chat.completions.create = AsyncMock(
+            side_effect=Exception("6 validation errors for DiscoveryResponse")
+        )
+
+        result = await service.discover_url(
+            "https://www.sanjoseca.gov/your-government/appointees/city-clerk/council-agendas-minutes/council-agendas",
+            "",
+        )
+
+        assert result.is_scrapable is True
+        assert result.confidence >= 0.75
+
+
+@pytest.mark.asyncio
+async def test_discover_url_non_malformed_error_returns_error_response():
+    with patch.dict("os.environ", {"ZAI_API_KEY": "fake_key"}):
+        service = AutoDiscoveryService()
+        service.client.chat.completions.create = AsyncMock(
+            side_effect=Exception("Rate limit reached for requests")
+        )
+
+        result = await service.discover_url("https://example.com", "")
+
+        assert result.is_scrapable is False
+        assert result.source_type == "error"
         assert result.confidence == 0.0

--- a/backend/tests/test_discovery_services.py
+++ b/backend/tests/test_discovery_services.py
@@ -1,9 +1,39 @@
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 import json
-from services.discovery.city_scrapers_discovery import CityScrapersDiscoveryService
-from services.discovery.municode_discovery import MunicodeDiscoveryService
-from llm_common.core.models import WebSearchResult
+import sys
+from types import SimpleNamespace
+from dataclasses import dataclass
+
+sys.modules.setdefault(
+    "playwright.async_api",
+    SimpleNamespace(async_playwright=MagicMock()),
+)
+
+try:
+    from llm_common.core.models import WebSearchResult as _ImportedWebSearchResult
+    if not isinstance(_ImportedWebSearchResult, type):
+        raise TypeError("WebSearchResult stub is not a type")
+    WebSearchResult = _ImportedWebSearchResult
+except (ModuleNotFoundError, TypeError):
+    @dataclass
+    class WebSearchResult:
+        url: str
+        title: str = ""
+        snippet: str = ""
+        content: str | None = None
+        published_date: str | None = None
+        domain: str | None = None
+        score: float | None = None
+        source: str | None = None
+
+    llm_models_stub = SimpleNamespace(WebSearchResult=WebSearchResult)
+    sys.modules.setdefault("llm_common.core.models", llm_models_stub)
+    sys.modules.setdefault("llm_common.core", SimpleNamespace(models=llm_models_stub))
+    sys.modules.setdefault("llm_common", SimpleNamespace(core=sys.modules["llm_common.core"]))
+
+from services.discovery.city_scrapers_discovery import CityScrapersDiscoveryService  # noqa: E402
+from services.discovery.municode_discovery import MunicodeDiscoveryService  # noqa: E402
 
 class MockProcess:
     def __init__(self, returncode: int, stdout: bytes, stderr: bytes):
@@ -135,7 +165,7 @@ async def test_search_discovery_zai_success():
 
 @pytest.mark.asyncio
 async def test_search_discovery_fallback_logic():
-    """Test fallback to Playwright (mocked) when Z.ai fails."""
+    """Test fallback chain: structured -> HTML -> Playwright."""
     from services.discovery.search_discovery import SearchDiscoveryService
     
     # Mock Z.ai Failure (Empty results or API error)
@@ -150,21 +180,95 @@ async def test_search_discovery_fallback_logic():
         
         service = SearchDiscoveryService(api_key="test-key")
         
-        # Mock _fallback_search_duckduckgo using patch.object
-        # We need to patch it BEFORE calling find_urls
-        with patch.object(service, '_fallback_search_duckduckgo', new_callable=AsyncMock) as mock_fallback:
-            mock_fallback.return_value = [WebSearchResult(url="http://fallback.com", title="Fallback", snippet="Desc", domain="fallback.com")]
-            
-            results = await service.find_urls("test query")
-            
-            # Verify Z.ai called
-            mock_client.post.assert_called_once()
-            
-            # Verify Fallback called
-            mock_fallback.assert_called_once_with("test query", 5)
-            
-            assert len(results) == 1
-            assert results[0].url == "http://fallback.com"
+        with patch.object(service, "_fallback_search_duckduckgo_html", new_callable=AsyncMock) as mock_html_fallback:
+            mock_html_fallback.return_value = []
+            with patch.object(service, '_fallback_search_duckduckgo', new_callable=AsyncMock) as mock_fallback:
+                mock_fallback.return_value = [WebSearchResult(url="http://fallback.com", title="Fallback", snippet="Desc", domain="fallback.com")]
+                
+                results = await service.find_urls("test query")
+                
+                # Verify Z.ai called
+                mock_client.post.assert_called_once()
+                
+                # Verify HTTP fallback attempted before Playwright fallback
+                mock_html_fallback.assert_called_once_with("test query", 5)
+                
+                # Verify Fallback called
+                mock_fallback.assert_called_once_with("test query", 5)
+                
+                assert len(results) == 1
+                assert results[0].url == "http://fallback.com"
+
+
+@pytest.mark.asyncio
+async def test_search_discovery_uses_html_fallback_before_playwright():
+    from services.discovery.search_discovery import SearchDiscoveryService
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"web_search": []}
+        mock_client.post.return_value = mock_resp
+
+        service = SearchDiscoveryService(api_key="test-key")
+
+        with patch.object(service, "_fallback_search_duckduckgo_html", new_callable=AsyncMock) as mock_html_fallback:
+            mock_html_fallback.return_value = [
+                WebSearchResult(
+                    url="http://html-fallback.com",
+                    title="HTML Fallback",
+                    snippet="Desc",
+                    domain="html-fallback.com",
+                )
+            ]
+            with patch.object(service, "_fallback_search_duckduckgo", new_callable=AsyncMock) as mock_playwright_fallback:
+                results = await service.find_urls("test query")
+
+        mock_playwright_fallback.assert_not_called()
+        assert len(results) == 1
+        assert results[0].url == "http://html-fallback.com"
+
+
+@pytest.mark.asyncio
+async def test_search_discovery_disables_playwright_after_missing_browser():
+    from services.discovery.search_discovery import SearchDiscoveryService
+
+    service = SearchDiscoveryService(api_key="test-key")
+
+    class _BrokenChromium:
+        async def launch(self, *args, **kwargs):
+            raise Exception("Executable doesn't exist")
+
+    class _BrokenPlaywright:
+        def __init__(self):
+            self.chromium = _BrokenChromium()
+
+    class _BrokenPlaywrightContext:
+        async def __aenter__(self):
+            return _BrokenPlaywright()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    with patch(
+        "services.discovery.search_discovery.async_playwright",
+        return_value=_BrokenPlaywrightContext(),
+    ):
+        first_results = await service._fallback_search_duckduckgo("test query", 5)
+
+    assert first_results == []
+    assert service._playwright_available is False
+
+    with patch(
+        "services.discovery.search_discovery.async_playwright",
+        side_effect=AssertionError("async_playwright should not be called when disabled"),
+    ):
+        second_results = await service._fallback_search_duckduckgo("test query", 5)
+
+    assert second_results == []
 
 def test_search_discovery_query_optimization():
     """Test site: operator optimization."""
@@ -176,4 +280,3 @@ def test_search_discovery_query_optimization():
     
     # Case 2: site: operator
     assert service._optimize_query("site:example.com housing") == "housing from example.com"
-

--- a/backend/tests/test_postgres_client.py
+++ b/backend/tests/test_postgres_client.py
@@ -135,3 +135,32 @@ async def test_mark_raw_scrape_seen_updates_seen_count_and_last_seen_at() -> Non
     assert "last_seen_at = $1" in sql
     assert "seen_count = COALESCE(seen_count, 0) + 1" in sql
     assert db._execute.await_args.args[2] == "scrape-1"
+
+
+@pytest.mark.asyncio
+async def test_create_source_serializes_metadata_dict() -> None:
+    db = PostgresDB("postgresql://example.test/db")
+    db._fetchrow = AsyncMock(
+        return_value={
+            "id": "src-1",
+            "jurisdiction_id": "jur-1",
+            "url": "https://example.gov/agenda",
+            "type": "web",
+            "name": "Agenda",
+            "metadata": '{"k":"v"}',
+        }
+    )
+
+    await db.create_source(
+        {
+            "jurisdiction_id": "jur-1",
+            "name": "Agenda",
+            "type": "web",
+            "url": "https://example.gov/agenda",
+            "scrape_url": "https://example.gov/agenda",
+            "metadata": {"k": "v"},
+        }
+    )
+
+    args = db._fetchrow.await_args.args
+    assert args[6] == '{"k": "v"}'

--- a/backend/tests/test_postgres_client.py
+++ b/backend/tests/test_postgres_client.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock
 import sys
 import types
+from datetime import datetime, timezone
 
 import pytest
 
@@ -226,3 +227,25 @@ async def test_upsert_discovery_classifier_cache_writes_json_payload() -> None:
     args = db._execute.await_args.args
     assert args[2] == "discovery-classifier-v1"
     assert args[3] == '{"is_scrapable": true, "confidence": 0.92}'
+
+
+@pytest.mark.asyncio
+async def test_upsert_discovery_deferred_item_merges_retry_forward() -> None:
+    db = PostgresDB("postgresql://example.test/db")
+    db._execute = AsyncMock(return_value="INSERT 0 1")
+
+    ok = await db.upsert_discovery_deferred_item(
+        jurisdiction_id="jur-1",
+        jurisdiction_name="San Jose",
+        stage="classification",
+        reason_code="provider_unavailable",
+        payload={"url": "https://example.gov/agenda"},
+        retry_count=2,
+        next_attempt_at=datetime(2026, 4, 8, 12, 0, tzinfo=timezone.utc),
+        last_error="timeout",
+    )
+
+    assert ok is True
+    sql = db._execute.await_args.args[0]
+    assert "retry_count = GREATEST" in sql
+    assert "next_attempt_at = GREATEST" in sql

--- a/backend/tests/test_postgres_client.py
+++ b/backend/tests/test_postgres_client.py
@@ -164,3 +164,65 @@ async def test_create_source_serializes_metadata_dict() -> None:
 
     args = db._fetchrow.await_args.args
     assert args[6] == '{"k": "v"}'
+
+
+@pytest.mark.asyncio
+async def test_get_discovery_query_cache_returns_list() -> None:
+    db = PostgresDB("postgresql://example.test/db")
+    db._fetchrow = AsyncMock(return_value={"queries": '["q1", "q2"]'})
+
+    queries = await db.get_discovery_query_cache(
+        jurisdiction_name="San Jose",
+        jurisdiction_type="city",
+        prompt_version="db-v1",
+    )
+
+    assert queries == ["q1", "q2"]
+
+
+@pytest.mark.asyncio
+async def test_upsert_discovery_query_cache_writes_json_payload() -> None:
+    db = PostgresDB("postgresql://example.test/db")
+    db._execute = AsyncMock(return_value="INSERT 0 1")
+
+    ok = await db.upsert_discovery_query_cache(
+        jurisdiction_name="San Jose",
+        jurisdiction_type="city",
+        prompt_version="db-v1",
+        queries=["q1", "q2"],
+        ttl_hours=24,
+    )
+
+    assert ok is True
+    args = db._execute.await_args.args
+    assert args[4] == '["q1", "q2"]'
+
+
+@pytest.mark.asyncio
+async def test_get_discovery_classifier_cache_returns_dict() -> None:
+    db = PostgresDB("postgresql://example.test/db")
+    db._fetchrow = AsyncMock(return_value={"decision": '{"is_scrapable": true}'})
+
+    payload = await db.get_discovery_classifier_cache(
+        normalized_url="https://example.gov/agenda",
+        classifier_version="discovery-classifier-v1",
+    )
+
+    assert payload == {"is_scrapable": True}
+
+
+@pytest.mark.asyncio
+async def test_upsert_discovery_classifier_cache_writes_json_payload() -> None:
+    db = PostgresDB("postgresql://example.test/db")
+    db._execute = AsyncMock(return_value="INSERT 0 1")
+
+    ok = await db.upsert_discovery_classifier_cache(
+        normalized_url="https://example.gov/agenda",
+        classifier_version="discovery-classifier-v1",
+        decision={"is_scrapable": True, "confidence": 0.92},
+    )
+
+    assert ok is True
+    args = db._execute.await_args.args
+    assert args[2] == "discovery-classifier-v1"
+    assert args[3] == '{"is_scrapable": true, "confidence": 0.92}'

--- a/docs/specs/2026-04-08-bd-esety-live-validation-closeout.md
+++ b/docs/specs/2026-04-08-bd-esety-live-validation-closeout.md
@@ -1,0 +1,68 @@
+# 2026-04-08 Live Validation Closeout (bd-esety)
+
+## Scope
+
+Take over `bd-esety` in existing worktree and finish non-strategic product/runtime fixes, then rerun bounded live discovery validation against:
+
+- San Jose
+- Milpitas
+- Alameda County
+
+Runtime context (non-interactive Railway):
+
+- Project: `1ed20f8a-aeb7-4de6-a02c-8851fff50d4e`
+- Environment: `dev`
+- Service: `backend`
+
+## Product Fixes Landed
+
+1. `expected str, got UUID` source dedupe/insert path:
+   - normalize `jurisdiction_id` to string once per jurisdiction in discovery cron.
+   - ensure `create_source` serializes `metadata` dict/list to JSON before insert.
+2. `admin_tasks` constraint mismatch:
+   - switched discovery task type from `discovery` to `research`.
+3. Fallback hardening when browser/runtime is missing:
+   - add DuckDuckGo HTML (non-Playwright) fallback.
+   - disable Playwright fallback after launch failure instead of repeated hard-fail.
+4. Malformed classifier structured-output hardening:
+   - detect malformed `DiscoveryResponse` tool output errors.
+   - apply deterministic URL heuristic fallback only for malformed-output cases.
+   - keep non-malformed runtime errors (for example `429`) as explicit error path.
+
+## Validation Run Notes
+
+Focused tests (local worktree) passed:
+
+- `pytest -q backend/tests/services/discovery/test_discovery.py backend/tests/cron/test_run_discovery.py backend/tests/test_postgres_client.py::test_create_source_serializes_metadata_dict backend/tests/test_discovery_services.py -k "discover_url or run_discovery or create_source_serializes_metadata_dict or search_discovery"`
+- Result: `15 passed, 5 deselected`
+
+Live bounded reruns were executed with explicit Railway context. Observed repeatedly:
+
+- Accepted/duplicate/rejected paths are now active (for example: added candidate, duplicate skips, classifier rejects).
+- UUID dedupe/insert crash is no longer observed.
+- `task_type` DB constraint failure is no longer observed.
+- Primary web search still fails with DNS resolution:
+  - `[zai] Search failed: [Errno 8] nodename nor servname provided, or not known`
+- Classifier/query generation calls intermittently hard-rate-limit:
+  - `Error code: 429 - {'error': {'code': '1302', 'message': 'Rate limit reached for requests'}}`
+
+Observed task IDs from this session:
+
+- `9e4178c5-494a-4082-afee-9ef03ec25b1f`
+- `7136bc3f-a776-4386-b5fc-312a143cc048`
+- `8ba6e958-6070-48e0-9f12-6971a2cd1644`
+- `f76e8a44-327d-4943-b1fd-6c14a2f9ea1c`
+- `bc5eb3c8-02ef-4856-b061-7649418eacab`
+
+## Final Classification
+
+`bd-esety` product-side blockers are fixed in code and covered by tests.
+
+Remaining instability is external/runtime truth:
+
+1. upstream search DNS failures (`z.ai` search endpoint path),
+2. upstream `429` rate limiting on chat/classifier/query-generation calls.
+
+Given these external conditions, bounded live reruns cannot produce stable, complete end-to-end result metrics in this window despite product fixes.
+
+Tool routing exception: `llm-tldr`/`serena` MCP surfaces were unavailable in this runtime (`list_mcp_resources` and templates returned empty), so shell fallback was used.


### PR DESCRIPTION
## Summary\n- complete deferred retry queue handling in discovery cron\n- process due deferred items with bounded per-run budget and bounded backoff retries\n- defer provider-limited classifier/search outcomes (including provider budget exhaustion) with durable metadata\n- report deferred outcomes separately from accepted/rejected/duplicate counts\n- add focused tests for cron deferred behavior and DB helper merge semantics\n\n## Validation\n- pytest -q backend/tests/cron/test_run_discovery.py backend/tests/test_postgres_client.py\n- python -m py_compile backend/scripts/cron/run_discovery.py backend/db/postgres_client.py\n- ruff check (unavailable: command not found)\n\nFeature-Key: bd-ro2cx\nAgent: codex