### PR TITLE
bd-jxclm.11: consultant review of Windmill persisted pipeline spec

### DIFF
--- a/docs/reviews/2026-04-11-windmill-persisted-pipeline-consultant-review.md
+++ b/docs/reviews/2026-04-11-windmill-persisted-pipeline-consultant-review.md
@@ -1,0 +1,169 @@
+# Consultant Review: Windmill-Driven Persisted Discovery Pipeline
+
+- **Spec under review:** `docs/specs/2026-04-11-windmill-driven-persisted-pipeline.md`
+- **Spec PR:** https://github.com/stars-end/affordabot/pull/415
+- **Spec PR head:** `385338ffce5108a0c15080c65946b1e11549fd31`
+- **Reviewer role:** External architecture consultant
+- **Beads:** epic `bd-jxclm`, subtask `bd-jxclm.11`
+- **Date:** 2026-04-11
+
+Tool routing exception: skipped `llm-tldr` / `serena` MCP navigation — the review scope is the spec document plus two adjacent files (`ops/windmill/README.md`, `backend/scripts/cron/run_universal_harvester.py`, `backend/services/llm/web_search_factory.py`) and a targeted Read was cheaper and sufficient than symbolic navigation across the whole repo.
+
+## Verdict
+
+**`approve_with_changes`**
+
+The architecture is directionally correct and the Windmill/backend split is the right one for a single-founder team. The spec is publishable as a reviewed design, but several concrete changes should be applied before the first implementation task (`bd-jxclm.2`) starts. Most of them are guardrails on freshness, schema, and MVP scope — not architectural rewrites.
+
+## Top Risks (Ordered by Severity)
+
+1. **Silent staleness via "latest-good" fallback.** The spec allows stale search snapshots to back a run up to `max_search_stale_hours` (168h default). Without explicit, loud alerting on *every* fallback hit and a hard ceiling after N consecutive fallbacks, a quiet SearXNG outage can degrade discovery for a full week before a human notices. This is the single highest-blast-radius risk in the design.
+2. **Step API proliferation.** Ten `/internal/pipeline/*` endpoints at MVP is ~2–3× what a bounded single-jurisdiction run actually needs. Each endpoint adds auth coverage, contract tests, idempotency tests, and Windmill branch logic. For a founder-led team this is a concrete cognitive-load tax that the spec does not acknowledge.
+3. **Pipeline schema is large and sequenced too early.** Eight new tables (`pipeline_runs`, `pipeline_steps`, `search_queries`, `search_result_snapshots`, `pipeline_freshness_decisions`, `fetch_artifacts`, `extraction_artifacts`, `ingestion_jobs`) all land in Phase 2 before any business value is proven. Schema churn during Phases 4–5 is very likely and will be painful.
+4. **Unbounded MinIO growth with no retention in the MVP.** Retention is mentioned as a risk but is deferred to `bd-jxclm.8` and never defined numerically. Raw HTML + screenshots per fetch can grow fast per jurisdiction onboarded.
+5. **No pipeline contract version field in the canonical request/response envelope.** The spec mentions version drift in the risk section and says "include pipeline contract version in manifests and backend responses," but the Backend Step API example payloads in §"Backend Step API" do not include the field. This is a trivial but easy-to-forget omission that will bite at rollout.
+6. **Promotion step is described but not scope-gated.** Auto-promotion mentions "explicitly allowed families and high-confidence first-party surfaces" without specifying which families qualify at MVP. Without a gate, this becomes an open-ended policy surface.
+7. **Rollback plan is "additive" but does not specify the shadow-run period.** Phase 7 says rollback is "additive" and existing cron endpoints remain, but there is no explicit parity window ("run old and new in parallel for N days, compare X metric"). Without that, cutover is implicitly a flag flip.
+8. **Playwright and Z.ai OCR fallback are listed as Phase 5 scope but not sequenced behind measured need.** Both are operationally heavy (Playwright needs a runtime, Z.ai OCR is cost-metered). They should only land when direct HTTP + readability has been shown to fail for a quantified share of real pages.
+9. **No data classification or PII handling for raw HTML / screenshot artifacts.** Municipal pages are usually public, but screenshots and raw HTML may carry embedded third-party content, cookies in HAR-like captures, or staff contact details. The spec does not say this is intentionally out of scope.
+10. **`trigger_source` is free-form string.** This is fine for logs but should be explicitly not-load-bearing for routing or retry policy — a small note prevents the pattern from calcifying.
+
+## Boundary Critique: Windmill vs Backend
+
+**What the spec gets right:**
+- The prohibition list in §"Active Contract" (Windmill must not write `sources`, `raw_scrapes`, `document_chunks`, etc.) is the correct invariant. It matches the existing shared-instance pattern documented in `ops/windmill/README.md` and does not require a mental model change.
+- Pushing scoring, dedupe, and promotion into the backend is the right call. Windmill should never encode domain truth.
+- The step request envelope (`run_id`, `step_key`, `idempotency_key`, `trigger_source`, `manifest`) is the correct shape.
+
+**What leaks or is ambiguous:**
+- **Retry policy ownership.** The spec says "Windmill is allowed to retry safe steps according to backend-declared retryability" and the response includes `retryable: true|false`. Good. But the spec does not say whether retry *count* is a Windmill policy or a backend policy. If Windmill owns it, a flow-version bump changes retry behavior silently. Recommendation: backend returns `retryable`, `max_retries`, and `retry_after_seconds`; Windmill obeys, does not guess.
+- **`next_recommended_step` in the response.** This quietly moves a flow-graph decision from Windmill into the backend. It is a hint, but Windmill flow authors may code against it. Either declare it advisory-only in the spec or remove it and let Windmill own the DAG. I recommend declaring it advisory, because the backend is the only component that knows whether a step's output justifies skipping ahead, but the flow-graph itself must stay declarative in Windmill.
+- **Alerting ownership.** Spec says Windmill "send Slack/operator alerts." Good. But freshness/stale-backed alerts are semantically a backend concern (the backend is the only thing that knows `stale_backed=true`). Clarify: backend emits the alert *content* in `operator_summary` + a structured `alerts[]` field; Windmill is the dumb transport.
+- **Contract version.** Must move from risk section into the mandatory envelope as noted in Risk 5.
+
+**Net assessment:** the boundary is ~90% right. The remaining 10% is ownership of retry *policy*, alert *content*, and the advisory nature of `next_recommended_step`.
+
+## Persistence / Schema Critique
+
+The schema is well-normalized and lineage-preserving, which is good for audit. It is also larger than MVP warrants.
+
+**Concrete critiques:**
+- **`pipeline_steps` and `pipeline_runs` can land at MVP.** Everything else can be staged.
+- **`search_queries` as a registry table is premature.** At MVP a manifest-driven list is enough. A registry table becomes necessary when (a) the same query must fire across multiple runs on different cadences, or (b) operators need to edit queries without a deploy. Neither is true on day one.
+- **`pipeline_freshness_decisions` is one table too many.** The decision is a property of the step that consumed the snapshot; it belongs as columns on `pipeline_steps` (`freshness_policy`, `stale_backed`, `latest_success_at`, `decision_reason`) or as a single JSON column. A dedicated table is "correct" but introduces an avoidable join and a second place to keep consistent.
+- **`fetch_artifacts` and `extraction_artifacts` should not both be tables at MVP.** Collapse into one `content_artifacts` row with an `artifact_kind` enum (`fetch`, `extraction`, `screenshot`). This preserves lineage via `parent_artifact_id` without doubling the migration surface.
+- **`search_result_snapshots.provider_endpoint_hash` is good** — that is exactly the kind of field that lets a post-mortem distinguish two SearXNG instances. Keep it.
+- **`idempotency_key` format.** Spec suggests `run_id:step_key:manifest_hash`. Good, but note that `manifest_hash` must be a stable canonical serialization (sorted keys, no whitespace variance). Add a one-line note to prevent silent cache misses.
+- **Missing:** `pipeline_runs.contract_version` and `pipeline_steps.contract_version`. This is the persistence home for Risk 5.
+- **Missing:** an explicit `pipeline_runs.parent_run_id` for "resume from failed step" lineage. Without it, a resumed run either overwrites the original (loses history) or has no link back (loses audit).
+- **Missing:** `pipeline_runs.jurisdiction_id` as a first-class column for cheap filtering. Putting it only in the manifest makes ops queries painful.
+
+## Freshness / Latest-Good Fallback Critique
+
+Latest-good fallback is the riskiest feature in the design because it turns a loud failure (SearXNG down) into a quiet success. The spec mitigations are directionally right but insufficient.
+
+**What must be added to the spec before implementation:**
+1. **Hard ceiling on consecutive fallbacks.** After N (recommended: 2) consecutive runs that fallback for the same `query_key`, the run must fail closed, not degrade silently further. N should be configurable per source family.
+2. **Alert on *every* fallback, not just on refresh failure.** Currently the spec says "Windmill should still alert on refresh failure." That is necessary but not sufficient — if the refresh step *itself* marks partial and returns stale-backed results, Slack should get it.
+3. **Fallback telemetry as a first-class metric.** Add `stale_backed_count` to the run summary. Operator should be able to see "N of M query keys used stale fallback" at a glance, not dig through step rows.
+4. **`max_stale_hours` per source family, not global.** Permit pages rot faster than municipal code. 168h is probably too generous for meetings, too tight for code. Make the 168h value a default, not a policy.
+5. **Fallback must preserve the *original* `provider_endpoint_hash`** so a post-mortem can distinguish "SearXNG was up but the provider was different" from "we used a 6-day-old snapshot".
+6. **Explicit "no fallback on empty result set" rule.** If SearXNG returns `200 OK` with zero results, that is *not* a failure and must not trigger latest-good. Zero-result is a real state that should surface as `created_count: 0`. The spec does not currently distinguish these.
+
+## MVP Cut Recommendations
+
+The spec has 7 execution phases and 10 subtasks. For a founder-led team the MVP that delivers business value is smaller than what is currently sequenced.
+
+**Cut from MVP (defer to post-parity):**
+- `bd-jxclm.6` Private SearXNG provisioning as a *blocking* dependency. Start with the existing Z.ai search path behind the new step contract; swap the backend of `/internal/pipeline/search-execute` to SearXNG as a later, isolated change. This lets the pipeline skeleton land without waiting on infra.
+- `pipeline_freshness_decisions` table (fold into `pipeline_steps`, see schema critique).
+- `search_queries` registry table (use manifest-driven queries at MVP).
+- `fetch_artifacts` + `extraction_artifacts` as two separate tables (collapse into `content_artifacts`).
+- `/internal/pipeline/search-rerank` as a separate endpoint — merge into `search-execute` at MVP. Rerank logic is small enough to live inside the execute step until there is a demonstrated need for a re-rank-only pass.
+- `/internal/pipeline/promote` endpoint at MVP. Promotion is an explicit non-goal for day-one trust (spec says promotion is a separate concern). Run the MVP in `capture_only` mode and have promotion land in a later wave.
+- Playwright fallback at MVP. Require direct HTTP + readability only, with failures recorded. Add Playwright when a measured >X% of real target pages require it.
+- Z.ai layout/OCR fallback at MVP. Same reasoning — bounded hard-document fallback can land after parity is proven.
+- `pipeline_retry_step` dedicated Windmill flow. A single `pipeline_manual_run` flow with a `resume_from_step` manifest field is enough at MVP.
+
+**Keep at MVP:**
+- `pipeline_runs`, `pipeline_steps` (with freshness columns inlined).
+- `/internal/pipeline/runs`, `/search-execute`, `/read-fetch`, `/extract`, `/embed`, `/report` — six endpoints, not ten.
+- `search_result_snapshots` + `content_artifacts` tables.
+- MinIO artifact layout (keep as designed).
+- Daily Windmill flow + manual Windmill flow.
+
+**Result:** one round of schema migration instead of three, six endpoints instead of ten, no infra block on SearXNG provisioning.
+
+## Failure Drills Missing Before Rollout
+
+The Runtime Smokes section is reasonable but skews toward happy-path verification. The following drills must be exercised before calling the rollout complete:
+
+1. **Crash-mid-step drill.** Kill the backend process while a `/read-fetch` step is mid-write to MinIO + Postgres. Verify the step row reflects the actual terminal state on restart, not a zombie `running`.
+2. **Partial MinIO write drill.** Simulate an S3/MinIO 500 during an artifact write. Verify the step returns `failed` (or `partial` only if safe) and does not leave a half-written row pointing to a non-existent artifact.
+3. **Idempotency replay drill.** Call the same endpoint with the same `idempotency_key` twice, concurrently. Verify one wins cleanly and the other returns the original result with `reused_count > 0`.
+4. **Contract-version skew drill.** Call a v2 endpoint with a v1 manifest. Verify fail-closed behavior, not silent coercion.
+5. **Stale-ceiling drill.** Simulate SearXNG down for three consecutive runs. Verify the run fails closed after N=2 and alerts fire.
+6. **Resume-from-failed-step drill.** Fail a run at `extract`, then call the manual flow with `resume_from_step=extract` and verify upstream `read-fetch` results are reused, not redone.
+7. **Rollback drill.** With new pipeline running, disable the Windmill schedule and re-trigger the old cron endpoint. Verify zero data loss and zero cross-contamination of run tables.
+8. **Auth-drift drill.** Rotate `CRON_SECRET`. Verify the Windmill flow and the backend fail loudly in the same window rather than one side failing silently.
+
+## Required Spec Changes Before Implementation
+
+These are the blocking edits to the spec document. None are architectural rewrites; all are tightening.
+
+1. Add `contract_version` to the canonical request and response envelopes (§"Backend Step API").
+2. Add `alerts: [{severity, code, summary}]` to the canonical response envelope.
+3. Change `retryable: true|false` to `retry: { retryable, max_retries, retry_after_seconds }` and declare that Windmill obeys these values rather than setting its own.
+4. Declare `next_recommended_step` as advisory-only; the Windmill DAG remains the source of truth for flow graph.
+5. Under §"Persistence Model", mark `pipeline_freshness_decisions`, `search_queries`, `fetch_artifacts`, and `extraction_artifacts` as **Phase 3+**, not Phase 2. Collapse fetch/extraction into `content_artifacts` at MVP.
+6. Add `pipeline_runs.contract_version`, `pipeline_runs.parent_run_id`, `pipeline_runs.jurisdiction_id`, `pipeline_runs.stale_backed_count` columns.
+7. Add a §"Freshness Policy" subsection covering: per-family `max_stale_hours`, hard ceiling on consecutive fallbacks, always-alert on `stale_backed=true`, zero-result is not a failure.
+8. Add §"Retention" numeric defaults (recommended starting values: 30d for raw fetch HTML, 90d for extracted markdown, 7d for debug screenshots, indefinite for `pipeline_runs` and `pipeline_steps` rows).
+9. Move private SearXNG (`bd-jxclm.6`) off the MVP blocking path; document that MVP may run with the existing search backend behind the new step contract.
+10. Document the parity window in §"Rollback": explicit duration, explicit pass/fail criteria, explicit metric comparison (e.g., "7 days, ≥95% equivalent created_count per jurisdiction, zero net new failures").
+11. State that raw HTML and screenshot artifacts are assumed public-data-only and that any PII-handling policy is out of scope for this epic (or in scope with a concrete plan).
+
+## Optional Future Improvements
+
+- A `pipeline_dashboard` materialized view for operator queries (runs, durations, stale counts).
+- Trace correlation: propagate a W3C traceparent from Windmill → backend → artifacts for cross-tool debugging.
+- Backfill tooling to replay a historical `pipeline_run` from its persisted artifacts — useful for prompt/model upgrades without re-fetching.
+- Content-hash-based dedupe across runs (not just within a run) for `content_artifacts`.
+- A `pipeline_run_diffs` helper that compares two runs of the same manifest to expose drift.
+- Export of run summaries to Beads as an `evidence` attachment on the originating subtask.
+
+## Direct Answers to Review Questions
+
+**1. Windmill as orchestrator vs domain executor — does business logic leak?**
+Mostly no, with two thin leaks: (a) retry policy is implicitly Windmill-owned, and (b) `next_recommended_step` risks encoding flow-graph decisions on the backend side. Both are fixable in the spec with two sentences. The §"Active Contract" prohibition list is strong and matches the existing shared-instance pattern in `ops/windmill/README.md`.
+
+**2. Are the backend step endpoints too fine, too coarse, or appropriately resumable?**
+Too fine. Ten endpoints at MVP is ~2× what a single bounded run needs. Merge `search-rerank` into `search-execute`, defer `promote` to post-MVP, and the remaining six endpoints are appropriately resumable.
+
+**3. Is the proposed schema enough for auditability and replay without avoidable operational burden?**
+Over-built for MVP. Eight tables can compress to four: `pipeline_runs`, `pipeline_steps`, `search_result_snapshots`, `content_artifacts`. Freshness decisions fold into `pipeline_steps`. The full schema is a good *eventual* target, not a good starting migration.
+
+**4. Is latest-good fallback safe? What metadata / alerting is missing?**
+Not yet safe. Missing: consecutive-fallback ceiling, per-family `max_stale_hours`, always-alert on `stale_backed=true`, zero-result vs failure distinction, preservation of original `provider_endpoint_hash`, and a `stale_backed_count` summary metric. See "Freshness / Latest-Good Fallback Critique" for the full list.
+
+**5. Are SearXNG, reader, MinIO, Postgres, pgvector responsibilities separated cleanly?**
+Yes. The spec correctly treats SearXNG as a *primitive* returning candidates, reader/extraction as persisted evidence, MinIO as bulk artifact home, Postgres as state-of-record, and pgvector as downstream ingestion only. The one nuance: the spec should say explicitly that `document_chunks` writes are the *only* place pgvector is mutated by the pipeline.
+
+**6. Which pieces should be cut from MVP?**
+Private SearXNG provisioning as a blocker, `pipeline_freshness_decisions` table, `search_queries` registry table, split fetch/extraction tables, `search-rerank` endpoint, `promote` endpoint, Playwright fallback, Z.ai OCR fallback, and the dedicated `pipeline_retry_step` flow. See "MVP Cut Recommendations" for details.
+
+**7. What failure drills are missing before rollout?**
+Eight drills listed above. The critical four are: crash-mid-step, partial MinIO write, idempotency replay, and stale-ceiling fail-closed.
+
+**8. What sequencing changes would reduce implementation risk?**
+Reorder so that `bd-jxclm.2` ships the *reduced* schema (four tables), `bd-jxclm.3` ships only the six MVP endpoints, `bd-jxclm.4` lands with the *existing* search backend (not SearXNG), `bd-jxclm.5` ships reader with direct HTTP + readability only (no Playwright, no OCR), `bd-jxclm.9` ships the daily + manual flows, and `bd-jxclm.6/.7/.8` and `.10` run in parallel after the skeleton exists. This sequences value in front of infra rather than behind it.
+
+**9. Security or data-retention risks in MinIO / raw artifact model?**
+Three: (a) no numeric retention is committed in-spec, (b) raw HTML screenshots may carry third-party tracking content or contact details, (c) MinIO bucket ACLs are not mentioned. All three should be explicitly either in scope with a plan or declared out of scope with a rationale. Recommend explicit numeric retention in §"Retention" and a one-line statement that MinIO buckets are private with backend-only access.
+
+**10. Should any logic currently proposed for backend belong in Windmill, or vice versa?**
+No "backend → Windmill" moves are warranted — the backend bias is correct. One small "Windmill → backend" move: the alert *content* for freshness and promotion should be constructed in the backend (returned in `operator_summary` + `alerts[]`) and Windmill should be a dumb transport, not a message formatter. Everything else can stay where the spec puts it.
+
+---
+
+**Summary.** Approve with the spec edits above. The direction is correct; the MVP shape is slightly too ambitious for a founder-led team and the freshness semantics need two paragraphs of tightening. After those edits, `bd-jxclm.2` is a safe place to start implementation.

--- a/docs/reviews/2026-04-11-windmill-persisted-pipeline-consultant-review.md
+++ b/docs/reviews/2026-04-11-windmill-persisted-pipeline-consultant-review.md
@@ -1,73 +1,260 @@
 # Consultant Review: Windmill-Driven Persisted Discovery Pipeline
 
-**Date:** 2026-04-11
-**Reviewer:** External Architecture Consultant
+**Spec under review**: `docs/specs/2026-04-11-windmill-driven-persisted-pipeline.md`
+**PR**: https://github.com/stars-end/affordabot/pull/415
+**Reviewer**: External architecture consultant
+**Date**: 2026-04-11
+**Beads**: bd-jxclm.11
 
-## Verdict
-**Verdict:** `approve_with_changes`
+---
 
-## Tool routing exception
-Tool routing exception: Semantic discovery via `llm-tldr` and symbol-aware navigation via `serena` were not required because the user explicitly provided the exact 4 file paths needed for the targeted architectural review.
+## Verdict: `approve_with_changes`
+
+The spec is sound in its core contract — Windmill as orchestrator, backend as domain executor, persisted intermediates for resumability. The boundary definitions are the best part of this document. However, several concrete issues must be resolved before implementation begins: the step API is one step too fine in the search phase, the schema is missing columns for replay safety, the freshness fallback needs alerting and TTL guardrails, and the MinIO artifact model needs a retention enforcement design. These are fixable without re-architecting.
+
+---
 
 ## Top Risks (Ordered by Severity)
-1. **Unbounded Artifact Growth (MinIO Storage Exhaustion):** The introduction of raw HTML, PDF, and JSON snapshot artifacts for every search query could rapidly deplete storage. If MinIO lifecycle policies are not implemented *before* rollout, it will lead to an operational failure.
-2. **Hidden Stale Fallback Degradation:** While the spec includes `stale_backed=true` in decisions, without a loud observability hook in Windmill, a completely broken SearXNG could be masked for weeks if the maximum stale hours are set broadly.
-3. **Windmill Timeout Sync Vulnerability:** If a backend step (e.g., embedding or extraction) takes longer than Windmill's HTTP timeout, Windmill may retry the step while the backend is still running the first attempt. The backend must have strong locking or atomic upserts on the `idempotency_key`.
+
+### R1. Search step granularity creates fragile orchestration coupling
+
+The spec proposes four search-phase endpoints: `search-plan`, `search-execute`, `search-rerank`, and `freshness-gate`. The first three are so tightly coupled that Windmill must sequence them with no branching value — `search-plan` produces a query list that immediately feeds `search-execute`, which immediately feeds `search-rerank`. If any of these fails, the recovery is always "redo from search-plan." This is one logical unit with three HTTP round-trips, three idempotency checks, and three step rows for what is semantically one operation: "generate and materialize search candidates."
+
+**Impact**: Increased Windmill flow complexity, more places for version drift, and no resumability gain between plan/execute/rerank since they share a single failure domain.
+
+**Fix**: Collapse `search-plan`, `search-execute`, and `search-rerank` into a single `search-materialize` step. Freshness-gate remains separate because it has genuine branching logic (fresh results vs. stale fallback). The backend can still internally decompose into plan/execute/rerank; the step API just doesn't expose that as separate HTTP calls.
+
+### R2. `pipeline_steps` schema missing `manifest_hash` for idempotency replay
+
+The spec's idempotency key is `run_id:step_key:manifest_hash`, but `pipeline_steps` does not include a `manifest_hash` column. Without it, the idempotency key cannot be reconstructed from persisted state after a Windmill restart. The `idempotency_key` column itself is a derived string, but it cannot be validated against the manifest that produced it without the hash stored separately.
+
+**Impact**: If Windmill retries a step with a slightly different manifest (e.g., a jurisdiction was added), the idempotency key would differ, but there is no persisted way to detect manifest drift from the database alone.
+
+**Fix**: Add `manifest_hash TEXT` to `pipeline_steps`. The backend should reject a step invocation if the stored `manifest_hash` for the same `(run_id, step_key)` differs from the incoming one, unless the step is explicitly being re-run.
+
+### R3. Freshness fallback can mask indefinite SearXNG outages
+
+The spec correctly marks `stale_backed=true` in `pipeline_freshness_decisions`, but there is no mechanism to escalate when stale fallback becomes the norm rather than the exception. A SearXNG outage that lasts days would produce runs that silently succeed on stale data, with only a `stale_backed=true` column that nobody reads.
+
+**Impact**: Data drift accumulates without operator awareness. The system appears healthy while producing increasingly stale results.
+
+**Fix**: Add two guardrails:
+1. A `consecutive_stale_fallbacks` counter on `search_queries` that increments on stale use and resets on fresh success. Alert when it exceeds a configurable threshold (default: 3).
+2. A hard TTL: if `latest_success_at` is older than `2 * max_stale_hours`, the step must fail rather than fall back, regardless of policy. This prevents indefinite stale operation.
+
+### R4. MinIO artifact retention is specified but not enforced
+
+The spec mentions "retention windows, size budgets, and MinIO lifecycle cleanup" as mitigation for artifact growth, but does not define the lifecycle policy or where enforcement lives. Without a concrete retention design, artifact growth is a known risk with no committed countermeasure.
+
+**Fix**: Define a minimum retention policy in the spec before Phase 2:
+- Raw search JSON: 30 days
+- Fetched HTML/PDF: 90 days
+- Extracted markdown: 90 days (or until superseded by content_hash match)
+- Debug screenshots: 7 days
+- Reports: indefinite
+
+Enforcement: backend writes a `retention_expires_at` column on each artifact row. A daily Windmill-scheduled cleanup job calls a backend endpoint that deletes expired artifacts from MinIO and marks the row `purged`.
+
+### R5. No contract version negotiation mechanism
+
+The spec mentions "include pipeline contract version in manifests and backend responses" but does not define the version format, the negotiation behavior, or what happens when versions diverge. This is a known risk (`Version Drift Between Windmill and Backend`) with a placeholder mitigation.
+
+**Fix**: Add a `contract_version` field to the manifest (semver, starting at `1.0.0`). The backend rejects any request with an unsupported major version. Minor version differences are logged but allowed. The version should be a constant in the backend codebase, not a Windmill variable.
+
+### R6. Concurrent idempotency key collision under Windmill retry
+
+If a backend step takes longer than Windmill's HTTP timeout, Windmill may retry the same step while the backend is still processing the first attempt. The spec mentions idempotency keys but does not specify the concurrency control mechanism.
+
+**Fix**: The backend must use `INSERT ... ON CONFLICT (idempotency_key) DO NOTHING` with a check that returns the existing step's status if the insert conflicts. For long-running steps, the backend should return `202 Accepted` for the in-progress invocation and Windmill should poll rather than immediately retry.
+
+---
 
 ## Boundary Critique: Windmill vs Backend
-The proposed boundaries are well-defined and adhere to best practices. Windmill is correctly constrained to scheduling, branching, retries, and manifest-passing. Keeping the domain logic, table writes, and artifact persistence strictly within the affordabot backend prevents "orchestrator bloat" and maintains a clean single source of truth for business rules.
+
+### What the spec gets right
+
+The Active Contract section is the strongest part of this spec. The "Windmill is allowed to" / "Windmill is not allowed to" / "Backend is required to" enumeration is exactly the right abstraction level. The prohibition on Windmill writing domain tables, implementing scoring, or holding unversioned business rules is clear and enforceable.
+
+The manifest-in, status-out pattern is clean. Windmill passes intent; backend returns fact.
+
+### Where business logic leaks
+
+1. **Freshness policy in the manifest**: The manifest includes `freshness_policy` and `max_search_stale_hours`. If Windmill is setting these values, the operator is making a business decision about data freshness in the orchestration layer. This should either be a backend-enforced default with optional override, or the manifest should reference a named policy (e.g., `"freshness_policy": "standard_daily"`) whose parameters are owned by the backend.
+
+2. **`sample_size_per_bucket` in the manifest**: This is a business logic parameter controlling how many documents to process. It should be a backend default with optional override, not a required manifest field.
+
+3. **The `report` step**: The spec lists `POST /internal/pipeline/report` as a backend step, but report generation is purely a synthesis of already-persisted data. If Windmill needs to trigger a report, it should be a lightweight query, not a state-changing step. Making it a step with its own `pipeline_steps` row implies it has side effects, which it shouldn't.
+
+### Recommendation
+
+Move freshness policy names and sample size defaults into a backend `pipeline_policies` table or configuration. The manifest should reference policy names, not policy parameters. The `report` endpoint should be a GET, not a POST, and should not create a step row.
+
+---
 
 ## Persistence/Schema Critique
-The persistence schema successfully separates orchestration state (`pipeline_runs`, `pipeline_steps`) from domain state (`search_queries`, `fetch_artifacts`, `ingestion_jobs`). This separation allows for clean auditability and simplifies debugging. Moving large blobs (raw HTML, resulting markdown) into MinIO instead of Postgres is the right architectural choice to maintain DB health. 
+
+### Sufficient
+
+The separation of `pipeline_runs` / `pipeline_steps` / `search_result_snapshots` / `fetch_artifacts` / `extraction_artifacts` / `ingestion_jobs` is well-scoped. Each table answers a distinct question. The lineage chain from search snapshot to fetch artifact to extraction artifact to ingestion job is traceable.
+
+### Missing
+
+1. **`manifest_hash` on `pipeline_steps`** (see R2 above).
+2. **`manifest` JSONB column on `pipeline_runs`**: The manifest JSON is referenced throughout but not persisted with the run. If you need to replay a run or understand what was requested, you need the manifest stored with the run, not just its hash.
+3. **`content_hash` uniqueness constraint**: `fetch_artifacts.content_hash` should have a unique constraint (or at minimum a per-run unique index) to support idempotent re-fetch. The spec mentions content hashing but does not declare the constraint.
+4. **`extraction_artifacts.markdown_hash` uniqueness**: Same concern. Re-extraction of identical content should be a no-op, which requires a uniqueness check.
+5. **`pipeline_freshness_decisions.stale_backed` should be NOT NULL DEFAULT FALSE**: The spec lists it as a column but does not declare default or nullability. If freshness decisions are written before fallback is evaluated, `NULL` would be ambiguous (not yet evaluated vs. evaluated as not stale).
+6. **`search_result_snapshots.validated_at`**: No mechanism to track whether snapshot URLs were later confirmed live during fetch. A stale snapshot referencing dead URLs is worse than no snapshot.
+
+### Overbuilt
+
+The `search_result_snapshots` table has both `provider_score` and `local_score`. Until the backend implements local scoring (which is not in Phase 1-4), `local_score` will always be NULL. Consider adding it in the phase where scoring is implemented, not upfront.
+
+---
 
 ## Freshness Fallback Critique
-The "latest-good fallback" mechanism is intelligent for handling external SearXNG flakiness. However, it is paramount that Windmill triggers a non-fatal alert when a fallback occurs. Silent usage of stale data can be as dangerous as no data in a financial/legislative context. The inclusion of `status`, `freshness_policy`, and `stale_backed` flags in `pipeline_freshness_decisions` is necessary but sufficient only if actively monitored.
 
-## Required Spec Changes Before Implementation
-1. **Idempotency Locking:** Specifically address how the backend will handle concurrent requests for the same `idempotency_key` (e.g., if Windmill times out and retries while the backend is still processing the first request).
-2. **Alerting on Fallback:** Update the Windmill Flow orchestration (Phase 6) to include a requirement that Windmill sends a Slack alert to the operator when `stale_backed` is true, ensuring operators know the system is masking a SearXNG outage.
-3. **Data Retention Timelines:** Explicitly define the TTL (Time-To-Live) / Retention policy for MinIO raw artifacts in Phase 2 or Phase 8.
+### What works
+
+- The `pipeline_freshness_decisions` table with `stale_backed`, `freshness_policy`, `latest_success_at`, and `decision_reason` provides a solid audit trail for individual fallback decisions.
+- The principle of "allow stale fallback only inside explicit policy" is correct.
+
+### What is missing
+
+1. **Consecutive stale counter** (see R3): No escalation mechanism.
+2. **Hard TTL floor** (see R3): No absolute staleness ceiling.
+3. **SearXNG health probe**: Before executing a search, the backend should probe SearXNG availability with a lightweight request. If SearXNG is down, the backend can immediately decide to use stale data rather than waiting for a timeout. This reduces latency and avoids filling connection pools with doomed requests.
+4. **Stale snapshot validity signal**: `search_result_snapshots` does not record whether a snapshot was later validated (i.e., did the URLs in the snapshot still exist when fetched?). A stale snapshot that references dead URLs is worse than no snapshot. Add a `validated_at` column that is updated when fetch results confirm snapshot URLs.
+
+---
 
 ## MVP Cut Recommendations
-- **Search Rerank Step (`search_rerank`):** This is likely an optimization that isn't strictly required to prove pipeline correctness.
-- **Complex Extraction Layers:** Defer the Playwright (JS-heavy) and OCR (Z.ai fallback) pathways for Phase 1 MVP. Stick to strict HTTP fetch + standard readability extraction to validate the whole pipeline flow end-to-end sooner.
+
+Cut from MVP (Phase 1-4):
+
+| Item | Reason |
+|------|--------|
+| `search-rerank` as separate endpoint | Merge into `search-materialize`. Reranking is internal logic, not a resumable boundary. |
+| `search-plan` as separate endpoint | Merge into `search-materialize`. Plan and execute share a failure domain. |
+| `local_score` on `search_result_snapshots` | No implementation in MVP phases. Add when scoring logic exists. |
+| `screenshot_artifact_path` on `fetch_artifacts` | Screenshots are debug-only. Ship in Phase 8 (observability). |
+| `metadata_artifact_path` on `extraction_artifacts` | Undefined contract. Add when metadata extraction is specified. |
+| `report` as a POST step | Make it a GET query. Reports are reads, not state transitions. |
+| Z.ai layout/OCR fallback (Phase 5) | Defer to post-MVP. Ship direct HTTP + readability + PDF extraction first. |
+
+Keep in MVP:
+
+| Item | Reason |
+|------|--------|
+| `search-materialize` (combined) + `freshness-gate` | Core search boundary |
+| `read-fetch` + `extract` | Core content acquisition |
+| `embed` + `promote` | Core ingestion and source trust |
+| MinIO raw artifact writes | Required for idempotent re-extraction |
+| All pipeline state tables | Required for resume and audit |
+| Content hash reuse | Required to avoid re-ingesting unchanged content |
+
+---
+
+## Required Spec Changes Before Implementation
+
+1. **Collapse `search-plan`, `search-execute`, `search-rerank` into `search-materialize`** (see R1).
+2. **Add `manifest_hash` to `pipeline_steps`** (see R2).
+3. **Add `manifest` JSONB column to `pipeline_runs`**.
+4. **Add `consecutive_stale_fallbacks` to `search_queries`** with alerting threshold (see R3).
+5. **Add hard TTL floor**: `2 * max_stale_hours` must fail, not fall back (see R3).
+6. **Define concrete MinIO retention policy with `retention_expires_at`** (see R4).
+7. **Define `contract_version` format and rejection behavior** (see R5).
+8. **Make `report` a GET endpoint, not a POST step**.
+9. **Move freshness policy parameters to backend-owned defaults with named policy references in manifests**.
+10. **Add `validated_at` to `search_result_snapshots`** for snapshot validity tracking.
+
+---
 
 ## Optional Future Improvements
-- **Automated Replay Testing:** Once idempotent steps exist, create a dedicated test environment that reruns pipeline events against stale snapshots to test the recovery paths safely off-production.
-- **Circuit Breakers for SearXNG:** Instead of waiting for per-query timeouts, implement a rapid-failure circuit breaker to switch to fallback mode earlier if the first 3 SearXNG requests fail globally.
+
+- **Snapshot diffing**: When a new search snapshot matches a prior one by URL set, record the diff (added/removed URLs) for operator review.
+- **Backpressure on Windmill**: If the backend is under load, step endpoints should return a `retry_after_seconds` field so Windmill can back off without failing the step.
+- **Step timeout contracts**: Each step endpoint should declare its expected maximum runtime so Windmill can set appropriate timeouts.
+- **Artifact deduplication across runs**: If two runs fetch the same URL with the same content hash, they should share the same MinIO object rather than duplicating storage.
+- **Cross-run lineage**: `fetch_artifacts` and `extraction_artifacts` reference `run_id`, but the same URL fetched across runs has no explicit linkage. A `canonical_url` index would support "show me all fetches of this URL across time."
+- **SearXNG query result caching**: For jurisdictions that change slowly, materialized search snapshots can be reused across daily runs without re-querying SearXNG, reducing search volume.
+- **Circuit breaker for SearXNG**: Instead of per-query timeouts, implement a rapid-failure circuit breaker that switches to fallback mode after N consecutive SearXNG failures globally.
+- **Automated replay testing**: Once idempotent steps exist, create a dedicated test environment that reruns pipeline events against stale snapshots to test recovery paths safely off-production.
 
 ---
 
 ## Direct Answers to Review Questions
 
-**1. Does the spec keep Windmill as orchestrator and affordabot backend as domain executor, or does business logic still leak across the boundary?**
-Yes, it strictly maintains the boundary. Windmill is passed a manifest and routes HTTP calls, but the actual domain decisions (like what constitutes a valid source) and database writes remain in the affordabot backend.
+### Q1: Does the spec keep Windmill as orchestrator and affordabot backend as domain executor, or does business logic still leak across the boundary?
 
-**2. Are the backend step endpoints too fine-grained, too coarse, or appropriately resumable?**
-They are appropriately resumable. Steps like `search-plan`, `fetch`, and `extract` represent specific, retryable jobs that each produce a durable outcome.
+**Mostly yes, with three leaks.** The Active Contract section is excellent and the manifest-in/status-out pattern is clean. However: (a) freshness policy parameters (`max_search_stale_hours`, `freshness_policy`) in the manifest are business decisions that should be backend-owned defaults with named policy references; (b) `sample_size_per_bucket` in the manifest is a business parameter; (c) the `report` step as a state-changing POST blurs the read/write boundary. These are fixable without re-architecting.
 
-**3. Is the proposed schema enough for auditability and replay without creating avoidable operational burden?**
-Yes, the explicit separation of step execution metadata and artifact persistence (MinIO) guarantees auditability without bogging down the relational database.
+### Q2: Are the backend step endpoints too fine-grained, too coarse, or appropriately resumable?
 
-**4. Is latest-good fallback safe? What metadata or alerting is missing to prevent silent stale behavior?**
-The metadata (`stale_backed` column) exists, but the alerting behavior is missing. Windmill must alert operators when `stale_backed=true` to prevent prolonged masking of Search API outages.
+**Too fine-grained in the search phase, appropriately scoped elsewhere.** The three-step search decomposition (`plan`/`execute`/`rerank`) creates orchestration overhead with no resumability benefit — they share a single failure domain and must always be re-executed together. Collapsing into `search-materialize` reduces HTTP round-trips and step rows without losing any recovery granularity. The remaining steps (`freshness-gate`, `read-fetch`, `extract`, `embed`, `promote`) are well-scoped — each has a distinct failure mode and resumable state.
 
-**5. Are SearXNG, reader/fetcher, MinIO artifacts, Postgres, and pgvector responsibilities separated cleanly?**
-Yes. SearXNG acts purely as candidate generation. MinIO handles blob storage, Postgres manages relational step state, and pgvector handles embeddings derived only from the extracted artifacts.
+### Q3: Is the proposed schema enough for auditability and replay without creating avoidable operational burden?
 
-**6. Which pieces should be cut from MVP?**
-Cut `search_rerank`, Playwright-based fetching, and OCR fallbacks. Focus strictly on direct HTTP fetching and pipeline idempotency.
+**Almost sufficient, with gaps.** The lineage chain from search to ingestion is traceable. The freshness decisions table provides auditability. Gaps: (a) `manifest_hash` is not stored on `pipeline_steps`, breaking idempotency replay verification; (b) the manifest itself is not stored on `pipeline_runs`, making it impossible to reconstruct what was requested without cross-referencing Windmill logs; (c) `stale_backed` nullability is ambiguous. The schema is not overbuilt — the table count is appropriate. The one overbuilt element is `local_score` on `search_result_snapshots`, which has no implementation in any planned phase.
 
-**7. What failure drills are missing before rollout?**
-- SearXNG complete outage simulation to verify alert firing.
-- Windmill execution timeout handling to verify backend idempotency locks.
-- MinIO write failure handling.
+### Q4: Is latest-good fallback safe? What metadata or alerting is missing to prevent silent stale behavior?
 
-**8. What sequencing changes would reduce implementation risk?**
-Move `bd-jxclm.8` (Infra: define artifact storage retention and observability) to an earlier phase (Phase 2 alongside schema design). Storage limits must be bounded early before tests write gigabytes of HTML.
+**Not safe without additions.** The `stale_backed=true` flag is necessary but insufficient. Missing: (a) a consecutive stale counter with alerting — three consecutive stale fallbacks should trigger an operator alert; (b) a hard TTL ceiling — if the last successful search is older than `2 * max_stale_hours`, the step must fail rather than fall back; (c) a SearXNG health probe to fail fast on outage rather than timing out; (d) a `validated_at` column on `search_result_snapshots` to track whether snapshot URLs were later confirmed live. Without these, a prolonged SearXNG outage produces runs that appear healthy while serving increasingly stale and potentially dead-link data.
 
-**9. Are there any security or data-retention risks in the proposed MinIO/raw artifact model?**
-Yes, retaining raw artifacts indefinitely can expose PII or copyrighted material and consume tremendous storage. A strict, automated retention policy (e.g., 14 or 30 days max for raw data) is mandatory.
+### Q5: Are SearXNG, reader/fetcher, MinIO artifacts, Postgres, and pgvector responsibilities separated cleanly?
 
-**10. Should any logic currently proposed for backend belong in Windmill, or vice versa?**
-No, the boundary is optimal as defined. Windmill handles scheduling and inputs, while the backend processes all states and artifacts.
+**Yes, with one ambiguity.** The separation is well-defined: SearXNG returns candidates, backend owns scoring and promotion, MinIO holds raw artifacts, Postgres holds relational and pipeline state, pgvector holds embeddings. The ambiguity: the spec does not clarify whether the reader/fetcher writes directly to `raw_scrapes` (the existing domain table) or only to `fetch_artifacts`/`extraction_artifacts` (the new pipeline tables). If both, what is the synchronization contract? The spec should state that pipeline tables are the source of truth for the pipeline, and promotion to `raw_scrapes` happens at the `promote` step. The fetcher should not write `raw_scrapes` directly.
+
+### Q6: Which pieces should be cut from MVP?
+
+- `search-plan`, `search-execute`, `search-rerank` as separate endpoints — collapse into `search-materialize`
+- `local_score` on `search_result_snapshots` — no implementation planned
+- `screenshot_artifact_path` on `fetch_artifacts` — debug-only, defer
+- `metadata_artifact_path` on `extraction_artifacts` — undefined contract
+- `report` as POST step — make it a GET query
+- Z.ai layout/OCR fallback — defer to post-MVP
+
+### Q7: What failure drills are missing before rollout?
+
+1. **SearXNG total outage**: Disable SearXNG, verify stale fallback works within policy, verify hard TTL fails when exceeded, verify alerting fires on consecutive stale fallbacks.
+2. **MinIO write failure**: Simulate MinIO unavailability during `read-fetch`, verify the step returns `failed` (not `partial` with missing artifacts), verify re-execution after MinIO recovery succeeds.
+3. **Backend step timeout**: Verify Windmill retries a step that takes longer than expected, and that the backend's idempotency key prevents double execution.
+4. **Concurrent step invocation**: Two Windmill workers call the same step with the same `idempotency_key` simultaneously. Verify only one execution completes and the second returns the first's result.
+5. **Manifest drift**: Windmill sends a step with a different manifest hash than the original run. Verify the backend rejects it.
+6. **Partial extraction**: A fetch succeeds but extraction fails (e.g., PDF parsing error). Verify the fetch artifact is persisted and the step is resumable from `extract` without re-fetching.
+7. **Rollback drill**: Disable new pipeline, re-enable existing cron endpoints, verify no data loss in pipeline tables, verify existing scripts still function.
+
+### Q8: What sequencing changes would reduce implementation risk?
+
+The current phase ordering is logical but has one risk: Phase 4 (SearXNG) and Phase 5 (Reader/Extraction) can proceed in parallel but share a dependency on Phase 3 (Backend Step Contracts). However, Phase 4 also depends on Phase 6 (SearXNG provisioning), which is infra work. Recommended reordering:
+
+1. **Phase 2 then Phase 3**: Schema then endpoints, as planned. No change.
+2. **Phase 6 before Phase 4**: Provision SearXNG before building the search materialization on top of it. If SearXNG provisioning reveals integration issues (e.g., Railway networking, rate limits), you want to know before building the search step.
+3. **Phase 5 and Phase 4 in parallel**: Once endpoints and SearXNG infra exist, reader/extraction and search materialization can be built concurrently since they are independent.
+4. **Phase 8 (observability) before Phase 9 (Windmill flows)**: You need artifact retention and observability in place before wiring Windmill flows that will generate real artifacts. Otherwise your first real run will produce artifacts with no cleanup mechanism.
+
+### Q9: Are there any security or data-retention risks in the proposed MinIO/raw artifact model?
+
+**Three risks:**
+
+1. **PII in fetched content**: Government websites sometimes include resident names, addresses, and contact information in meeting minutes and permit documents. Raw HTML/PDF artifacts stored in MinIO will contain this PII. The spec does not address PII handling or redaction. Recommendation: classify artifacts as PII-bearing at the `fetch_artifacts` level (add a `contains_pii` column or `content_classification` field) and apply stricter retention to PII-bearing artifacts.
+
+2. **No access control on MinIO objects**: The spec does not mention access control for MinIO artifacts. Pipeline artifacts should not be publicly accessible. If MinIO is configured with public read (common for development), raw HTML containing PII becomes a data exposure risk. Recommendation: enforce bucket-level access control and require authenticated reads for pipeline artifacts.
+
+3. **Indefinite report retention**: The spec's artifact path includes `pipeline-runs/<run_id>/reports/summary.md` with no stated retention. Reports are operator-facing and could contain summarized PII or sensitive source evaluation details. Define a retention window.
+
+### Q10: Should any logic currently proposed for backend belong in Windmill, or vice versa?
+
+**Two items:**
+
+1. **Freshness policy evaluation should stay in backend** (correct in spec). However, the freshness *policy parameters* should also be backend-owned, not Windmill-supplied. The manifest should reference a named policy, not pass raw hour values. This keeps the business rule in one place.
+
+2. **Slack alerting is listed as a Windmill responsibility** (correct for orchestration-level alerts like "step failed"). However, the spec should clarify that data-quality alerts (e.g., "search returning fewer results than expected", "extraction quality degraded") belong to the backend, not Windmill. Windmill should alert on *step execution health*; the backend should alert on *data quality*. The current spec does not distinguish these two alerting domains.
+
+---
+
+## Summary
+
+This spec represents a significant and well-thought-out improvement over the current architecture. The Z.ai chat-as-reader path in `run_universal_harvester.py` is genuinely brittle — it depends on a proprietary API for both search and content reading, has no intermediate persistence, and cannot resume from partial failure. The proposed pipeline fixes all three problems.
+
+The core contract (Windmill orchestrates, backend executes, everything is persisted) is right. The ten required spec changes are all additive — none require re-architecting. Implement the changes, then proceed with Phase 2.

--- a/docs/reviews/2026-04-11-windmill-persisted-pipeline-consultant-review.md
+++ b/docs/reviews/2026-04-11-windmill-persisted-pipeline-consultant-review.md
@@ -1,169 +1,73 @@
 # Consultant Review: Windmill-Driven Persisted Discovery Pipeline
 
-- **Spec under review:** `docs/specs/2026-04-11-windmill-driven-persisted-pipeline.md`
-- **Spec PR:** https://github.com/stars-end/affordabot/pull/415
-- **Spec PR head:** `385338ffce5108a0c15080c65946b1e11549fd31`
-- **Reviewer role:** External architecture consultant
-- **Beads:** epic `bd-jxclm`, subtask `bd-jxclm.11`
-- **Date:** 2026-04-11
-
-Tool routing exception: skipped `llm-tldr` / `serena` MCP navigation — the review scope is the spec document plus two adjacent files (`ops/windmill/README.md`, `backend/scripts/cron/run_universal_harvester.py`, `backend/services/llm/web_search_factory.py`) and a targeted Read was cheaper and sufficient than symbolic navigation across the whole repo.
+**Date:** 2026-04-11
+**Reviewer:** External Architecture Consultant
 
 ## Verdict
+**Verdict:** `approve_with_changes`
 
-**`approve_with_changes`**
-
-The architecture is directionally correct and the Windmill/backend split is the right one for a single-founder team. The spec is publishable as a reviewed design, but several concrete changes should be applied before the first implementation task (`bd-jxclm.2`) starts. Most of them are guardrails on freshness, schema, and MVP scope — not architectural rewrites.
+## Tool routing exception
+Tool routing exception: Semantic discovery via `llm-tldr` and symbol-aware navigation via `serena` were not required because the user explicitly provided the exact 4 file paths needed for the targeted architectural review.
 
 ## Top Risks (Ordered by Severity)
-
-1. **Silent staleness via "latest-good" fallback.** The spec allows stale search snapshots to back a run up to `max_search_stale_hours` (168h default). Without explicit, loud alerting on *every* fallback hit and a hard ceiling after N consecutive fallbacks, a quiet SearXNG outage can degrade discovery for a full week before a human notices. This is the single highest-blast-radius risk in the design.
-2. **Step API proliferation.** Ten `/internal/pipeline/*` endpoints at MVP is ~2–3× what a bounded single-jurisdiction run actually needs. Each endpoint adds auth coverage, contract tests, idempotency tests, and Windmill branch logic. For a founder-led team this is a concrete cognitive-load tax that the spec does not acknowledge.
-3. **Pipeline schema is large and sequenced too early.** Eight new tables (`pipeline_runs`, `pipeline_steps`, `search_queries`, `search_result_snapshots`, `pipeline_freshness_decisions`, `fetch_artifacts`, `extraction_artifacts`, `ingestion_jobs`) all land in Phase 2 before any business value is proven. Schema churn during Phases 4–5 is very likely and will be painful.
-4. **Unbounded MinIO growth with no retention in the MVP.** Retention is mentioned as a risk but is deferred to `bd-jxclm.8` and never defined numerically. Raw HTML + screenshots per fetch can grow fast per jurisdiction onboarded.
-5. **No pipeline contract version field in the canonical request/response envelope.** The spec mentions version drift in the risk section and says "include pipeline contract version in manifests and backend responses," but the Backend Step API example payloads in §"Backend Step API" do not include the field. This is a trivial but easy-to-forget omission that will bite at rollout.
-6. **Promotion step is described but not scope-gated.** Auto-promotion mentions "explicitly allowed families and high-confidence first-party surfaces" without specifying which families qualify at MVP. Without a gate, this becomes an open-ended policy surface.
-7. **Rollback plan is "additive" but does not specify the shadow-run period.** Phase 7 says rollback is "additive" and existing cron endpoints remain, but there is no explicit parity window ("run old and new in parallel for N days, compare X metric"). Without that, cutover is implicitly a flag flip.
-8. **Playwright and Z.ai OCR fallback are listed as Phase 5 scope but not sequenced behind measured need.** Both are operationally heavy (Playwright needs a runtime, Z.ai OCR is cost-metered). They should only land when direct HTTP + readability has been shown to fail for a quantified share of real pages.
-9. **No data classification or PII handling for raw HTML / screenshot artifacts.** Municipal pages are usually public, but screenshots and raw HTML may carry embedded third-party content, cookies in HAR-like captures, or staff contact details. The spec does not say this is intentionally out of scope.
-10. **`trigger_source` is free-form string.** This is fine for logs but should be explicitly not-load-bearing for routing or retry policy — a small note prevents the pattern from calcifying.
+1. **Unbounded Artifact Growth (MinIO Storage Exhaustion):** The introduction of raw HTML, PDF, and JSON snapshot artifacts for every search query could rapidly deplete storage. If MinIO lifecycle policies are not implemented *before* rollout, it will lead to an operational failure.
+2. **Hidden Stale Fallback Degradation:** While the spec includes `stale_backed=true` in decisions, without a loud observability hook in Windmill, a completely broken SearXNG could be masked for weeks if the maximum stale hours are set broadly.
+3. **Windmill Timeout Sync Vulnerability:** If a backend step (e.g., embedding or extraction) takes longer than Windmill's HTTP timeout, Windmill may retry the step while the backend is still running the first attempt. The backend must have strong locking or atomic upserts on the `idempotency_key`.
 
 ## Boundary Critique: Windmill vs Backend
+The proposed boundaries are well-defined and adhere to best practices. Windmill is correctly constrained to scheduling, branching, retries, and manifest-passing. Keeping the domain logic, table writes, and artifact persistence strictly within the affordabot backend prevents "orchestrator bloat" and maintains a clean single source of truth for business rules.
 
-**What the spec gets right:**
-- The prohibition list in §"Active Contract" (Windmill must not write `sources`, `raw_scrapes`, `document_chunks`, etc.) is the correct invariant. It matches the existing shared-instance pattern documented in `ops/windmill/README.md` and does not require a mental model change.
-- Pushing scoring, dedupe, and promotion into the backend is the right call. Windmill should never encode domain truth.
-- The step request envelope (`run_id`, `step_key`, `idempotency_key`, `trigger_source`, `manifest`) is the correct shape.
+## Persistence/Schema Critique
+The persistence schema successfully separates orchestration state (`pipeline_runs`, `pipeline_steps`) from domain state (`search_queries`, `fetch_artifacts`, `ingestion_jobs`). This separation allows for clean auditability and simplifies debugging. Moving large blobs (raw HTML, resulting markdown) into MinIO instead of Postgres is the right architectural choice to maintain DB health. 
 
-**What leaks or is ambiguous:**
-- **Retry policy ownership.** The spec says "Windmill is allowed to retry safe steps according to backend-declared retryability" and the response includes `retryable: true|false`. Good. But the spec does not say whether retry *count* is a Windmill policy or a backend policy. If Windmill owns it, a flow-version bump changes retry behavior silently. Recommendation: backend returns `retryable`, `max_retries`, and `retry_after_seconds`; Windmill obeys, does not guess.
-- **`next_recommended_step` in the response.** This quietly moves a flow-graph decision from Windmill into the backend. It is a hint, but Windmill flow authors may code against it. Either declare it advisory-only in the spec or remove it and let Windmill own the DAG. I recommend declaring it advisory, because the backend is the only component that knows whether a step's output justifies skipping ahead, but the flow-graph itself must stay declarative in Windmill.
-- **Alerting ownership.** Spec says Windmill "send Slack/operator alerts." Good. But freshness/stale-backed alerts are semantically a backend concern (the backend is the only thing that knows `stale_backed=true`). Clarify: backend emits the alert *content* in `operator_summary` + a structured `alerts[]` field; Windmill is the dumb transport.
-- **Contract version.** Must move from risk section into the mandatory envelope as noted in Risk 5.
-
-**Net assessment:** the boundary is ~90% right. The remaining 10% is ownership of retry *policy*, alert *content*, and the advisory nature of `next_recommended_step`.
-
-## Persistence / Schema Critique
-
-The schema is well-normalized and lineage-preserving, which is good for audit. It is also larger than MVP warrants.
-
-**Concrete critiques:**
-- **`pipeline_steps` and `pipeline_runs` can land at MVP.** Everything else can be staged.
-- **`search_queries` as a registry table is premature.** At MVP a manifest-driven list is enough. A registry table becomes necessary when (a) the same query must fire across multiple runs on different cadences, or (b) operators need to edit queries without a deploy. Neither is true on day one.
-- **`pipeline_freshness_decisions` is one table too many.** The decision is a property of the step that consumed the snapshot; it belongs as columns on `pipeline_steps` (`freshness_policy`, `stale_backed`, `latest_success_at`, `decision_reason`) or as a single JSON column. A dedicated table is "correct" but introduces an avoidable join and a second place to keep consistent.
-- **`fetch_artifacts` and `extraction_artifacts` should not both be tables at MVP.** Collapse into one `content_artifacts` row with an `artifact_kind` enum (`fetch`, `extraction`, `screenshot`). This preserves lineage via `parent_artifact_id` without doubling the migration surface.
-- **`search_result_snapshots.provider_endpoint_hash` is good** — that is exactly the kind of field that lets a post-mortem distinguish two SearXNG instances. Keep it.
-- **`idempotency_key` format.** Spec suggests `run_id:step_key:manifest_hash`. Good, but note that `manifest_hash` must be a stable canonical serialization (sorted keys, no whitespace variance). Add a one-line note to prevent silent cache misses.
-- **Missing:** `pipeline_runs.contract_version` and `pipeline_steps.contract_version`. This is the persistence home for Risk 5.
-- **Missing:** an explicit `pipeline_runs.parent_run_id` for "resume from failed step" lineage. Without it, a resumed run either overwrites the original (loses history) or has no link back (loses audit).
-- **Missing:** `pipeline_runs.jurisdiction_id` as a first-class column for cheap filtering. Putting it only in the manifest makes ops queries painful.
-
-## Freshness / Latest-Good Fallback Critique
-
-Latest-good fallback is the riskiest feature in the design because it turns a loud failure (SearXNG down) into a quiet success. The spec mitigations are directionally right but insufficient.
-
-**What must be added to the spec before implementation:**
-1. **Hard ceiling on consecutive fallbacks.** After N (recommended: 2) consecutive runs that fallback for the same `query_key`, the run must fail closed, not degrade silently further. N should be configurable per source family.
-2. **Alert on *every* fallback, not just on refresh failure.** Currently the spec says "Windmill should still alert on refresh failure." That is necessary but not sufficient — if the refresh step *itself* marks partial and returns stale-backed results, Slack should get it.
-3. **Fallback telemetry as a first-class metric.** Add `stale_backed_count` to the run summary. Operator should be able to see "N of M query keys used stale fallback" at a glance, not dig through step rows.
-4. **`max_stale_hours` per source family, not global.** Permit pages rot faster than municipal code. 168h is probably too generous for meetings, too tight for code. Make the 168h value a default, not a policy.
-5. **Fallback must preserve the *original* `provider_endpoint_hash`** so a post-mortem can distinguish "SearXNG was up but the provider was different" from "we used a 6-day-old snapshot".
-6. **Explicit "no fallback on empty result set" rule.** If SearXNG returns `200 OK` with zero results, that is *not* a failure and must not trigger latest-good. Zero-result is a real state that should surface as `created_count: 0`. The spec does not currently distinguish these.
-
-## MVP Cut Recommendations
-
-The spec has 7 execution phases and 10 subtasks. For a founder-led team the MVP that delivers business value is smaller than what is currently sequenced.
-
-**Cut from MVP (defer to post-parity):**
-- `bd-jxclm.6` Private SearXNG provisioning as a *blocking* dependency. Start with the existing Z.ai search path behind the new step contract; swap the backend of `/internal/pipeline/search-execute` to SearXNG as a later, isolated change. This lets the pipeline skeleton land without waiting on infra.
-- `pipeline_freshness_decisions` table (fold into `pipeline_steps`, see schema critique).
-- `search_queries` registry table (use manifest-driven queries at MVP).
-- `fetch_artifacts` + `extraction_artifacts` as two separate tables (collapse into `content_artifacts`).
-- `/internal/pipeline/search-rerank` as a separate endpoint — merge into `search-execute` at MVP. Rerank logic is small enough to live inside the execute step until there is a demonstrated need for a re-rank-only pass.
-- `/internal/pipeline/promote` endpoint at MVP. Promotion is an explicit non-goal for day-one trust (spec says promotion is a separate concern). Run the MVP in `capture_only` mode and have promotion land in a later wave.
-- Playwright fallback at MVP. Require direct HTTP + readability only, with failures recorded. Add Playwright when a measured >X% of real target pages require it.
-- Z.ai layout/OCR fallback at MVP. Same reasoning — bounded hard-document fallback can land after parity is proven.
-- `pipeline_retry_step` dedicated Windmill flow. A single `pipeline_manual_run` flow with a `resume_from_step` manifest field is enough at MVP.
-
-**Keep at MVP:**
-- `pipeline_runs`, `pipeline_steps` (with freshness columns inlined).
-- `/internal/pipeline/runs`, `/search-execute`, `/read-fetch`, `/extract`, `/embed`, `/report` — six endpoints, not ten.
-- `search_result_snapshots` + `content_artifacts` tables.
-- MinIO artifact layout (keep as designed).
-- Daily Windmill flow + manual Windmill flow.
-
-**Result:** one round of schema migration instead of three, six endpoints instead of ten, no infra block on SearXNG provisioning.
-
-## Failure Drills Missing Before Rollout
-
-The Runtime Smokes section is reasonable but skews toward happy-path verification. The following drills must be exercised before calling the rollout complete:
-
-1. **Crash-mid-step drill.** Kill the backend process while a `/read-fetch` step is mid-write to MinIO + Postgres. Verify the step row reflects the actual terminal state on restart, not a zombie `running`.
-2. **Partial MinIO write drill.** Simulate an S3/MinIO 500 during an artifact write. Verify the step returns `failed` (or `partial` only if safe) and does not leave a half-written row pointing to a non-existent artifact.
-3. **Idempotency replay drill.** Call the same endpoint with the same `idempotency_key` twice, concurrently. Verify one wins cleanly and the other returns the original result with `reused_count > 0`.
-4. **Contract-version skew drill.** Call a v2 endpoint with a v1 manifest. Verify fail-closed behavior, not silent coercion.
-5. **Stale-ceiling drill.** Simulate SearXNG down for three consecutive runs. Verify the run fails closed after N=2 and alerts fire.
-6. **Resume-from-failed-step drill.** Fail a run at `extract`, then call the manual flow with `resume_from_step=extract` and verify upstream `read-fetch` results are reused, not redone.
-7. **Rollback drill.** With new pipeline running, disable the Windmill schedule and re-trigger the old cron endpoint. Verify zero data loss and zero cross-contamination of run tables.
-8. **Auth-drift drill.** Rotate `CRON_SECRET`. Verify the Windmill flow and the backend fail loudly in the same window rather than one side failing silently.
+## Freshness Fallback Critique
+The "latest-good fallback" mechanism is intelligent for handling external SearXNG flakiness. However, it is paramount that Windmill triggers a non-fatal alert when a fallback occurs. Silent usage of stale data can be as dangerous as no data in a financial/legislative context. The inclusion of `status`, `freshness_policy`, and `stale_backed` flags in `pipeline_freshness_decisions` is necessary but sufficient only if actively monitored.
 
 ## Required Spec Changes Before Implementation
+1. **Idempotency Locking:** Specifically address how the backend will handle concurrent requests for the same `idempotency_key` (e.g., if Windmill times out and retries while the backend is still processing the first request).
+2. **Alerting on Fallback:** Update the Windmill Flow orchestration (Phase 6) to include a requirement that Windmill sends a Slack alert to the operator when `stale_backed` is true, ensuring operators know the system is masking a SearXNG outage.
+3. **Data Retention Timelines:** Explicitly define the TTL (Time-To-Live) / Retention policy for MinIO raw artifacts in Phase 2 or Phase 8.
 
-These are the blocking edits to the spec document. None are architectural rewrites; all are tightening.
-
-1. Add `contract_version` to the canonical request and response envelopes (§"Backend Step API").
-2. Add `alerts: [{severity, code, summary}]` to the canonical response envelope.
-3. Change `retryable: true|false` to `retry: { retryable, max_retries, retry_after_seconds }` and declare that Windmill obeys these values rather than setting its own.
-4. Declare `next_recommended_step` as advisory-only; the Windmill DAG remains the source of truth for flow graph.
-5. Under §"Persistence Model", mark `pipeline_freshness_decisions`, `search_queries`, `fetch_artifacts`, and `extraction_artifacts` as **Phase 3+**, not Phase 2. Collapse fetch/extraction into `content_artifacts` at MVP.
-6. Add `pipeline_runs.contract_version`, `pipeline_runs.parent_run_id`, `pipeline_runs.jurisdiction_id`, `pipeline_runs.stale_backed_count` columns.
-7. Add a §"Freshness Policy" subsection covering: per-family `max_stale_hours`, hard ceiling on consecutive fallbacks, always-alert on `stale_backed=true`, zero-result is not a failure.
-8. Add §"Retention" numeric defaults (recommended starting values: 30d for raw fetch HTML, 90d for extracted markdown, 7d for debug screenshots, indefinite for `pipeline_runs` and `pipeline_steps` rows).
-9. Move private SearXNG (`bd-jxclm.6`) off the MVP blocking path; document that MVP may run with the existing search backend behind the new step contract.
-10. Document the parity window in §"Rollback": explicit duration, explicit pass/fail criteria, explicit metric comparison (e.g., "7 days, ≥95% equivalent created_count per jurisdiction, zero net new failures").
-11. State that raw HTML and screenshot artifacts are assumed public-data-only and that any PII-handling policy is out of scope for this epic (or in scope with a concrete plan).
+## MVP Cut Recommendations
+- **Search Rerank Step (`search_rerank`):** This is likely an optimization that isn't strictly required to prove pipeline correctness.
+- **Complex Extraction Layers:** Defer the Playwright (JS-heavy) and OCR (Z.ai fallback) pathways for Phase 1 MVP. Stick to strict HTTP fetch + standard readability extraction to validate the whole pipeline flow end-to-end sooner.
 
 ## Optional Future Improvements
-
-- A `pipeline_dashboard` materialized view for operator queries (runs, durations, stale counts).
-- Trace correlation: propagate a W3C traceparent from Windmill → backend → artifacts for cross-tool debugging.
-- Backfill tooling to replay a historical `pipeline_run` from its persisted artifacts — useful for prompt/model upgrades without re-fetching.
-- Content-hash-based dedupe across runs (not just within a run) for `content_artifacts`.
-- A `pipeline_run_diffs` helper that compares two runs of the same manifest to expose drift.
-- Export of run summaries to Beads as an `evidence` attachment on the originating subtask.
-
-## Direct Answers to Review Questions
-
-**1. Windmill as orchestrator vs domain executor — does business logic leak?**
-Mostly no, with two thin leaks: (a) retry policy is implicitly Windmill-owned, and (b) `next_recommended_step` risks encoding flow-graph decisions on the backend side. Both are fixable in the spec with two sentences. The §"Active Contract" prohibition list is strong and matches the existing shared-instance pattern in `ops/windmill/README.md`.
-
-**2. Are the backend step endpoints too fine, too coarse, or appropriately resumable?**
-Too fine. Ten endpoints at MVP is ~2× what a single bounded run needs. Merge `search-rerank` into `search-execute`, defer `promote` to post-MVP, and the remaining six endpoints are appropriately resumable.
-
-**3. Is the proposed schema enough for auditability and replay without avoidable operational burden?**
-Over-built for MVP. Eight tables can compress to four: `pipeline_runs`, `pipeline_steps`, `search_result_snapshots`, `content_artifacts`. Freshness decisions fold into `pipeline_steps`. The full schema is a good *eventual* target, not a good starting migration.
-
-**4. Is latest-good fallback safe? What metadata / alerting is missing?**
-Not yet safe. Missing: consecutive-fallback ceiling, per-family `max_stale_hours`, always-alert on `stale_backed=true`, zero-result vs failure distinction, preservation of original `provider_endpoint_hash`, and a `stale_backed_count` summary metric. See "Freshness / Latest-Good Fallback Critique" for the full list.
-
-**5. Are SearXNG, reader, MinIO, Postgres, pgvector responsibilities separated cleanly?**
-Yes. The spec correctly treats SearXNG as a *primitive* returning candidates, reader/extraction as persisted evidence, MinIO as bulk artifact home, Postgres as state-of-record, and pgvector as downstream ingestion only. The one nuance: the spec should say explicitly that `document_chunks` writes are the *only* place pgvector is mutated by the pipeline.
-
-**6. Which pieces should be cut from MVP?**
-Private SearXNG provisioning as a blocker, `pipeline_freshness_decisions` table, `search_queries` registry table, split fetch/extraction tables, `search-rerank` endpoint, `promote` endpoint, Playwright fallback, Z.ai OCR fallback, and the dedicated `pipeline_retry_step` flow. See "MVP Cut Recommendations" for details.
-
-**7. What failure drills are missing before rollout?**
-Eight drills listed above. The critical four are: crash-mid-step, partial MinIO write, idempotency replay, and stale-ceiling fail-closed.
-
-**8. What sequencing changes would reduce implementation risk?**
-Reorder so that `bd-jxclm.2` ships the *reduced* schema (four tables), `bd-jxclm.3` ships only the six MVP endpoints, `bd-jxclm.4` lands with the *existing* search backend (not SearXNG), `bd-jxclm.5` ships reader with direct HTTP + readability only (no Playwright, no OCR), `bd-jxclm.9` ships the daily + manual flows, and `bd-jxclm.6/.7/.8` and `.10` run in parallel after the skeleton exists. This sequences value in front of infra rather than behind it.
-
-**9. Security or data-retention risks in MinIO / raw artifact model?**
-Three: (a) no numeric retention is committed in-spec, (b) raw HTML screenshots may carry third-party tracking content or contact details, (c) MinIO bucket ACLs are not mentioned. All three should be explicitly either in scope with a plan or declared out of scope with a rationale. Recommend explicit numeric retention in §"Retention" and a one-line statement that MinIO buckets are private with backend-only access.
-
-**10. Should any logic currently proposed for backend belong in Windmill, or vice versa?**
-No "backend → Windmill" moves are warranted — the backend bias is correct. One small "Windmill → backend" move: the alert *content* for freshness and promotion should be constructed in the backend (returned in `operator_summary` + `alerts[]`) and Windmill should be a dumb transport, not a message formatter. Everything else can stay where the spec puts it.
+- **Automated Replay Testing:** Once idempotent steps exist, create a dedicated test environment that reruns pipeline events against stale snapshots to test the recovery paths safely off-production.
+- **Circuit Breakers for SearXNG:** Instead of waiting for per-query timeouts, implement a rapid-failure circuit breaker to switch to fallback mode earlier if the first 3 SearXNG requests fail globally.
 
 ---
 
-**Summary.** Approve with the spec edits above. The direction is correct; the MVP shape is slightly too ambitious for a founder-led team and the freshness semantics need two paragraphs of tightening. After those edits, `bd-jxclm.2` is a safe place to start implementation.
+## Direct Answers to Review Questions
+
+**1. Does the spec keep Windmill as orchestrator and affordabot backend as domain executor, or does business logic still leak across the boundary?**
+Yes, it strictly maintains the boundary. Windmill is passed a manifest and routes HTTP calls, but the actual domain decisions (like what constitutes a valid source) and database writes remain in the affordabot backend.
+
+**2. Are the backend step endpoints too fine-grained, too coarse, or appropriately resumable?**
+They are appropriately resumable. Steps like `search-plan`, `fetch`, and `extract` represent specific, retryable jobs that each produce a durable outcome.
+
+**3. Is the proposed schema enough for auditability and replay without creating avoidable operational burden?**
+Yes, the explicit separation of step execution metadata and artifact persistence (MinIO) guarantees auditability without bogging down the relational database.
+
+**4. Is latest-good fallback safe? What metadata or alerting is missing to prevent silent stale behavior?**
+The metadata (`stale_backed` column) exists, but the alerting behavior is missing. Windmill must alert operators when `stale_backed=true` to prevent prolonged masking of Search API outages.
+
+**5. Are SearXNG, reader/fetcher, MinIO artifacts, Postgres, and pgvector responsibilities separated cleanly?**
+Yes. SearXNG acts purely as candidate generation. MinIO handles blob storage, Postgres manages relational step state, and pgvector handles embeddings derived only from the extracted artifacts.
+
+**6. Which pieces should be cut from MVP?**
+Cut `search_rerank`, Playwright-based fetching, and OCR fallbacks. Focus strictly on direct HTTP fetching and pipeline idempotency.
+
+**7. What failure drills are missing before rollout?**
+- SearXNG complete outage simulation to verify alert firing.
+- Windmill execution timeout handling to verify backend idempotency locks.
+- MinIO write failure handling.
+
+**8. What sequencing changes would reduce implementation risk?**
+Move `bd-jxclm.8` (Infra: define artifact storage retention and observability) to an earlier phase (Phase 2 alongside schema design). Storage limits must be bounded early before tests write gigabytes of HTML.
+
+**9. Are there any security or data-retention risks in the proposed MinIO/raw artifact model?**
+Yes, retaining raw artifacts indefinitely can expose PII or copyrighted material and consume tremendous storage. A strict, automated retention policy (e.g., 14 or 30 days max for raw data) is mandatory.
+
+**10. Should any logic currently proposed for backend belong in Windmill, or vice versa?**
+No, the boundary is optimal as defined. Windmill handles scheduling and inputs, while the backend processes all states and artifacts.

--- a/docs/specs/2026-04-11-windmill-driven-persisted-pipeline.md
+++ b/docs/specs/2026-04-11-windmill-driven-persisted-pipeline.md
@@ -1,0 +1,508 @@
+# Windmill-Driven Persisted Discovery Pipeline
+
+## Summary
+
+Affordabot should move offline discovery, search refresh, page reading, extraction, ingestion, and QA reporting into a Windmill-orchestrated, backend-executed, persisted pipeline. Windmill should own scheduling, step orchestration, retries, run visibility, and operator entrypoints. The affordabot backend should own all business logic, domain validation, table writes, artifact writes, freshness policy, source promotion, and pgvector ingestion.
+
+This keeps Windmill useful without turning it into a second backend.
+
+## Problem
+
+The current scheduled ingestion model is too script-shaped for broad source expansion. Several jobs run as large backend scripts behind Windmill trigger endpoints, which gives basic schedule visibility but weak step-level resumeability. If one late stage fails, earlier successful work is not always first-class reusable state.
+
+The current web discovery and reader surfaces also blur provider responsibilities:
+
+- Search/discovery can be served by an OSS SearXNG-compatible endpoint, but public SearXNG instances are not reliable production dependencies.
+- The universal harvester currently asks Z.ai chat plus a web-search tool to read a URL and return markdown. That makes page reading opaque, quota-bound, and difficult to debug.
+- Search results, fetched source content, extracted markdown, source promotion decisions, and vector ingestion are not consistently represented as durable intermediate artifacts with freshness gates.
+
+The desired system needs to continue working when external search is temporarily down, avoid repeating successful upstream work, and preserve an audit trail for source truth.
+
+## Goals
+
+- Make Windmill the orchestrator for scheduled and manual offline data pipeline runs.
+- Keep affordabot backend as the only owner of domain logic and writes to affordabot domain tables.
+- Persist every meaningful intermediate state: search plan, search result snapshots, freshness decisions, fetched raw content, extracted markdown, ingestion jobs, vector chunks, and run reports.
+- Use private SearXNG as the recurring search primitive for candidate generation.
+- Support latest-good fallback when SearXNG fails and prior search snapshots are still within freshness policy.
+- Replace the opaque Z.ai chat-as-reader path for normal pages with backend-owned reader/extraction stages.
+- Keep Z.ai or OCR/layout services as bounded fallbacks for hard documents, not as the default control plane.
+- Make every step idempotent and resumable by `run_id`, `step_key`, and idempotency key.
+- Provide enough persisted evidence for operator review and external consultant review.
+
+## Non-Goals
+
+- Do not move affordabot domain writes directly into Windmill scripts.
+- Do not make Windmill workers mount the affordabot repo and run internal Python modules directly as the primary execution model.
+- Do not use public SearXNG instances for production scheduled runs.
+- Do not treat search snapshots as accepted source truth.
+- Do not rewrite user-facing advisor/chat flows around Windmill.
+- Do not remove existing cron endpoints until the new pipeline proves parity and rollback is documented.
+
+## Active Contract
+
+After this epic, the canonical offline pipeline contract should be:
+
+```text
+Windmill flow
+  -> authenticated backend pipeline endpoint
+  -> backend creates/updates pipeline run state
+  -> backend executes one domain step
+  -> backend persists step output and artifacts
+  -> backend returns explicit step status and next-step metadata
+  -> Windmill branches/retries/reports based on response
+```
+
+Windmill is allowed to:
+
+- schedule daily and manual runs
+- pass manifests, `run_id`, `step_key`, and operator inputs
+- call authenticated backend endpoints
+- branch on backend response status
+- retry safe steps according to backend-declared retryability
+- record orchestration logs
+- send Slack/operator alerts
+
+Windmill is not allowed to:
+
+- write `sources`, `raw_scrapes`, `document_chunks`, source review tables, or pipeline domain tables directly
+- implement SearXNG result scoring, source truth scoring, source promotion, content hashing, or vector ingestion
+- hold unversioned business rules that must stay aligned with backend code
+- silently coerce failed backend steps into success
+
+The backend is required to:
+
+- own all Postgres, pgvector, and MinIO writes
+- enforce auth and idempotency
+- validate manifests and source-family policies
+- evaluate freshness and stale fallback
+- persist raw and normalized artifacts
+- return explicit status payloads suitable for Windmill branching
+- fail loudly when durable state or artifact writes fail
+
+## Architecture / Design
+
+### Control Plane
+
+Windmill remains the operational control plane. Existing affordabot Windmill assets already document the shared-instance pattern: Windmill calls authenticated backend cron endpoints and backend executes the job. The new design extends that pattern from monolithic cron endpoints to step-oriented pipeline endpoints.
+
+New flows should live under the existing Windmill workspace namespace, for example:
+
+```text
+f/affordabot/pipeline_daily_refresh
+f/affordabot/pipeline_manual_run
+f/affordabot/pipeline_retry_step
+```
+
+The Windmill flow should pass an input manifest, not business logic:
+
+```json
+{
+  "run_label": "daily-discovery-refresh",
+  "run_mode": "capture_and_ingest",
+  "jurisdictions": ["Saratoga CA"],
+  "families": ["meetings", "permits", "municipal_code"],
+  "freshness_policy": "use_last_good_if_search_fails",
+  "max_search_stale_hours": 168,
+  "max_document_stale_hours": 720,
+  "sample_size_per_bucket": 5,
+  "operator_notes": "bounded daily refresh"
+}
+```
+
+### Backend Step API
+
+Prefer step endpoints that are coarse enough to be meaningful and fine enough to resume:
+
+```text
+POST /internal/pipeline/runs
+POST /internal/pipeline/search-plan
+POST /internal/pipeline/search-execute
+POST /internal/pipeline/search-rerank
+POST /internal/pipeline/freshness-gate
+POST /internal/pipeline/read-fetch
+POST /internal/pipeline/extract
+POST /internal/pipeline/embed
+POST /internal/pipeline/promote
+POST /internal/pipeline/report
+```
+
+Every request should include:
+
+```json
+{
+  "run_id": "uuid",
+  "step_key": "search_execute",
+  "idempotency_key": "run_id:step_key:manifest_hash",
+  "trigger_source": "windmill:f/affordabot/pipeline_daily_refresh",
+  "manifest": {}
+}
+```
+
+Every response should include:
+
+```json
+{
+  "status": "succeeded|failed|partial|skipped",
+  "run_id": "uuid",
+  "step_key": "search_execute",
+  "retryable": true,
+  "created_count": 0,
+  "reused_count": 0,
+  "failed_count": 0,
+  "artifact_paths": [],
+  "next_recommended_step": "search_rerank",
+  "operator_summary": "plain English summary"
+}
+```
+
+### Persistence Model
+
+The schema should separate orchestration state from domain state.
+
+Pipeline state:
+
+```text
+pipeline_runs
+- id
+- run_label
+- run_mode
+- manifest_hash
+- trigger_source
+- status
+- started_at
+- finished_at
+- created_by
+- summary
+- error_summary
+
+pipeline_steps
+- id
+- run_id
+- step_key
+- idempotency_key
+- status
+- started_at
+- finished_at
+- created_count
+- reused_count
+- failed_count
+- retryable
+- error_code
+- error_detail
+- artifact_manifest
+```
+
+Search state:
+
+```text
+search_queries
+- id
+- query_key
+- jurisdiction_id
+- source_family
+- query_text
+- cadence
+- enabled
+- max_stale_hours
+
+search_result_snapshots
+- id
+- run_id
+- query_key
+- query_text
+- provider
+- provider_endpoint_hash
+- observed_at
+- rank
+- title
+- url
+- snippet
+- normalized_domain
+- provider_score
+- local_score
+- raw_artifact_path
+- raw_payload_hash
+```
+
+Freshness decisions:
+
+```text
+pipeline_freshness_decisions
+- id
+- run_id
+- decision_key
+- input_kind
+- input_ref
+- status
+- freshness_policy
+- latest_success_at
+- max_stale_hours
+- stale_backed
+- decision_reason
+```
+
+Reader and extraction state:
+
+```text
+fetch_artifacts
+- id
+- run_id
+- canonical_url
+- fetched_at
+- status
+- http_status
+- content_type
+- content_hash
+- raw_artifact_path
+- screenshot_artifact_path
+- error_code
+
+extraction_artifacts
+- id
+- run_id
+- fetch_artifact_id
+- extraction_method
+- status
+- markdown_hash
+- markdown_artifact_path
+- metadata_artifact_path
+- error_code
+```
+
+Ingestion state:
+
+```text
+ingestion_jobs
+- id
+- run_id
+- extraction_artifact_id
+- content_hash
+- embedding_model
+- status
+- chunk_count
+- reused_existing_chunks
+- error_code
+```
+
+Existing domain tables such as `sources`, `raw_scrapes`, source review queues, and `document_chunks` remain backend-owned. Pipeline tables can point at those domain records, but Windmill must never write them directly.
+
+### Artifact Storage
+
+MinIO should hold raw and intermediate artifacts that are too large or too operationally useful for normal relational rows:
+
+```text
+pipeline-runs/<run_id>/search/<query_key>/raw.json
+pipeline-runs/<run_id>/fetch/<content_hash>/raw.html
+pipeline-runs/<run_id>/fetch/<content_hash>/source.pdf
+pipeline-runs/<run_id>/extract/<markdown_hash>/content.md
+pipeline-runs/<run_id>/debug/<step_key>/screenshot.png
+pipeline-runs/<run_id>/reports/summary.md
+```
+
+Artifact writes are part of the backend step contract. If the step cannot persist the required artifact, the step should fail or return `partial` only when the partial state is explicitly safe to resume.
+
+### Search Boundary
+
+Private SearXNG is a search primitive, not a truth engine. It should return candidate URLs and snippets. The backend owns:
+
+- query registry and query generation
+- provider selection and endpoint config
+- normalized URL extraction
+- dedupe
+- official-domain scoring
+- source-family scoring
+- freshness fallback
+- promotion to review queue or source inventory
+
+The recurring daily search job should materialize search snapshots for known query keys. Runtime consumers should prefer recent snapshots and only live-search on cache misses or explicitly allowed ad hoc work.
+
+### Reader Boundary
+
+The current Z.ai chat-as-reader behavior should be replaced for ordinary pages. The backend reader pipeline should use:
+
+1. direct HTTP fetch
+2. readability/trafilatura-style extraction
+3. Playwright fallback for JavaScript-heavy pages
+4. PDF extraction path for PDFs
+5. Z.ai layout/OCR only for hard-document fallback when local extraction fails or policy says OCR is allowed
+
+The reader result is not source truth. It is persisted evidence for scoring, extraction, review, and ingestion.
+
+### Source Promotion Boundary
+
+Promotion to accepted source inventory should remain separate from search snapshots and extraction artifacts.
+
+Search snapshots answer: "What did a provider return for this query?"
+
+Fetch/extraction answers: "What content did this URL expose at this time?"
+
+Promotion answers: "Should affordabot trust this URL/family as an accepted source?"
+
+The backend should implement promotion as a policy-driven step:
+
+- auto-promote only for explicitly allowed families and high-confidence first-party surfaces
+- otherwise create candidate review items
+- record rejection reasons and confidence signals
+- preserve lineage back to search/fetch/extraction artifacts
+
+## Execution Phases
+
+### Phase 1: Specification and Review
+
+- Commit this spec.
+- Publish a draft PR so external reviewers can inspect it cross-VM.
+- Run consultant review before implementation starts.
+
+### Phase 2: Pipeline State and Artifacts
+
+- Add schema migrations and model/service layer for pipeline runs, steps, snapshots, decisions, fetch artifacts, extraction artifacts, and ingestion jobs.
+- Define MinIO prefixes and retention policy.
+- Add idempotency and status transition tests.
+
+### Phase 3: Backend Step Contracts
+
+- Add authenticated internal endpoints for each step.
+- Ensure each endpoint can be called repeatedly with the same idempotency key.
+- Ensure each endpoint returns Windmill-friendly status payloads.
+
+### Phase 4: Materialized SearXNG Search
+
+- Provision and configure private SearXNG.
+- Implement search plan, execute, normalize, rerank, snapshot, and latest-good fallback.
+- Prove failure behavior by disabling SearXNG and continuing from an acceptable prior snapshot.
+
+### Phase 5: Reader, Extraction, and Ingestion
+
+- Implement fetch, extraction, content hash reuse, markdown artifact writes, and pgvector ingestion freshness.
+- Replace normal-page dependence on Z.ai chat-as-reader.
+- Preserve Z.ai layout/OCR as a bounded hard-document fallback.
+
+### Phase 6: Windmill Flow Orchestration
+
+- Add daily and manual Windmill flows that call backend step endpoints.
+- Branch on backend status and retryability.
+- Emit Slack/operator summaries.
+- Keep Windmill scripts thin and free of domain writes.
+
+### Phase 7: Validation and Rollout
+
+- Run a bounded end-to-end flow for one jurisdiction and a small family set.
+- Validate persisted intermediates, stale fallback, artifact retention, and resume-from-failed-step.
+- Document rollback to existing cron/script behavior until replacement is proven.
+
+## Beads Structure
+
+- Epic: `bd-jxclm` - Design Windmill-driven persisted discovery pipeline
+- First task: `bd-jxclm.1` - Write Windmill-driven pipeline implementation spec
+- `bd-jxclm.2` - Add persisted pipeline state and artifact schema
+- `bd-jxclm.3` - Implement backend pipeline step endpoints
+- `bd-jxclm.4` - Materialize SearXNG search refresh with freshness gating
+- `bd-jxclm.5` - Build reader, extraction, and artifact materialization stages
+- `bd-jxclm.6` - Infra: provision private SearXNG search service
+- `bd-jxclm.7` - Infra: wire Windmill and Railway runtime configuration
+- `bd-jxclm.8` - Infra: define artifact storage retention and observability
+- `bd-jxclm.9` - Add Windmill orchestration flows and run controls
+- `bd-jxclm.10` - Add pipeline validation, rollout, and operator runbooks
+
+Dependency summary:
+
+- All implementation and infra tasks depend on `bd-jxclm.1`.
+- Backend endpoints depend on schema.
+- Materialized SearXNG search depends on schema, endpoints, and private SearXNG provisioning.
+- Reader/extraction depends on schema, endpoints, and artifact retention policy.
+- Windmill flows depend on backend endpoints, materialized search, reader/extraction, and Windmill/Railway config.
+- Validation depends on Windmill flows, SearXNG provisioning, and artifact observability.
+
+## Validation
+
+### Unit and Contract Tests
+
+- Pipeline state transition tests.
+- Idempotency tests for every backend endpoint.
+- Auth tests for internal pipeline endpoints.
+- Windmill contract tests for required variables, headers, and trigger source.
+- Freshness policy tests for fresh, stale-acceptable, stale-rejected, and no-prior-snapshot states.
+- Artifact write/read tests for MinIO paths and failure handling.
+
+### Runtime Smokes
+
+1. Private SearXNG endpoint returns JSON from backend runtime.
+2. Windmill manual flow triggers backend and backend records `X-PR-CRON-SOURCE`.
+3. A bounded run for one jurisdiction writes search snapshots.
+4. A second run with unchanged content reuses prior fetch/extraction/embedding state.
+5. A simulated SearXNG outage uses latest-good search snapshots if within policy.
+6. A simulated artifact write failure marks the step failed or partial with visible operator summary.
+7. The final report links run id, step ids, artifact paths, and accepted/rejected candidate counts.
+
+### Completion Proof
+
+The epic is not complete until a bounded Windmill-triggered run produces:
+
+- `pipeline_runs` row with terminal success or expected partial state
+- step rows for search, freshness, read/fetch, extraction, embedding, promotion/reporting
+- persisted search snapshot rows
+- at least one raw artifact in MinIO
+- at least one extracted markdown artifact or explicit extraction skip reason
+- pgvector/document chunk reuse or ingestion evidence
+- Slack/operator report
+- rollback instructions
+
+## Risks / Rollback
+
+### Windmill Becomes a Second Backend
+
+Risk: business logic leaks into Windmill scripts.
+
+Mitigation: keep Windmill flow code limited to HTTP calls, status branching, retries, and alerts. Backend endpoints own all writes and policy.
+
+### Stale Search Results Hide Outages
+
+Risk: latest-good fallback masks SearXNG failures.
+
+Mitigation: allow stale fallback only inside explicit policy and always mark `stale_backed=true`. Windmill should still alert on refresh failure.
+
+### Search Snapshots Become Accepted Truth
+
+Risk: search result rows are treated as trusted sources.
+
+Mitigation: promotion remains a separate backend step with review/acceptance state and lineage.
+
+### Artifact Growth
+
+Risk: raw search/fetch/extraction artifacts grow without bounds.
+
+Mitigation: implement retention windows, size budgets, and MinIO lifecycle cleanup before broad rollout.
+
+### Version Drift Between Windmill and Backend
+
+Risk: a Windmill flow calls endpoint contracts from a different backend version.
+
+Mitigation: include pipeline contract version in manifests and backend responses. Fail closed on unsupported versions.
+
+### Rollback
+
+Rollback should be additive:
+
+1. Disable new Windmill pipeline schedules.
+2. Keep manual flow disabled except for repair.
+3. Re-enable or call existing cron endpoints/scripts while preserving newly written pipeline tables.
+4. Do not delete pipeline artifacts until retention policy confirms they are not needed for diagnosis.
+
+## Recommended First Task
+
+Start with `bd-jxclm.2`, after this spec is reviewed. The persisted state model is the foundation for every later step. Without schema, idempotency, and artifact references, the system cannot safely resume, reuse latest-good results, or prove what happened during a Windmill run.
+
+## External Consultant Review Prompt
+
+Use the pushed PR for this spec as the source of truth. The consultant should review the design before implementation and focus on business logic boundaries, failure modes, and operational simplicity.
+
+Required review questions:
+
+1. Does the Windmill/backend boundary keep domain logic in affordabot while still making Windmill useful as an orchestrator?
+2. Are the proposed step boundaries too fine, too coarse, or appropriately resumable?
+3. Is the schema sufficient for auditability without overbuilding?
+4. Is latest-good fallback safe, and what metadata is missing to prevent silent stale behavior?
+5. Are SearXNG, reader, MinIO, and pgvector responsibilities separated cleanly?
+6. What parts should be cut from the MVP to reduce delivery risk?
+7. What failure drills are missing before rollout?


### PR DESCRIPTION
## Summary

External architecture consultant review of the Windmill-driven persisted discovery pipeline spec (bd-jxclm.1 / PR #415).

## Verdict: `approve_with_changes`

The spec is sound in its core contract — Windmill as orchestrator, backend as domain executor, persisted intermediates for resumability. However, 10 concrete spec changes are required before implementation begins.

## Top Findings

1. **Search step granularity** — Collapse `search-plan`/`search-execute`/`search-rerank` into single `search-materialize` step
2. **Schema gaps** — Missing `manifest_hash` on `pipeline_steps`, `manifest` JSONB on `pipeline_runs`, `validated_at` on `search_result_snapshots`
3. **Freshness fallback safety** — Needs consecutive stale counter, hard TTL floor (`2 * max_stale_hours`), SearXNG health probe
4. **MinIO retention** — Define concrete retention policy with `retention_expires_at` before Phase 2
5. **Contract versioning** — Define semver format and rejection behavior

## Review Artifact

`docs/reviews/2026-04-11-windmill-persisted-pipeline-consultant-review.md`

Feature-Key: bd-jxclm.11
Agent: opencode
Role: architecture-consultant