### PR TITLE
bd-jxclm.14.2: add Windmill-maximal orchestration assets for San Jose POC

### DIFF
--- a/backend/tests/ops/test_windmill_persisted_pipeline_contract.py
+++ b/backend/tests/ops/test_windmill_persisted_pipeline_contract.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 import requests
+import yaml
 
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -37,35 +38,70 @@ class DummyResponse:
 
 
 def test_poc_flow_contract_has_step_order_retry_timeout_and_branches():
-    flow_text = POC_FLOW_PATH.read_text()
-    schedule_text = POC_SCHEDULE_PATH.read_text()
+    flow_doc = yaml.safe_load(POC_FLOW_PATH.read_text())
+    schedule_doc = yaml.safe_load(POC_SCHEDULE_PATH.read_text())
 
-    assert "id: start_run" in flow_text
-    assert "id: search_materialize" in flow_text
-    assert "id: decision_branch" in flow_text
-    assert "id: read_extract_fresh" in flow_text
-    assert "id: analyze_fresh" in flow_text
-    assert "id: finalize_report_fresh" in flow_text
+    modules = flow_doc["value"]["modules"]
+    modules_by_id = {module["id"]: module for module in modules}
 
-    assert "path: f/affordabot/trigger_pipeline_step" in flow_text
-    assert "value: search_materialize" in flow_text
-    assert "value: 180" in flow_text
-    assert "retry:" in flow_text
-    assert "attempts: 3" in flow_text
-    assert "type: branchone" in flow_text
-    assert "expr: results.search_materialize.response.decision" in flow_text
-    assert "fresh_snapshot:" in flow_text
-    assert "stale_backed:" in flow_text
-    assert "zero_results:" in flow_text
-    assert "provider_failed_no_fallback:" in flow_text
-    assert "fail_zero_results" in flow_text
-    assert "fail_provider_no_fallback" in flow_text
-    assert "zai_search_canary" not in flow_text
-    assert "web_search" not in flow_text.lower()
+    assert "start_run" in modules_by_id
+    assert "search_materialize" in modules_by_id
+    assert "decision_branch" in modules_by_id
 
-    assert "script_path: f/affordabot/pipeline_sanjose_searxng_zai_poc" in schedule_text
-    assert "is_flow: true" in schedule_text
-    assert "enabled: false" in schedule_text
+    search_retry = modules_by_id["search_materialize"]["value"]["retry"]
+    assert search_retry["attempts"] == 3
+    assert search_retry["backoff"]["initial_interval"] == 60
+    assert search_retry["backoff"]["max_interval"] == 600
+    assert search_retry["backoff"]["multiplier"] == 2
+    search_timeout = modules_by_id["search_materialize"]["value"]["input_transforms"]["timeout_seconds"]["value"]
+    assert search_timeout == 180
+
+    branch_value = modules_by_id["decision_branch"]["value"]
+    assert branch_value["type"] == "branchone"
+    assert isinstance(branch_value["branches"], list)
+
+    branch_exprs = [branch["expr"] for branch in branch_value["branches"]]
+    assert 'results.search_materialize.response.decision == "fresh_snapshot"' in branch_exprs
+    assert 'results.search_materialize.response.decision == "stale_backed"' in branch_exprs
+    assert 'results.search_materialize.response.decision == "zero_results"' in branch_exprs
+    assert 'results.search_materialize.response.decision == "provider_failed_no_fallback"' in branch_exprs
+    assert "default" in branch_value
+    assert any(module["id"] == "fail_unexpected_decision" for module in branch_value["default"])
+
+    def branch_modules(expr: str) -> list[dict]:
+        for branch in branch_value["branches"]:
+            if branch["expr"] == expr:
+                return branch["modules"]
+        raise AssertionError(f"Missing branch expr: {expr}")
+
+    assert [module["id"] for module in branch_modules('results.search_materialize.response.decision == "fresh_snapshot"')] == [
+        "read_extract_fresh",
+        "analyze_fresh",
+        "finalize_report_fresh",
+    ]
+    assert [module["id"] for module in branch_modules('results.search_materialize.response.decision == "stale_backed"')] == [
+        "read_extract_stale",
+        "analyze_stale",
+        "finalize_report_stale",
+    ]
+    assert [module["id"] for module in branch_modules('results.search_materialize.response.decision == "zero_results"')] == [
+        "fail_zero_results"
+    ]
+    assert [
+        module["id"]
+        for module in branch_modules('results.search_materialize.response.decision == "provider_failed_no_fallback"')
+    ] == ["fail_provider_no_fallback"]
+
+    failure_module = flow_doc["value"]["failure_module"]
+    assert failure_module["id"] == "flow_failure_handler"
+    assert failure_module["value"]["type"] == "script"
+    assert failure_module["value"]["path"] == "f/affordabot/trigger_pipeline_step"
+    failure_step = failure_module["value"]["input_transforms"]["step"]["value"]
+    assert failure_step == "finalize_report"
+
+    assert schedule_doc["script_path"] == "f/affordabot/pipeline_sanjose_searxng_zai_poc"
+    assert schedule_doc["is_flow"] is True
+    assert schedule_doc["enabled"] is False
 
 
 def test_deprecated_zai_web_search_is_canary_only():
@@ -94,6 +130,7 @@ def test_step_trigger_schema_and_script_contract():
     assert "payload:" in schema_text
 
     assert "STEP_ENDPOINT_BY_NAME" in script_text
+    assert "SOURCE_BY_STEP" in script_text
     assert '"/internal/pipeline/poc/start-run"' in script_text
     assert '"/internal/pipeline/poc/search-materialize"' in script_text
     assert '"/internal/pipeline/poc/read-extract"' in script_text
@@ -147,6 +184,7 @@ def test_main_posts_expected_step_headers_and_payload(monkeypatch):
     assert captured["headers"]["Authorization"] == "Bearer secret-123"
     assert captured["headers"]["X-PR-CRON-SECRET"] == "secret-123"
     assert captured["headers"]["X-PR-PIPELINE-STEP"] == "search_materialize"
+    assert captured["headers"]["X-PR-CRON-SOURCE"] == "windmill:f/affordabot/pipeline_sanjose_searxng_zai_poc/search_materialize"
     assert captured["timeout"] == 180
     assert captured["json"]["contract_version"] == "persisted-pipeline.v1"
     assert captured["json"]["run_id"] == "run-123"
@@ -156,6 +194,26 @@ def test_main_posts_expected_step_headers_and_payload(monkeypatch):
     assert captured["json"]["query_family"] == "city_council_minutes"
     assert result["status"] == "succeeded"
     assert result["decision"] == "fresh_snapshot"
+
+
+def test_main_uses_canary_source_header_for_deprecated_zai_search(monkeypatch):
+    captured = {}
+
+    def fake_post(url, headers, json, timeout):
+        captured["headers"] = headers
+        return DummyResponse(status_code=200, payload={"status": "succeeded", "decision": "analysis_succeeded"})
+
+    monkeypatch.setattr(trigger_pipeline_step.requests, "post", fake_post)
+    monkeypatch.setattr(trigger_pipeline_step, "send_slack_alert", lambda *args, **kwargs: None)
+
+    trigger_pipeline_step.main(
+        step="zai_search_canary",
+        backend_url="https://backend.example.com",
+        cron_secret="secret-123",
+        payload={"canary_name": "weekly"},
+    )
+
+    assert captured["headers"]["X-PR-CRON-SOURCE"] == "windmill:f/affordabot/zai_web_search_weekly_canary/zai_search_canary"
 
 
 def test_main_raises_on_http_error_and_sends_error_alert(monkeypatch):

--- a/backend/tests/ops/test_windmill_persisted_pipeline_contract.py
+++ b/backend/tests/ops/test_windmill_persisted_pipeline_contract.py
@@ -1,0 +1,183 @@
+from importlib.util import module_from_spec
+from importlib.util import spec_from_file_location
+from pathlib import Path
+
+import pytest
+import requests
+
+
+ROOT = Path(__file__).resolve().parents[3]
+WINDMILL_DIR = ROOT / "ops" / "windmill" / "f" / "affordabot"
+STEP_TRIGGER_SCRIPT_PATH = WINDMILL_DIR / "trigger_pipeline_step.py"
+STEP_TRIGGER_SCHEMA_PATH = WINDMILL_DIR / "trigger_pipeline_step.script.yaml"
+POC_FLOW_PATH = WINDMILL_DIR / "pipeline_sanjose_searxng_zai_poc__flow" / "flow.yaml"
+POC_SCHEDULE_PATH = WINDMILL_DIR / "pipeline_sanjose_searxng_zai_poc.schedule.yaml"
+ZAI_CANARY_FLOW_PATH = WINDMILL_DIR / "zai_web_search_weekly_canary__flow" / "flow.yaml"
+ZAI_CANARY_SCHEDULE_PATH = WINDMILL_DIR / "zai_web_search_weekly_canary.schedule.yaml"
+README_PATH = ROOT / "ops" / "windmill" / "README.md"
+
+spec = spec_from_file_location("windmill_trigger_pipeline_step", STEP_TRIGGER_SCRIPT_PATH)
+trigger_pipeline_step = module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(trigger_pipeline_step)
+
+
+class DummyResponse:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"HTTP {self.status_code}")
+
+
+def test_poc_flow_contract_has_step_order_retry_timeout_and_branches():
+    flow_text = POC_FLOW_PATH.read_text()
+    schedule_text = POC_SCHEDULE_PATH.read_text()
+
+    assert "id: start_run" in flow_text
+    assert "id: search_materialize" in flow_text
+    assert "id: decision_branch" in flow_text
+    assert "id: read_extract_fresh" in flow_text
+    assert "id: analyze_fresh" in flow_text
+    assert "id: finalize_report_fresh" in flow_text
+
+    assert "path: f/affordabot/trigger_pipeline_step" in flow_text
+    assert "value: search_materialize" in flow_text
+    assert "value: 180" in flow_text
+    assert "retry:" in flow_text
+    assert "attempts: 3" in flow_text
+    assert "type: branchone" in flow_text
+    assert "expr: results.search_materialize.response.decision" in flow_text
+    assert "fresh_snapshot:" in flow_text
+    assert "stale_backed:" in flow_text
+    assert "zero_results:" in flow_text
+    assert "provider_failed_no_fallback:" in flow_text
+    assert "fail_zero_results" in flow_text
+    assert "fail_provider_no_fallback" in flow_text
+    assert "zai_search_canary" not in flow_text
+    assert "web_search" not in flow_text.lower()
+
+    assert "script_path: f/affordabot/pipeline_sanjose_searxng_zai_poc" in schedule_text
+    assert "is_flow: true" in schedule_text
+    assert "enabled: false" in schedule_text
+
+
+def test_deprecated_zai_web_search_is_canary_only():
+    canary_flow_text = ZAI_CANARY_FLOW_PATH.read_text()
+    canary_schedule_text = ZAI_CANARY_SCHEDULE_PATH.read_text()
+    readme_text = README_PATH.read_text()
+
+    assert "value: zai_search_canary" in canary_flow_text
+    assert "product_path_enabled: false" in canary_flow_text
+    assert "script_path: f/affordabot/zai_web_search_weekly_canary" in canary_schedule_text
+    assert "enabled: false" in canary_schedule_text
+
+    assert "Z.ai direct Web Search: deprecated, canary only, disabled by default" in readme_text
+    assert "zai_web_search_weekly_canary" in readme_text
+
+
+def test_step_trigger_schema_and_script_contract():
+    schema_text = STEP_TRIGGER_SCHEMA_PATH.read_text()
+    script_text = STEP_TRIGGER_SCRIPT_PATH.read_text()
+    script_text_lower = script_text.lower()
+
+    assert "step:" in schema_text
+    assert "timeout_seconds:" in schema_text
+    assert "windmill_flow_run_id:" in schema_text
+    assert "windmill_job_id:" in schema_text
+    assert "payload:" in schema_text
+
+    assert "STEP_ENDPOINT_BY_NAME" in script_text
+    assert '"/internal/pipeline/poc/start-run"' in script_text
+    assert '"/internal/pipeline/poc/search-materialize"' in script_text
+    assert '"/internal/pipeline/poc/read-extract"' in script_text
+    assert '"/internal/pipeline/poc/analyze"' in script_text
+    assert '"/internal/pipeline/poc/finalize-report"' in script_text
+    assert "X-PR-CRON-SECRET" in script_text
+    assert "X-PR-CRON-SOURCE" in script_text
+    assert "X-PR-PIPELINE-STEP" in script_text
+
+    # Windmill orchestration only: no direct DB/object-store writes in trigger scripts.
+    assert "psycopg" not in script_text_lower
+    assert "sqlalchemy" not in script_text_lower
+    assert "insert into" not in script_text_lower
+    assert "update " not in script_text_lower
+    assert "minio" not in script_text_lower
+
+
+def test_main_posts_expected_step_headers_and_payload(monkeypatch):
+    captured = {}
+
+    def fake_post(url, headers, json, timeout):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return DummyResponse(
+            status_code=200,
+            payload={
+                "status": "succeeded",
+                "decision": "fresh_snapshot",
+                "run_id": "run-123",
+            },
+        )
+
+    monkeypatch.setattr(trigger_pipeline_step.requests, "post", fake_post)
+    monkeypatch.setattr(trigger_pipeline_step, "send_slack_alert", lambda *args, **kwargs: None)
+
+    result = trigger_pipeline_step.main(
+        step="search_materialize",
+        backend_url="https://backend.example.com/",
+        cron_secret="secret-123",
+        timeout_seconds=180,
+        run_id="run-123",
+        windmill_flow_run_id="flow-1",
+        windmill_job_id="job-1",
+        jurisdiction="San Jose, CA",
+        payload={"query_family": "city_council_minutes"},
+    )
+
+    assert captured["url"] == "https://backend.example.com/internal/pipeline/poc/search-materialize"
+    assert captured["headers"]["Authorization"] == "Bearer secret-123"
+    assert captured["headers"]["X-PR-CRON-SECRET"] == "secret-123"
+    assert captured["headers"]["X-PR-PIPELINE-STEP"] == "search_materialize"
+    assert captured["timeout"] == 180
+    assert captured["json"]["contract_version"] == "persisted-pipeline.v1"
+    assert captured["json"]["run_id"] == "run-123"
+    assert captured["json"]["windmill_flow_run_id"] == "flow-1"
+    assert captured["json"]["windmill_job_id"] == "job-1"
+    assert captured["json"]["jurisdiction"] == "San Jose, CA"
+    assert captured["json"]["query_family"] == "city_council_minutes"
+    assert result["status"] == "succeeded"
+    assert result["decision"] == "fresh_snapshot"
+
+
+def test_main_raises_on_http_error_and_sends_error_alert(monkeypatch):
+    alerts = []
+
+    def fake_post(url, headers, json, timeout):
+        return DummyResponse(status_code=503, payload={"status": "failed", "decision": "provider_failed_no_fallback"})
+
+    def fake_alert(webhook_url, severity, title, message, env):
+        alerts.append((severity, title, message, env))
+
+    monkeypatch.setattr(trigger_pipeline_step.requests, "post", fake_post)
+    monkeypatch.setattr(trigger_pipeline_step, "send_slack_alert", fake_alert)
+
+    with pytest.raises(requests.HTTPError):
+        trigger_pipeline_step.main(
+            step="search_materialize",
+            backend_url="https://backend.example.com",
+            cron_secret="secret-123",
+            slack_webhook_url="https://hooks.slack.test/services/abc",
+        )
+
+    assert alerts
+    assert alerts[0][0] == "ERROR"
+    assert "HTTP_503" in alerts[0][1]

--- a/docs/research/2026-04-12-windmill-poc-orchestration-contract.md
+++ b/docs/research/2026-04-12-windmill-poc-orchestration-contract.md
@@ -1,0 +1,71 @@
+# Windmill POC Orchestration Contract (bd-jxclm.14.2)
+
+## Scope
+
+This artifact defines the orchestration-only implementation contract for the
+San Jose architecture-locking POC.
+
+It intentionally does not change backend provider/business logic code.
+
+## Ownership Boundary
+
+- Windmill owns:
+  - schedule/manual trigger
+  - retries, timeout, and branching
+  - flow-level observability
+- Backend owns:
+  - search/read/analyze/finalize decision logic
+  - freshness/stale policy
+  - all product table/object writes
+
+## Product Flow
+
+Flow: `f/affordabot/pipeline_sanjose_searxng_zai_poc`
+
+Step order:
+
+1. `start_run`
+2. `search_materialize` with native retry
+3. decision branch on backend `decision`
+4. `read_extract` (Z.ai direct reader canonical path)
+5. `analyze` (Z.ai LLM canonical path)
+6. `finalize_report`
+
+Required branch decisions:
+
+- `fresh_snapshot`
+- `stale_backed`
+- `zero_results` (fail path)
+- `provider_failed_no_fallback` (fail path)
+
+## Deprecation Boundary
+
+Z.ai direct Web Search is outside the product flow.
+
+Canary-only artifact:
+
+- Flow: `f/affordabot/zai_web_search_weekly_canary`
+- Schedule: `ops/windmill/f/affordabot/zai_web_search_weekly_canary.schedule.yaml`
+- Default: `enabled: false`
+
+## Webhook/On-Demand Trigger Shape
+
+Recommended route contract:
+
+- method: `POST`
+- route: `/wm/affordabot/pipeline/sanjose-poc`
+- body:
+  - `jurisdiction` (optional, default `San Jose, CA`)
+  - `windmill_flow_run_id` (optional)
+  - `windmill_job_id` (optional)
+
+Auth model:
+
+- Windmill route auth at route layer
+- Backend step auth with `CRON_SECRET` headers from `trigger_pipeline_step`
+
+## Syntax Assumption Note
+
+The committed flow uses a `branchone` block shape for branch contracts.
+If live Windmill parser syntax differs, only syntax wrapping should change.
+Branch semantics and step ordering must remain unchanged.

--- a/docs/research/2026-04-12-windmill-poc-orchestration-contract.md
+++ b/docs/research/2026-04-12-windmill-poc-orchestration-contract.md
@@ -66,6 +66,15 @@ Auth model:
 
 ## Syntax Assumption Note
 
-The committed flow uses a `branchone` block shape for branch contracts.
-If live Windmill parser syntax differs, only syntax wrapping should change.
-Branch semantics and step ordering must remain unchanged.
+The committed flow uses `branchone` with OpenFlow-style branch list:
+
+- `branches: [{ expr, modules }]`
+- `default: [modules]`
+
+Reference:
+
+- https://www.windmill.dev/docs/flows/flow_branches
+
+This PR validates the YAML structure in repo tests by parsing YAML and asserting
+the branch/failure wiring. Live `wmill sync` was not executed in this PR, so
+final parser compatibility is still a runtime check.

--- a/ops/windmill/README.md
+++ b/ops/windmill/README.md
@@ -151,12 +151,14 @@ Assumed response shape for branching:
 }
 ```
 
-Syntax assumption:
+OpenFlow reference and syntax note:
 
-The `decision_branch` module currently uses a `branchone` contract shape that is
-validated by repo tests as a committed orchestration contract. If live Windmill
-parser expectations differ, keep this branch contract and adjust only syntax-level
-wrapping during `wmill sync` rollout.
+- Windmill docs describe `branch one` using an ordered `branches` list with per-branch `expr` + `modules`, plus a `default` branch.
+- Reference: `https://www.windmill.dev/docs/flows/flow_branches` (OpenFlow/TS branch-one examples).
+
+This repo validates that shape via parsed YAML tests. We did not run live `wmill sync`
+in this PR, so parser compatibility remains a runtime verification item. If parser
+wrapping differs, keep branch semantics and only adapt syntax wrappers during rollout.
 
 ### Z.ai Direct Web Search Deprecation Boundary
 

--- a/ops/windmill/README.md
+++ b/ops/windmill/README.md
@@ -29,6 +29,7 @@ Committed Windmill assets:
 
 - `ops/windmill/wmill.yaml`
 - `ops/windmill/f/affordabot/trigger_cron_job.py`
+- `ops/windmill/f/affordabot/trigger_pipeline_step.py`
 - `ops/windmill/f/affordabot/*__flow/flow.yaml`
 - `ops/windmill/f/affordabot/*.schedule.yaml`
 
@@ -88,6 +89,91 @@ All cron trigger endpoints remain live and auth-gated:
 | `/cron/universal-harvester` | POST | `universal_harvester` |
 | `/cron/manual-substrate-expansion` | POST | `manual_substrate_expansion` (manual flow only) |
 
+### Persisted Pipeline POC (Windmill-Maximal Orchestration)
+
+The `pipeline_sanjose_searxng_zai_poc` flow is the architecture-locking POC for
+`bd-jxclm.14`. It models the intended ownership boundary:
+
+- Windmill owns schedule/manual triggering, retry, timeout, branching, and flow-level observability.
+- Backend owns product/domain policy and all writes to product tables/artifacts.
+
+Flow assets:
+
+- `ops/windmill/f/affordabot/pipeline_sanjose_searxng_zai_poc__flow/flow.yaml`
+- `ops/windmill/f/affordabot/pipeline_sanjose_searxng_zai_poc.schedule.yaml`
+- `ops/windmill/f/affordabot/trigger_pipeline_step.py`
+- `ops/windmill/f/affordabot/trigger_pipeline_step.script.yaml`
+
+POC flow shape:
+
+1. `start_run`
+2. `search_materialize` (native retry + timeout)
+3. `decision_branch` over backend `decision`
+4. `read_extract` (Z.ai direct reader canonical path)
+5. `analyze` (Z.ai LLM canonical path)
+6. `finalize_report`
+
+Expected backend decision branches:
+
+- `fresh_snapshot`
+- `stale_backed`
+- `zero_results`
+- `provider_failed_no_fallback`
+
+Trigger shapes:
+
+- Manual trigger:
+  - Windmill UI run surface for `f/affordabot/pipeline_sanjose_searxng_zai_poc`
+- Schedule trigger:
+  - `pipeline_sanjose_searxng_zai_poc.schedule.yaml` (committed disabled until HITL signoff)
+- Webhook/on-demand trigger:
+  - recommended pattern is a Windmill HTTP route or webhook bound to the same flow with the same input contract (`jurisdiction`, optional run identifiers)
+  - keep auth at Windmill route layer and backend `CRON_SECRET` boundary
+
+Backend contract notes:
+
+`trigger_pipeline_step` targets backend step endpoints only. It does not write to Postgres/MinIO directly.
+
+Assumed response shape for branching:
+
+```json
+{
+  "contract_version": "persisted-pipeline.v1",
+  "run_id": "string",
+  "windmill_flow_run_id": "string|null",
+  "windmill_job_id": "string|null",
+  "step": "search_materialize|read_extract|analyze|finalize_report",
+  "status": "succeeded|failed|blocked",
+  "decision": "fresh_snapshot|stale_backed|zero_results|provider_failed_no_fallback|reader_succeeded|analysis_succeeded",
+  "decision_reason": "string",
+  "evidence": {},
+  "alerts": []
+}
+```
+
+Syntax assumption:
+
+The `decision_branch` module currently uses a `branchone` contract shape that is
+validated by repo tests as a committed orchestration contract. If live Windmill
+parser expectations differ, keep this branch contract and adjust only syntax-level
+wrapping during `wmill sync` rollout.
+
+### Z.ai Direct Web Search Deprecation Boundary
+
+Product pipeline flows must not depend on Z.ai direct Web Search.
+
+A separate canary-only flow is committed for weekly health checks:
+
+- `ops/windmill/f/affordabot/zai_web_search_weekly_canary__flow/flow.yaml`
+- `ops/windmill/f/affordabot/zai_web_search_weekly_canary.schedule.yaml`
+
+Policy:
+
+- Product path search provider: OSS/SearXNG
+- Product path reader: Z.ai direct Web Reader
+- Product path analysis: Z.ai LLM
+- Z.ai direct Web Search: deprecated, canary only, disabled by default
+
 ### Manual Substrate Expansion Contract
 
 The `manual_substrate_expansion` flow accepts a manifest and forwards it to
@@ -115,6 +201,7 @@ zero-count capture/ingestion/promotion summaries, `failures`, and an
 # Contract tests for the shared-instance wrappers and alert path
 cd backend
 poetry run pytest tests/ops/test_windmill_contract.py -q
+poetry run pytest tests/ops/test_windmill_persisted_pipeline_contract.py -q
 
 # Sync the affordabot workspace assets into the shared Windmill instance
 cd ops/windmill

--- a/ops/windmill/f/affordabot/pipeline_sanjose_searxng_zai_poc.schedule.yaml
+++ b/ops/windmill/f/affordabot/pipeline_sanjose_searxng_zai_poc.schedule.yaml
@@ -1,0 +1,8 @@
+schedule: 0 30 9 * * ?
+on_failure: ""
+script_path: f/affordabot/pipeline_sanjose_searxng_zai_poc
+args:
+  jurisdiction: San Jose, CA
+timezone: Etc/UTC
+is_flow: true
+enabled: false

--- a/ops/windmill/f/affordabot/pipeline_sanjose_searxng_zai_poc__flow/flow.yaml
+++ b/ops/windmill/f/affordabot/pipeline_sanjose_searxng_zai_poc__flow/flow.yaml
@@ -80,10 +80,9 @@ value:
   - id: decision_branch
     value:
       type: branchone
-      expr: results.search_materialize.response.decision
       branches:
-        fresh_snapshot:
-          modules:
+      - expr: results.search_materialize.response.decision == "fresh_snapshot"
+        modules:
           - id: read_extract_fresh
             value:
               type: script
@@ -189,8 +188,8 @@ value:
                 jurisdiction:
                   type: javascript
                   expr: flow_input.jurisdiction || "San Jose, CA"
-        stale_backed:
-          modules:
+      - expr: results.search_materialize.response.decision == "stale_backed"
+        modules:
           - id: read_extract_stale
             value:
               type: script
@@ -296,27 +295,69 @@ value:
                 jurisdiction:
                   type: javascript
                   expr: flow_input.jurisdiction || "San Jose, CA"
-        zero_results:
-          modules:
+      - expr: results.search_materialize.response.decision == "zero_results"
+        modules:
           - id: fail_zero_results
             value:
               type: javascript
               expr: >-
                 throw new Error("search_materialize decision was zero_results; no silent fallback allowed")
-        provider_failed_no_fallback:
-          modules:
+      - expr: results.search_materialize.response.decision == "provider_failed_no_fallback"
+        modules:
           - id: fail_provider_no_fallback
             value:
               type: javascript
               expr: >-
                 throw new Error("search_materialize decision was provider_failed_no_fallback")
-      default_branch:
-        modules:
+      default:
         - id: fail_unexpected_decision
           value:
             type: javascript
             expr: >-
               throw new Error(`Unexpected search decision: ${results.search_materialize.response.decision}`)
+  failure_module:
+    id: flow_failure_handler
+    value:
+      type: script
+      path: f/affordabot/trigger_pipeline_step
+      input_transforms:
+        step:
+          type: static
+          value: finalize_report
+        backend_url:
+          type: static
+          value: $var:f/affordabot/BACKEND_PUBLIC_URL
+        cron_secret:
+          type: static
+          value: $var:f/affordabot/CRON_SECRET
+        env:
+          type: static
+          value: dev
+        timeout_seconds:
+          type: static
+          value: 180
+        slack_webhook_url:
+          type: static
+          value: $var:f/affordabot/SLACK_WEBHOOK_URL
+        run_id:
+          type: javascript
+          expr: results.start_run.response.run_id || null
+        windmill_flow_run_id:
+          type: javascript
+          expr: flow_input.windmill_flow_run_id || null
+        windmill_job_id:
+          type: javascript
+          expr: flow_input.windmill_job_id || null
+        jurisdiction:
+          type: javascript
+          expr: flow_input.jurisdiction || "San Jose, CA"
+        payload:
+          type: javascript
+          expr: >-
+            ({
+              failure_handler: "windmill_failure_module",
+              failure_reason: "pipeline_flow_failed_before_finalize"
+            })
 concurrency:
   limit: 1
   key: affordabot-persisted-pipeline-poc

--- a/ops/windmill/f/affordabot/pipeline_sanjose_searxng_zai_poc__flow/flow.yaml
+++ b/ops/windmill/f/affordabot/pipeline_sanjose_searxng_zai_poc__flow/flow.yaml
@@ -1,0 +1,340 @@
+summary: Affordabot persisted pipeline POC (San Jose, SearXNG, Z.ai reader/LLM)
+description: >
+  Architecture-locking orchestration POC. Windmill owns flow/retry/timeout/branching.
+  Backend owns domain decisions and persistence.
+value:
+  modules:
+  - id: start_run
+    value:
+      type: script
+      path: f/affordabot/trigger_pipeline_step
+      input_transforms:
+        step:
+          type: static
+          value: start_run
+        backend_url:
+          type: static
+          value: $var:f/affordabot/BACKEND_PUBLIC_URL
+        cron_secret:
+          type: static
+          value: $var:f/affordabot/CRON_SECRET
+        env:
+          type: static
+          value: dev
+        timeout_seconds:
+          type: static
+          value: 120
+        slack_webhook_url:
+          type: static
+          value: $var:f/affordabot/SLACK_WEBHOOK_URL
+        windmill_flow_run_id:
+          type: javascript
+          expr: flow_input.windmill_flow_run_id || null
+        windmill_job_id:
+          type: javascript
+          expr: flow_input.windmill_job_id || null
+        jurisdiction:
+          type: javascript
+          expr: flow_input.jurisdiction || "San Jose, CA"
+  - id: search_materialize
+    value:
+      type: script
+      path: f/affordabot/trigger_pipeline_step
+      input_transforms:
+        step:
+          type: static
+          value: search_materialize
+        backend_url:
+          type: static
+          value: $var:f/affordabot/BACKEND_PUBLIC_URL
+        cron_secret:
+          type: static
+          value: $var:f/affordabot/CRON_SECRET
+        env:
+          type: static
+          value: dev
+        timeout_seconds:
+          type: static
+          value: 180
+        slack_webhook_url:
+          type: static
+          value: $var:f/affordabot/SLACK_WEBHOOK_URL
+        run_id:
+          type: javascript
+          expr: results.start_run.response.run_id
+        windmill_flow_run_id:
+          type: javascript
+          expr: flow_input.windmill_flow_run_id || null
+        windmill_job_id:
+          type: javascript
+          expr: flow_input.windmill_job_id || null
+        jurisdiction:
+          type: javascript
+          expr: flow_input.jurisdiction || "San Jose, CA"
+      retry:
+        attempts: 3
+        backoff:
+          initial_interval: 60
+          max_interval: 600
+          multiplier: 2
+  - id: decision_branch
+    value:
+      type: branchone
+      expr: results.search_materialize.response.decision
+      branches:
+        fresh_snapshot:
+          modules:
+          - id: read_extract_fresh
+            value:
+              type: script
+              path: f/affordabot/trigger_pipeline_step
+              input_transforms:
+                step:
+                  type: static
+                  value: read_extract
+                backend_url:
+                  type: static
+                  value: $var:f/affordabot/BACKEND_PUBLIC_URL
+                cron_secret:
+                  type: static
+                  value: $var:f/affordabot/CRON_SECRET
+                env:
+                  type: static
+                  value: dev
+                timeout_seconds:
+                  type: static
+                  value: 240
+                slack_webhook_url:
+                  type: static
+                  value: $var:f/affordabot/SLACK_WEBHOOK_URL
+                run_id:
+                  type: javascript
+                  expr: results.start_run.response.run_id
+                windmill_flow_run_id:
+                  type: javascript
+                  expr: flow_input.windmill_flow_run_id || null
+                windmill_job_id:
+                  type: javascript
+                  expr: flow_input.windmill_job_id || null
+                jurisdiction:
+                  type: javascript
+                  expr: flow_input.jurisdiction || "San Jose, CA"
+          - id: analyze_fresh
+            value:
+              type: script
+              path: f/affordabot/trigger_pipeline_step
+              input_transforms:
+                step:
+                  type: static
+                  value: analyze
+                backend_url:
+                  type: static
+                  value: $var:f/affordabot/BACKEND_PUBLIC_URL
+                cron_secret:
+                  type: static
+                  value: $var:f/affordabot/CRON_SECRET
+                env:
+                  type: static
+                  value: dev
+                timeout_seconds:
+                  type: static
+                  value: 240
+                slack_webhook_url:
+                  type: static
+                  value: $var:f/affordabot/SLACK_WEBHOOK_URL
+                run_id:
+                  type: javascript
+                  expr: results.start_run.response.run_id
+                windmill_flow_run_id:
+                  type: javascript
+                  expr: flow_input.windmill_flow_run_id || null
+                windmill_job_id:
+                  type: javascript
+                  expr: flow_input.windmill_job_id || null
+                jurisdiction:
+                  type: javascript
+                  expr: flow_input.jurisdiction || "San Jose, CA"
+          - id: finalize_report_fresh
+            value:
+              type: script
+              path: f/affordabot/trigger_pipeline_step
+              input_transforms:
+                step:
+                  type: static
+                  value: finalize_report
+                backend_url:
+                  type: static
+                  value: $var:f/affordabot/BACKEND_PUBLIC_URL
+                cron_secret:
+                  type: static
+                  value: $var:f/affordabot/CRON_SECRET
+                env:
+                  type: static
+                  value: dev
+                timeout_seconds:
+                  type: static
+                  value: 180
+                slack_webhook_url:
+                  type: static
+                  value: $var:f/affordabot/SLACK_WEBHOOK_URL
+                run_id:
+                  type: javascript
+                  expr: results.start_run.response.run_id
+                windmill_flow_run_id:
+                  type: javascript
+                  expr: flow_input.windmill_flow_run_id || null
+                windmill_job_id:
+                  type: javascript
+                  expr: flow_input.windmill_job_id || null
+                jurisdiction:
+                  type: javascript
+                  expr: flow_input.jurisdiction || "San Jose, CA"
+        stale_backed:
+          modules:
+          - id: read_extract_stale
+            value:
+              type: script
+              path: f/affordabot/trigger_pipeline_step
+              input_transforms:
+                step:
+                  type: static
+                  value: read_extract
+                backend_url:
+                  type: static
+                  value: $var:f/affordabot/BACKEND_PUBLIC_URL
+                cron_secret:
+                  type: static
+                  value: $var:f/affordabot/CRON_SECRET
+                env:
+                  type: static
+                  value: dev
+                timeout_seconds:
+                  type: static
+                  value: 240
+                slack_webhook_url:
+                  type: static
+                  value: $var:f/affordabot/SLACK_WEBHOOK_URL
+                run_id:
+                  type: javascript
+                  expr: results.start_run.response.run_id
+                windmill_flow_run_id:
+                  type: javascript
+                  expr: flow_input.windmill_flow_run_id || null
+                windmill_job_id:
+                  type: javascript
+                  expr: flow_input.windmill_job_id || null
+                jurisdiction:
+                  type: javascript
+                  expr: flow_input.jurisdiction || "San Jose, CA"
+          - id: analyze_stale
+            value:
+              type: script
+              path: f/affordabot/trigger_pipeline_step
+              input_transforms:
+                step:
+                  type: static
+                  value: analyze
+                backend_url:
+                  type: static
+                  value: $var:f/affordabot/BACKEND_PUBLIC_URL
+                cron_secret:
+                  type: static
+                  value: $var:f/affordabot/CRON_SECRET
+                env:
+                  type: static
+                  value: dev
+                timeout_seconds:
+                  type: static
+                  value: 240
+                slack_webhook_url:
+                  type: static
+                  value: $var:f/affordabot/SLACK_WEBHOOK_URL
+                run_id:
+                  type: javascript
+                  expr: results.start_run.response.run_id
+                windmill_flow_run_id:
+                  type: javascript
+                  expr: flow_input.windmill_flow_run_id || null
+                windmill_job_id:
+                  type: javascript
+                  expr: flow_input.windmill_job_id || null
+                jurisdiction:
+                  type: javascript
+                  expr: flow_input.jurisdiction || "San Jose, CA"
+          - id: finalize_report_stale
+            value:
+              type: script
+              path: f/affordabot/trigger_pipeline_step
+              input_transforms:
+                step:
+                  type: static
+                  value: finalize_report
+                backend_url:
+                  type: static
+                  value: $var:f/affordabot/BACKEND_PUBLIC_URL
+                cron_secret:
+                  type: static
+                  value: $var:f/affordabot/CRON_SECRET
+                env:
+                  type: static
+                  value: dev
+                timeout_seconds:
+                  type: static
+                  value: 180
+                slack_webhook_url:
+                  type: static
+                  value: $var:f/affordabot/SLACK_WEBHOOK_URL
+                run_id:
+                  type: javascript
+                  expr: results.start_run.response.run_id
+                windmill_flow_run_id:
+                  type: javascript
+                  expr: flow_input.windmill_flow_run_id || null
+                windmill_job_id:
+                  type: javascript
+                  expr: flow_input.windmill_job_id || null
+                jurisdiction:
+                  type: javascript
+                  expr: flow_input.jurisdiction || "San Jose, CA"
+        zero_results:
+          modules:
+          - id: fail_zero_results
+            value:
+              type: javascript
+              expr: >-
+                throw new Error("search_materialize decision was zero_results; no silent fallback allowed")
+        provider_failed_no_fallback:
+          modules:
+          - id: fail_provider_no_fallback
+            value:
+              type: javascript
+              expr: >-
+                throw new Error("search_materialize decision was provider_failed_no_fallback")
+      default_branch:
+        modules:
+        - id: fail_unexpected_decision
+          value:
+            type: javascript
+            expr: >-
+              throw new Error(`Unexpected search decision: ${results.search_materialize.response.decision}`)
+concurrency:
+  limit: 1
+  key: affordabot-persisted-pipeline-poc
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  properties:
+    jurisdiction:
+      type: string
+      description: Jurisdiction identifier for this run.
+      default: San Jose, CA
+    windmill_flow_run_id:
+      type: string
+      description: Optional explicit flow run identifier for downstream traceability.
+      default: null
+    windmill_job_id:
+      type: string
+      description: Optional explicit job identifier for downstream traceability.
+      default: null
+  required: []
+ws_error_handler_muted: false

--- a/ops/windmill/f/affordabot/trigger_pipeline_step.py
+++ b/ops/windmill/f/affordabot/trigger_pipeline_step.py
@@ -1,0 +1,189 @@
+import json
+import os
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+from typing import Optional
+from urllib.parse import urlparse
+
+import requests
+
+STEP_ENDPOINT_BY_NAME = {
+    "start_run": "/internal/pipeline/poc/start-run",
+    "search_materialize": "/internal/pipeline/poc/search-materialize",
+    "read_extract": "/internal/pipeline/poc/read-extract",
+    "analyze": "/internal/pipeline/poc/analyze",
+    "finalize_report": "/internal/pipeline/poc/finalize-report",
+    "zai_search_canary": "/internal/pipeline/poc/zai-search-canary",
+}
+
+
+def normalize_slack_webhook_url(webhook_url: Optional[str]) -> Optional[str]:
+    if webhook_url is None:
+        return None
+
+    candidate = str(webhook_url).strip()
+    if not candidate:
+        return None
+
+    for _ in range(2):
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            break
+        if isinstance(parsed, str):
+            candidate = parsed.strip()
+            continue
+        break
+
+    if len(candidate) >= 2 and candidate[0] == candidate[-1] and candidate[0] in {"'", '"'}:
+        candidate = candidate[1:-1].strip()
+
+    parsed_url = urlparse(candidate)
+    if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
+        return None
+    return candidate
+
+
+def send_slack_alert(
+    webhook_url: Optional[str],
+    severity: str,
+    title: str,
+    message: str,
+    env: str = "dev",
+) -> None:
+    normalized_webhook_url = normalize_slack_webhook_url(webhook_url)
+    if not normalized_webhook_url:
+        return
+
+    emoji_map = {"INFO": "✅", "WARNING": "⚠️", "ERROR": "🔴", "CRITICAL": "🚨"}
+    emoji = emoji_map.get(severity, "📢")
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    hostname = os.uname().nodename.split(".")[0]
+
+    payload = {
+        "text": f"[{severity}] {emoji} {title}",
+        "blocks": [
+            {"type": "section", "text": {"type": "mrkdwn", "text": f"*[{severity}]* {emoji} *{title}*"}},
+            {"type": "section", "text": {"type": "mrkdwn", "text": message}},
+            {
+                "type": "context",
+                "elements": [{"type": "mrkdwn", "text": f"env={env} | host={hostname} | time={timestamp}"}],
+            },
+        ],
+    }
+
+    try:
+        response = requests.post(normalized_webhook_url, json=payload, timeout=10)
+        response.raise_for_status()
+        print(f"Slack alert sent: [{severity}] {title}")
+    except Exception as exc:
+        print(f"Failed to send Slack alert: {exc}")
+
+
+def _merge_payload(base_payload: dict[str, Any], extra_payload: Optional[dict[str, Any]]) -> dict[str, Any]:
+    if extra_payload is None:
+        return base_payload
+    merged = dict(base_payload)
+    merged.update(extra_payload)
+    return merged
+
+
+def main(
+    step: str,
+    backend_url: str,
+    cron_secret: str,
+    env: str = "dev",
+    timeout_seconds: int = 180,
+    slack_webhook_url: Optional[str] = None,
+    run_id: Optional[str] = None,
+    windmill_flow_run_id: Optional[str] = None,
+    windmill_job_id: Optional[str] = None,
+    jurisdiction: str = "San Jose, CA",
+    payload: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    if step not in STEP_ENDPOINT_BY_NAME:
+        raise ValueError(f"Unsupported step: {step}")
+
+    endpoint = STEP_ENDPOINT_BY_NAME[step]
+    url = f"{backend_url.rstrip('/')}{endpoint}"
+    normalized_slack_webhook_url = normalize_slack_webhook_url(slack_webhook_url)
+
+    headers = {
+        "Authorization": f"Bearer {cron_secret}",
+        "X-PR-CRON-SECRET": cron_secret,
+        "X-PR-CRON-SOURCE": f"windmill:f/affordabot/pipeline_sanjose_searxng_zai_poc/{step}",
+        "X-PR-PIPELINE-STEP": step,
+        "Content-Type": "application/json",
+    }
+
+    request_payload = {
+        "contract_version": "persisted-pipeline.v1",
+        "step": step,
+        "run_id": run_id,
+        "windmill_flow_run_id": windmill_flow_run_id,
+        "windmill_job_id": windmill_job_id,
+        "jurisdiction": jurisdiction,
+    }
+    request_payload = _merge_payload(request_payload, payload)
+
+    try:
+        response = requests.post(
+            url,
+            headers=headers,
+            json=request_payload,
+            timeout=timeout_seconds,
+        )
+    except requests.RequestException as exc:
+        send_slack_alert(
+            normalized_slack_webhook_url,
+            "ERROR",
+            f"Affordabot pipeline step {step}: REQUEST_FAILED",
+            f"Request to `{url}` failed: `{exc}`",
+            env,
+        )
+        raise
+
+    try:
+        response_payload = response.json()
+    except ValueError:
+        response_payload = {"raw_text": response.text}
+
+    if response.status_code >= 400:
+        send_slack_alert(
+            normalized_slack_webhook_url,
+            "ERROR",
+            f"Affordabot pipeline step {step}: HTTP_{response.status_code}",
+            f"Endpoint `{url}` returned `{response.status_code}`.\n```{response_payload}```",
+            env,
+        )
+        response.raise_for_status()
+
+    status = response_payload.get("status", "unknown") if isinstance(response_payload, dict) else "unknown"
+    decision = response_payload.get("decision") if isinstance(response_payload, dict) else None
+    severity = "INFO"
+    if status in {"failed", "blocked"}:
+        severity = "ERROR"
+    elif decision == "stale_backed":
+        severity = "WARNING"
+
+    send_slack_alert(
+        normalized_slack_webhook_url,
+        severity,
+        f"Affordabot pipeline step {step}: {status.upper()}",
+        f"Decision: `{decision}`\n```{response_payload}```",
+        env,
+    )
+
+    result = {
+        "step": step,
+        "status": status,
+        "decision": decision,
+        "http_status": response.status_code,
+        "response": response_payload,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "env": env,
+        "slack_configured": bool(normalized_slack_webhook_url),
+    }
+    print(result)
+    return result

--- a/ops/windmill/f/affordabot/trigger_pipeline_step.py
+++ b/ops/windmill/f/affordabot/trigger_pipeline_step.py
@@ -17,6 +17,15 @@ STEP_ENDPOINT_BY_NAME = {
     "zai_search_canary": "/internal/pipeline/poc/zai-search-canary",
 }
 
+SOURCE_BY_STEP = {
+    "start_run": "windmill:f/affordabot/pipeline_sanjose_searxng_zai_poc/start_run",
+    "search_materialize": "windmill:f/affordabot/pipeline_sanjose_searxng_zai_poc/search_materialize",
+    "read_extract": "windmill:f/affordabot/pipeline_sanjose_searxng_zai_poc/read_extract",
+    "analyze": "windmill:f/affordabot/pipeline_sanjose_searxng_zai_poc/analyze",
+    "finalize_report": "windmill:f/affordabot/pipeline_sanjose_searxng_zai_poc/finalize_report",
+    "zai_search_canary": "windmill:f/affordabot/zai_web_search_weekly_canary/zai_search_canary",
+}
+
 
 def normalize_slack_webhook_url(webhook_url: Optional[str]) -> Optional[str]:
     if webhook_url is None:
@@ -109,10 +118,11 @@ def main(
     url = f"{backend_url.rstrip('/')}{endpoint}"
     normalized_slack_webhook_url = normalize_slack_webhook_url(slack_webhook_url)
 
+    source = SOURCE_BY_STEP.get(step, f"windmill:f/affordabot/pipeline_step/{step}")
     headers = {
         "Authorization": f"Bearer {cron_secret}",
         "X-PR-CRON-SECRET": cron_secret,
-        "X-PR-CRON-SOURCE": f"windmill:f/affordabot/pipeline_sanjose_searxng_zai_poc/{step}",
+        "X-PR-CRON-SOURCE": source,
         "X-PR-PIPELINE-STEP": step,
         "Content-Type": "application/json",
     }

--- a/ops/windmill/f/affordabot/trigger_pipeline_step.script.yaml
+++ b/ops/windmill/f/affordabot/trigger_pipeline_step.script.yaml
@@ -1,0 +1,67 @@
+summary: Affordabot persisted pipeline step trigger
+description: Trigger an affordabot persisted pipeline backend step endpoint from Windmill.
+lock: ""
+kind: script
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  properties:
+    step:
+      type: string
+      description: Pipeline step name (start_run, search_materialize, read_extract, analyze, finalize_report, zai_search_canary).
+      default: null
+      originalType: string
+    backend_url:
+      type: string
+      description: Public backend URL used for persisted pipeline endpoint calls.
+      default: null
+      originalType: string
+    cron_secret:
+      type: string
+      description: Shared cron secret sent to backend auth headers.
+      default: null
+      originalType: string
+    env:
+      type: string
+      description: Environment label for logs.
+      default: dev
+      originalType: string
+    timeout_seconds:
+      type: integer
+      description: HTTP timeout for the step call.
+      default: 180
+      originalType: number
+    slack_webhook_url:
+      type: string
+      description: Optional Slack webhook for alerts.
+      default: null
+      originalType: string
+    run_id:
+      type: string
+      description: Existing run ID from start_run response.
+      default: null
+      originalType: string
+    windmill_flow_run_id:
+      type: string
+      description: Windmill flow run ID for cross-system traceability.
+      default: null
+      originalType: string
+    windmill_job_id:
+      type: string
+      description: Windmill job ID for per-step traceability.
+      default: null
+      originalType: string
+    jurisdiction:
+      type: string
+      description: Jurisdiction scope for the run.
+      default: San Jose, CA
+      originalType: string
+    payload:
+      type: object
+      description: Optional JSON payload merged into backend request body.
+      default: null
+      originalType: object
+  required:
+    - step
+    - backend_url
+    - cron_secret

--- a/ops/windmill/f/affordabot/zai_web_search_weekly_canary.schedule.yaml
+++ b/ops/windmill/f/affordabot/zai_web_search_weekly_canary.schedule.yaml
@@ -1,0 +1,7 @@
+schedule: 0 0 10 ? * MON
+on_failure: ""
+script_path: f/affordabot/zai_web_search_weekly_canary
+args: {}
+timezone: Etc/UTC
+is_flow: true
+enabled: false

--- a/ops/windmill/f/affordabot/zai_web_search_weekly_canary__flow/flow.yaml
+++ b/ops/windmill/f/affordabot/zai_web_search_weekly_canary__flow/flow.yaml
@@ -1,0 +1,53 @@
+summary: Affordabot deprecated Z.ai direct Web Search weekly canary
+description: >
+  Canary-only flow. This is explicitly outside the product pipeline path and
+  exists to detect if the deprecated Z.ai direct Web Search endpoint recovers.
+value:
+  modules:
+  - id: zai_search_canary
+    value:
+      type: script
+      path: f/affordabot/trigger_pipeline_step
+      input_transforms:
+        step:
+          type: static
+          value: zai_search_canary
+        backend_url:
+          type: static
+          value: $var:f/affordabot/BACKEND_PUBLIC_URL
+        cron_secret:
+          type: static
+          value: $var:f/affordabot/CRON_SECRET
+        env:
+          type: static
+          value: dev
+        timeout_seconds:
+          type: static
+          value: 120
+        slack_webhook_url:
+          type: static
+          value: $var:f/affordabot/SLACK_WEBHOOK_URL
+        payload:
+          type: javascript
+          expr: >-
+            ({
+              canary_name: "zai_direct_web_search_weekly",
+              expected_contract: "search_result[]",
+              product_path_enabled: false
+            })
+      retry:
+        attempts: 1
+        backoff:
+          initial_interval: 60
+          max_interval: 60
+          multiplier: 1
+concurrency:
+  limit: 1
+  key: affordabot-zai-search-weekly-canary
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  order: []
+  properties: {}
+  required: []
+ws_error_handler_muted: false


### PR DESCRIPTION
## Summary
Implements the Windmill/orchestration side of the San Jose architecture-locking POC for `bd-jxclm.14.2`.

This PR is intentionally scoped to orchestration assets, contract tests, and docs:
- adds `trigger_pipeline_step` Windmill script + schema for backend step endpoints
- adds `pipeline_sanjose_searxng_zai_poc` Windmill flow + schedule shape
- adds explicit branch contract for `fresh_snapshot`, `stale_backed`, `zero_results`, `provider_failed_no_fallback`
- adds separate weekly `zai_web_search_weekly_canary` flow/schedule as a deprecation boundary
- adds Windmill contract tests and orchestration contract doc

## Scope Guardrails
- No edits to `backend/services/**`
- No edits to `backend/scripts/verification/**`
- No direct Postgres/MinIO writes in Windmill orchestration scripts

## Validation
- `git diff --check`
- `cd backend && poetry run pytest tests/ops/test_windmill_persisted_pipeline_contract.py -q`
- `cd backend && poetry run pytest tests/ops/test_windmill_contract.py -q`
- `cd backend && poetry run ruff check tests/ops/test_windmill_persisted_pipeline_contract.py`
- `cd backend && poetry run ruff check ../ops/windmill/f/affordabot/trigger_pipeline_step.py`

## Notes
The `branchone` block in the new flow is committed as contract shape and covered by tests. If live Windmill parser syntax differs, only syntax wrapping should change during sync rollout; branching semantics must remain intact.

Agent: gpt-5.3-codex