### PR TITLE
bd-jxclm.14.5: runtime validation evidence for integrated POC

### DIFF
--- a/docs/research/2026-04-12-bd-jxclm.14.5-runtime-validation.md
+++ b/docs/research/2026-04-12-bd-jxclm.14.5-runtime-validation.md
@@ -1,80 +1,53 @@
-# bd-jxclm.14.5 Runtime Validation (PR #422)
+# bd-jxclm.14.5 Runtime Validation Refresh (PR #422 Head 52258a1)
 
-Date: 2026-04-12  
-Subtask: `bd-jxclm.14.5`  
-Base integration head inspected: `dc5a89fada6f0dcc3bf68566538a700604dad725` (PR #422)
+Date: 2026-04-12
+Subtask: `bd-jxclm.14.5`
+Validated integration head: `52258a18f4cb55754f2308dd779245177fde0390` (PR #422)
+Runtime report PR: #423
 
 ## Scope
 
-Goal: maximize runtime evidence without HITL secrets, classify remaining operational blockers, and verify:
+This refresh reruns runtime evidence after the #422 repairs:
 
-1. happy path
-2. stale-backed path
-3. fail-closed path
-4. finalize child-failure propagation behavior
-5. Windmill CLI/parser validation status
+1. Windmill YAML lint/parsing state
+2. trigger-script HTTP happy path
+3. trigger-script HTTP fail-closed path
+4. stale-backed fallback behavior
+5. finalize child-failure propagation behavior
+6. live Windmill workspace sync/run viability without secrets
 
-No product logic changes were made in this pass.
-
-## 1) Workspace + PR Context
-
-Commands:
-
-```bash
-dx-worktree create bd-jxclm.14.5 affordabot
-git fetch origin pull/422/head:pr-422
-git checkout -B feature-bd-jxclm.14.5 pr-422
-```
-
-Result:
-
-- Worktree path: `/tmp/agents/bd-jxclm.14.5/affordabot`
-- Branch content matched PR #422 integration state.
-
-## 2) Windmill CLI / Parser Validation
-
-### 2.1 CLI availability
+## 1) Branch Lineage Validation
 
 Commands:
 
 ```bash
-wmill --help
-which wmill
-npx --yes windmill-cli --help
+git rev-parse HEAD
+git merge-base --is-ancestor 52258a18f4cb55754f2308dd779245177fde0390 HEAD
 ```
 
 Result:
 
-- `wmill` binary is not preinstalled (`command not found`).
-- `npx --yes windmill-cli` works and reports CLI version `1.682.0`.
+- Runtime branch was rebased to include `52258a...`.
+- Current branch head is a descendant of `52258a...`.
 
-### 2.2 Static lint/parsing
+## 2) Windmill CLI Lint
 
 Command:
 
 ```bash
-npx --yes windmill-cli lint ops/windmill/f/affordabot
+npx windmill-cli lint ops/windmill/f/affordabot
 ```
 
 Result:
 
-- Lint failed on `pipeline_sanjose_searxng_zai_poc__flow/flow.yaml`.
-- Reported schema errors under `branchone` module branch entries:
-  - `value of tag "type" must be in oneOf` for branch modules/default modules.
-- This is now a concrete parser/schema blocker (not just missing `wmill`).
+- `PASS`: `Lint passed (13 file(s) validated, 13 valid)`.
+- Informational warning only: `No wmill.yaml found. Use 'wmill init' to bootstrap it.`
 
-## 3) Backend Startup Dependency + Closest Real HTTP Path
+Conclusion: prior schema blocker is resolved on current head.
 
-### 3.1 Baseline blocker
+## 3) Local HTTP Runtime Harness (No Product Code Edits)
 
-From code path:
-
-- [main.py](/tmp/agents/bd-jxclm.14.5/affordabot/backend/main.py#L50) calls `await db.connect()` on startup.
-- [postgres_client.py](/tmp/agents/bd-jxclm.14.5/affordabot/backend/db/postgres_client.py#L30) raises `ValueError("DATABASE_URL is not set")` when missing.
-
-### 3.2 Runtime harness used (no product code edits)
-
-Started local FastAPI with in-process startup patch:
+Baseline app startup still expects DB wiring; to run local HTTP drills without DB secrets, used an in-process startup monkeypatch only:
 
 ```bash
 cd backend
@@ -95,114 +68,146 @@ uvicorn.run(main.app, host="127.0.0.1", port=8015, log_level="warning")
 PY
 ```
 
-This enabled real HTTP endpoint testing and real trigger-script invocation without a reachable Postgres instance.
+No product files were changed for this harness.
 
 ## 4) Runtime Drills
 
-### 4.1 Happy path (real HTTP + real trigger script)
+### 4.1 Happy path over HTTP via trigger script
 
-Method:
+Command shape:
 
-- Called `ops/windmill/f/affordabot/trigger_pipeline_step.py::main(...)` over HTTP against `http://127.0.0.1:8015`.
-- Step order: `start_run -> search_materialize -> read_extract -> analyze -> finalize_report`.
+```bash
+cd backend
+poetry run python - <<'PY'
+from ops.windmill.f.affordabot.trigger_pipeline_step import main
+# start_run(live=False) -> search_materialize -> read_extract -> analyze -> finalize_report
+PY
+```
 
 Observed:
 
-- All five calls returned HTTP `200`.
-- Decisions: `run_started`, `fresh_snapshot`, `reader_succeeded`, `analysis_succeeded`, `fresh_snapshot`.
-- End-to-end trigger-script path is executable with local backend runtime.
+- All steps returned HTTP `200`.
+- Decisions:
+  - `start_run`: `run_started`
+  - `search_materialize`: `fresh_snapshot`
+  - `read_extract`: `reader_succeeded`
+  - `analyze`: `analysis_succeeded`
+  - `finalize_report`: `fresh_snapshot`
 
-### 4.2 Fail-closed drill (real HTTP + real trigger script)
+### 4.2 Fail-closed path over HTTP via trigger script
 
-Method:
+Command shape:
 
-- `start_run` with payload `live=true` (uses `SearXNGSearchProvider`).
-- No local SearXNG running (`localhost:8888` connection refused).
-- Called `search_materialize` through trigger script.
+```bash
+cd backend
+poetry run python - <<'PY'
+from ops.windmill.f.affordabot.trigger_pipeline_step import main
+# start_run(live=True) then search_materialize
+PY
+```
 
 Observed:
 
 - `search_materialize` returned HTTP `200` with:
   - `status = "failed"`
   - `decision = "provider_failed_no_fallback"`
-  - provider failure evidence with connection-refused error.
-- Domain failure semantics (`2xx` + decision envelope) are preserved.
+  - provider error evidence from `SearXNGSearchProvider` connection refusal.
 
-### 4.3 Stale-backed drill (endpoint-level)
+This confirms domain-failure semantics remain branchable 2xx envelopes.
 
-Method:
+### 4.3 Stale-backed path (endpoint-level evidence)
 
-- Used `TestClient` to keep endpoint contract but force provider transition in run context:
-  1. successful search to create baseline snapshot
-  2. swap in `FailingSearchProvider` for same run
-  3. re-run `search-materialize`
+Command:
+
+```bash
+cd backend
+poetry run python - <<'PY'
+from fastapi.testclient import TestClient
+import main
+from services.persisted_pipeline import FailingSearchProvider
+# start_run -> search_materialize (fresh) -> swap provider -> search_materialize
+PY
+```
 
 Observed:
 
-- second search response:
+- First search: `decision = "fresh_snapshot"`.
+- Second search after forced provider failure:
   - `status = "succeeded"`
   - `decision = "stale_backed"`
-  - includes `source_snapshot_id` and provider failure metadata.
+  - evidence includes `source_snapshot_id` and provider-failure payload.
 
-Note:
+### 4.4 Finalize child-failure propagation (corrected)
 
-- This stale-backed proof is endpoint-level, not pure trigger-script-only, because current API does not expose a runtime fault-injection control for provider outage after baseline materialization.
+Command:
 
-### 4.4 Finalize child-failure propagation drill
-
-Method:
-
-- Endpoint-level forced child failures by setting:
-  - `read_response.status = failed`
-  - `analyze_response.status = failed`
-- Called `/internal/pipeline/poc/finalize-report`.
+```bash
+cd backend
+poetry run pytest tests/test_persisted_pipeline_poc_endpoints.py::test_finalize_report_propagates_failed_read_status tests/test_persisted_pipeline_poc_endpoints.py::test_finalize_report_propagates_failed_analyze_status tests/test_persisted_pipeline_poc_endpoints.py::test_finalize_report_happy_path_still_succeeds -q
+```
 
 Observed:
 
-- Finalize returned HTTP `200` with:
-  - `status = "succeeded"`
-  - `decision = "fresh_snapshot"`
-  - evidence still shows `read_decision = reader_failed`, `analyze_decision = analysis_failed`.
+- `3 passed`.
+- Failed read/analyze now produce finalize `status = "failed"` with `decision = "downstream_failed"` (no masking).
+- Happy path finalize remains succeeded.
 
-Conclusion:
+This explicitly invalidates the prior stale claim that finalize still masked child failure.
 
-- Finalize currently masks child step failures instead of propagating terminal failure status.
-- This remains a real operational correctness issue.
+## 5) Additional Test Confirmation
 
-## 5) Blocker Classification
+Command:
 
-### Closed / refined
+```bash
+cd backend
+poetry run pytest tests/test_persisted_pipeline_poc_endpoints.py -q
+```
 
-1. `wmill` missing is no longer a hard blocker:
-   - `npx windmill-cli` is available and usable.
-2. Backend HTTP exercise is possible without DB secrets:
-   - with a local startup harness patch (no code commit needed).
+Result:
 
-### Still open
+- `8 passed` (FastAPI deprecation warnings only).
 
-1. Windmill flow YAML parser validity is blocked by current lint/schema errors.
-2. Finalize failure propagation is unsafe (`succeeded` despite failed read/analyze).
-3. Stale-backed drill is not injectable via trigger-script-only flow path yet.
-4. No live authenticated Windmill workspace sync/run evidence (no secrets used in this task by design).
+## 6) Live Windmill Workspace Sync/Run Gate
 
-## 6) Minimal future harness recommendation (for bd-jxclm.14.x follow-up)
+Checked non-secret prerequisites:
 
-If we want live runtime evidence without production DB dependence, add a guarded startup bypass:
+```bash
+npx windmill-cli workspace list
+```
 
-- env-gated, e.g. `POC_DISABLE_DB_STARTUP=1`
-- only for POC/internal routes
-- keep default behavior unchanged
+Observed:
 
-This removes ad hoc monkeypatching while preserving production safety.
+- No active workspace profile configured.
+- Environment variables absent in this runtime:
+  - `WMILL_BASE_URL`
+  - `WMILL_TOKEN`
+  - `WMILL_WORKSPACE`
+  - `WINDMILL_BASE_URL`
+  - `WINDMILL_TOKEN`
+  - `WINDMILL_WORKSPACE`
 
-## 7) Verdict
+Because no authenticated workspace configuration is present, live `wmill sync/run` cannot be executed in this pass without introducing secrets.
 
-`operational_gate_blocked_with_exact_causes`
+## 7) Validation Hygiene
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result:
+
+- Clean.
+
+## 8) Verdict
+
+`runtime_gate_pass_except_live_workspace`
 
 Reason:
 
-- We now have concrete runtime evidence for happy path, fail-closed, and stale-backed behavior (endpoint-level), but operational gate is still blocked by:
-  1. Windmill flow YAML schema/lint failures
-  2. finalize child-failure masking
-  3. no live Windmill workspace execution proof in this no-secrets pass
-
+1. Current #422 head (`52258a...`) lint/parsing is valid.
+2. HTTP happy + fail-closed trigger-script paths work.
+3. Stale-backed fallback behavior is reproducible.
+4. Finalize child-failure propagation is now correct (prior stale finding removed).
+5. Remaining blocker is only missing authenticated Windmill workspace config for live sync/run evidence.

--- a/docs/research/2026-04-12-bd-jxclm.14.5-runtime-validation.md
+++ b/docs/research/2026-04-12-bd-jxclm.14.5-runtime-validation.md
@@ -1,0 +1,208 @@
+# bd-jxclm.14.5 Runtime Validation (PR #422)
+
+Date: 2026-04-12  
+Subtask: `bd-jxclm.14.5`  
+Base integration head inspected: `dc5a89fada6f0dcc3bf68566538a700604dad725` (PR #422)
+
+## Scope
+
+Goal: maximize runtime evidence without HITL secrets, classify remaining operational blockers, and verify:
+
+1. happy path
+2. stale-backed path
+3. fail-closed path
+4. finalize child-failure propagation behavior
+5. Windmill CLI/parser validation status
+
+No product logic changes were made in this pass.
+
+## 1) Workspace + PR Context
+
+Commands:
+
+```bash
+dx-worktree create bd-jxclm.14.5 affordabot
+git fetch origin pull/422/head:pr-422
+git checkout -B feature-bd-jxclm.14.5 pr-422
+```
+
+Result:
+
+- Worktree path: `/tmp/agents/bd-jxclm.14.5/affordabot`
+- Branch content matched PR #422 integration state.
+
+## 2) Windmill CLI / Parser Validation
+
+### 2.1 CLI availability
+
+Commands:
+
+```bash
+wmill --help
+which wmill
+npx --yes windmill-cli --help
+```
+
+Result:
+
+- `wmill` binary is not preinstalled (`command not found`).
+- `npx --yes windmill-cli` works and reports CLI version `1.682.0`.
+
+### 2.2 Static lint/parsing
+
+Command:
+
+```bash
+npx --yes windmill-cli lint ops/windmill/f/affordabot
+```
+
+Result:
+
+- Lint failed on `pipeline_sanjose_searxng_zai_poc__flow/flow.yaml`.
+- Reported schema errors under `branchone` module branch entries:
+  - `value of tag "type" must be in oneOf` for branch modules/default modules.
+- This is now a concrete parser/schema blocker (not just missing `wmill`).
+
+## 3) Backend Startup Dependency + Closest Real HTTP Path
+
+### 3.1 Baseline blocker
+
+From code path:
+
+- [main.py](/tmp/agents/bd-jxclm.14.5/affordabot/backend/main.py#L50) calls `await db.connect()` on startup.
+- [postgres_client.py](/tmp/agents/bd-jxclm.14.5/affordabot/backend/db/postgres_client.py#L30) raises `ValueError("DATABASE_URL is not set")` when missing.
+
+### 3.2 Runtime harness used (no product code edits)
+
+Started local FastAPI with in-process startup patch:
+
+```bash
+cd backend
+CRON_SECRET=test-secret poetry run python - <<'PY'
+import main
+import uvicorn
+
+async def _noop_connect():
+    return None
+
+async def _noop_close():
+    return None
+
+main.db.connect = _noop_connect
+main.db.close = _noop_close
+main.CRON_SECRET = "test-secret"
+uvicorn.run(main.app, host="127.0.0.1", port=8015, log_level="warning")
+PY
+```
+
+This enabled real HTTP endpoint testing and real trigger-script invocation without a reachable Postgres instance.
+
+## 4) Runtime Drills
+
+### 4.1 Happy path (real HTTP + real trigger script)
+
+Method:
+
+- Called `ops/windmill/f/affordabot/trigger_pipeline_step.py::main(...)` over HTTP against `http://127.0.0.1:8015`.
+- Step order: `start_run -> search_materialize -> read_extract -> analyze -> finalize_report`.
+
+Observed:
+
+- All five calls returned HTTP `200`.
+- Decisions: `run_started`, `fresh_snapshot`, `reader_succeeded`, `analysis_succeeded`, `fresh_snapshot`.
+- End-to-end trigger-script path is executable with local backend runtime.
+
+### 4.2 Fail-closed drill (real HTTP + real trigger script)
+
+Method:
+
+- `start_run` with payload `live=true` (uses `SearXNGSearchProvider`).
+- No local SearXNG running (`localhost:8888` connection refused).
+- Called `search_materialize` through trigger script.
+
+Observed:
+
+- `search_materialize` returned HTTP `200` with:
+  - `status = "failed"`
+  - `decision = "provider_failed_no_fallback"`
+  - provider failure evidence with connection-refused error.
+- Domain failure semantics (`2xx` + decision envelope) are preserved.
+
+### 4.3 Stale-backed drill (endpoint-level)
+
+Method:
+
+- Used `TestClient` to keep endpoint contract but force provider transition in run context:
+  1. successful search to create baseline snapshot
+  2. swap in `FailingSearchProvider` for same run
+  3. re-run `search-materialize`
+
+Observed:
+
+- second search response:
+  - `status = "succeeded"`
+  - `decision = "stale_backed"`
+  - includes `source_snapshot_id` and provider failure metadata.
+
+Note:
+
+- This stale-backed proof is endpoint-level, not pure trigger-script-only, because current API does not expose a runtime fault-injection control for provider outage after baseline materialization.
+
+### 4.4 Finalize child-failure propagation drill
+
+Method:
+
+- Endpoint-level forced child failures by setting:
+  - `read_response.status = failed`
+  - `analyze_response.status = failed`
+- Called `/internal/pipeline/poc/finalize-report`.
+
+Observed:
+
+- Finalize returned HTTP `200` with:
+  - `status = "succeeded"`
+  - `decision = "fresh_snapshot"`
+  - evidence still shows `read_decision = reader_failed`, `analyze_decision = analysis_failed`.
+
+Conclusion:
+
+- Finalize currently masks child step failures instead of propagating terminal failure status.
+- This remains a real operational correctness issue.
+
+## 5) Blocker Classification
+
+### Closed / refined
+
+1. `wmill` missing is no longer a hard blocker:
+   - `npx windmill-cli` is available and usable.
+2. Backend HTTP exercise is possible without DB secrets:
+   - with a local startup harness patch (no code commit needed).
+
+### Still open
+
+1. Windmill flow YAML parser validity is blocked by current lint/schema errors.
+2. Finalize failure propagation is unsafe (`succeeded` despite failed read/analyze).
+3. Stale-backed drill is not injectable via trigger-script-only flow path yet.
+4. No live authenticated Windmill workspace sync/run evidence (no secrets used in this task by design).
+
+## 6) Minimal future harness recommendation (for bd-jxclm.14.x follow-up)
+
+If we want live runtime evidence without production DB dependence, add a guarded startup bypass:
+
+- env-gated, e.g. `POC_DISABLE_DB_STARTUP=1`
+- only for POC/internal routes
+- keep default behavior unchanged
+
+This removes ad hoc monkeypatching while preserving production safety.
+
+## 7) Verdict
+
+`operational_gate_blocked_with_exact_causes`
+
+Reason:
+
+- We now have concrete runtime evidence for happy path, fail-closed, and stale-backed behavior (endpoint-level), but operational gate is still blocked by:
+  1. Windmill flow YAML schema/lint failures
+  2. finalize child-failure masking
+  3. no live Windmill workspace execution proof in this no-secrets pass
+


### PR DESCRIPTION
## Summary
- run runtime validation against integrated PR #422 code path in a fresh worktree
- classify live/runtime blockers with exact command evidence and outcomes
- capture happy path, fail-closed, stale-backed, and finalize child-failure propagation behavior
- validate Windmill CLI availability and static YAML parsing via `npx windmill-cli`

## Evidence Artifact
- `docs/research/2026-04-12-bd-jxclm.14.5-runtime-validation.md`

## Key Outcomes
- `npx windmill-cli` is available (even though `wmill` binary is absent)
- static lint reports flow YAML schema errors in branch module shape
- real local HTTP loop via `trigger_pipeline_step.py` works with a no-DB startup harness
- fail-closed decision path is reproducible over real HTTP
- stale-backed is reproducible at endpoint-level with forced provider transition
- finalize currently masks failed child steps as `status=succeeded`

## Notes
- No product logic changes in this PR; report-only evidence update.
- This PR is based on `feature-bd-jxclm.14.4` (PR #422 head).

Agent: codex
Feature-Key: bd-jxclm.14.5