### PR TITLE
bd-jxclm.14.6: document windmill shared-instance workspace model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@
 
 # Universal Baseline — Agent Skills
 <!-- AUTO-GENERATED -->
-<!-- Source SHA: c5c8b61c17a693162ae2cfeaf28235f9f091b8df -->
-<!-- Last updated: 2026-04-11 21:05:38 UTC -->
+<!-- Source SHA: 0c91f6d615f07f67a6432407d6a46ea6633a1759 -->
+<!-- Last updated: 2026-04-12 05:22:02 UTC -->
 <!-- Regenerate: make publish-baseline -->
 
 ## Nakomi Agent Protocol
@@ -209,6 +209,14 @@ cd /tmp/agents/bd-xxxx/repo-name
 - **API keys**: \`op://dev/Agent-Secrets-Production/<FIELD>\` (see SECRETS_INDEX.md).
 - **Railway CLI token**: \`op://dev/Agent-Secrets-Production/RAILWAY_API_TOKEN\` for CI/automation.
 - **Quick reference**: use the \`op-secrets-quickref\` skill.
+
+### 5.0) Agent Secret-Auth Invariant (Always-On)
+
+- For routine agent secret access, raw \`op read\`, \`op item get\`, \`op item list\`, and \`op whoami\` are forbidden.
+- Human GUI-backed OP is bootstrap/recovery only; it is not an acceptable fallback for autonomous agent tasks.
+- Agents must use cache/service-account helpers, preferably \`DX_AUTH_CACHE_ONLY=1 dx_auth_read_secret_cached ...\`.
+- On cache/service-account miss, fail closed with a blocker. Do not fall back to GUI OP.
+- Do not run OP retry loops unless the task is explicitly auth repair.
 
 ### 5.1) Agent Onboarding SOP (Required First Steps)
 

--- a/docs/CRON_ARCHITECTURE.md
+++ b/docs/CRON_ARCHITECTURE.md
@@ -12,6 +12,15 @@ This replaces the legacy Prefect orchestration (removed in `bd-s8id.4`) and Rail
 
 ## Scheduler: Windmill
 
+Shared dev instance:
+- `https://server-dev-8d5b.up.railway.app`
+
+Workspace mapping:
+- affordabot repo assets `f/affordabot/*` -> workspace `affordabot`
+- prime-radiant-ai EODHD assets `f/eodhd/*` -> workspace `eodhd`
+
+The instance is shared, but workspaces are separated by repo/domain.
+
 ### Job Inventory
 
 | Windmill Job | Schedule | Script Entry | Auth |
@@ -97,6 +106,25 @@ wmill sync push --workspace affordabot
 curl -X POST -H "Authorization: Bearer $CRON_SECRET" \
   https://backend-dev-3d99.up.railway.app/cron/discovery
 ```
+
+CLI fallback when `wmill` is unavailable:
+
+```bash
+npx windmill-cli --version
+```
+
+Safe live checks (no secret output):
+
+```bash
+source ~/agent-skills/scripts/lib/dx-auth.sh
+export WINDMILL_API_TOKEN="$(dx_auth_read_secret_cached "op://dev/Agent-Secrets-Production/WINDMILL_API_TOKEN")"
+export WINDMILL_BASE_URL="$(dx_auth_read_secret_cached "op://dev/Agent-Secrets-Production/WINDMILL_DEV_LOGIN_URL")"
+npx windmill-cli version -r "$WINDMILL_BASE_URL"
+npx windmill-cli workspace list-remote -r "$WINDMILL_BASE_URL"
+```
+
+Safety warning:
+- Do not run broad `sync push` without confirming workspace target and schedule mutation intent.
 
 ## Rollback
 

--- a/fragments/universal-baseline.md
+++ b/fragments/universal-baseline.md
@@ -1,7 +1,7 @@
 # Universal Baseline — Agent Skills
 <!-- AUTO-GENERATED -->
-<!-- Source SHA: c5c8b61c17a693162ae2cfeaf28235f9f091b8df -->
-<!-- Last updated: 2026-04-11 21:05:38 UTC -->
+<!-- Source SHA: 0c91f6d615f07f67a6432407d6a46ea6633a1759 -->
+<!-- Last updated: 2026-04-12 05:22:02 UTC -->
 <!-- Regenerate: make publish-baseline -->
 
 ## Nakomi Agent Protocol
@@ -203,6 +203,14 @@ cd /tmp/agents/bd-xxxx/repo-name
 - **API keys**: \`op://dev/Agent-Secrets-Production/<FIELD>\` (see SECRETS_INDEX.md).
 - **Railway CLI token**: \`op://dev/Agent-Secrets-Production/RAILWAY_API_TOKEN\` for CI/automation.
 - **Quick reference**: use the \`op-secrets-quickref\` skill.
+
+### 5.0) Agent Secret-Auth Invariant (Always-On)
+
+- For routine agent secret access, raw \`op read\`, \`op item get\`, \`op item list\`, and \`op whoami\` are forbidden.
+- Human GUI-backed OP is bootstrap/recovery only; it is not an acceptable fallback for autonomous agent tasks.
+- Agents must use cache/service-account helpers, preferably \`DX_AUTH_CACHE_ONLY=1 dx_auth_read_secret_cached ...\`.
+- On cache/service-account miss, fail closed with a blocker. Do not fall back to GUI OP.
+- Do not run OP retry loops unless the task is explicitly auth repair.
 
 ### 5.1) Agent Onboarding SOP (Required First Steps)
 

--- a/ops/windmill/README.md
+++ b/ops/windmill/README.md
@@ -5,6 +5,16 @@
 Windmill is the scheduler of record for affordabot's scheduled jobs.
 Backend remains the execution plane; Windmill handles schedule, trigger, and observability.
 
+## Shared Dev Instance vs Workspace
+
+Windmill dev is a shared Railway-hosted instance:
+- `https://server-dev-8d5b.up.railway.app`
+
+This repo targets a specific workspace on that shared instance:
+- affordabot assets `f/affordabot/*` -> workspace `affordabot`
+
+Do not assume all repos share one workspace.
+
 ## Migration from Railway Cron
 
 As of `bd-s8id.3`, scheduling moved from root `railway.toml` Railway Cron to Windmill.
@@ -37,6 +47,10 @@ Required workspace variables:
 - `f/affordabot/BACKEND_PUBLIC_URL`
 - `f/affordabot/CRON_SECRET`
 - `f/affordabot/SLACK_WEBHOOK_URL`
+
+Auth source for CLI and automation:
+- `op://dev/Agent-Secrets-Production/WINDMILL_API_TOKEN`
+- `op://dev/Agent-Secrets-Production/WINDMILL_DEV_LOGIN_URL`
 
 Slack webhook note:
 - `trigger_cron_job` now normalizes accidentally quoted webhook values (for example `"https://hooks.slack..."`) before posting.
@@ -125,6 +139,31 @@ curl -X POST \
   -H "Authorization: Bearer $CRON_SECRET" \
   https://backend-dev-3d99.up.railway.app/cron/discovery
 ```
+
+If `wmill` is not installed locally:
+
+```bash
+npx windmill-cli --version
+```
+
+Safe auth pattern with cached 1Password helper (token never printed):
+
+```bash
+source ~/agent-skills/scripts/lib/dx-auth.sh
+export WINDMILL_API_TOKEN="$(dx_auth_read_secret_cached "op://dev/Agent-Secrets-Production/WINDMILL_API_TOKEN")"
+export WINDMILL_BASE_URL="$(dx_auth_read_secret_cached "op://dev/Agent-Secrets-Production/WINDMILL_DEV_LOGIN_URL")"
+```
+
+Safe live checks:
+
+```bash
+npx windmill-cli version -r "$WINDMILL_BASE_URL"
+npx windmill-cli workspace list-remote -r "$WINDMILL_BASE_URL"
+```
+
+Sync safety:
+- Always confirm target workspace is `affordabot` before `sync push`.
+- Do not run broad sync operations if schedule mutation intent is not explicit.
 
 ## Manual Operator Run (CLI-Safe)
 


### PR DESCRIPTION
## Summary
- document shared Windmill dev instance and explicit workspace mapping in affordabot docs
- add safe CLI auth pattern using cached 1Password helper without printing token values
- document 
[1mUsage:[22m   [95mwmill[39m  
[1mVersion:[22m [33m1.682.0[39m

[1mDescription:[22m

  Windmill CLI

[1mOptions:[22m

  [94m-h[39m, [94m--help[39m                       [31m[1m-[22m[39m Show this help.                                                                 
  [94m--workspace[39m         [33m<[39m[95mworkspace[39m[33m>[39m  [31m[1m-[22m[39m Specify the target workspace. This overrides the default workspace.             
  [94m--debug[39m, [94m--verbose[39m               [31m[1m-[22m[39m Show debug/verbose logs                                                         
  [94m--show-diffs[39m                     [31m[1m-[22m[39m Show diff informations when syncing (may show sensitive informations)           
  [94m--token[39m             [33m<[39m[95mtoken[39m[33m>[39m      [31m[1m-[22m[39m Specify an API token. This will override any stored token.                      
  [94m--base-url[39m          [33m<[39m[95mbaseUrl[39m[33m>[39m    [31m[1m-[22m[39m Specify the base URL of the API. If used, --token and --workspace are required  
                                     and no local remote/workspace already set will be used.                         
  [94m--config-dir[39m        [33m<[39m[95mconfigDir[39m[33m>[39m  [31m[1m-[22m[39m Specify a custom config directory. Overrides WMILL_CONFIG_DIR environment       
                                     variable and default ~/.config location.                                        

[1mCommands:[22m

  [94minit[39m                                                                             [31m[1m-[22m[39m Bootstrap a windmill project with a wmill.yaml file                            
  [94mapp[39m                                                                              [31m[1m-[22m[39m app related commands                                                           
  [94mflow[39m                                                                             [31m[1m-[22m[39m flow related commands                                                          
  [94mscript[39m                                                                           [31m[1m-[22m[39m script related commands                                                        
  [94mworkspace[39m, [94mprofile[39m                                                               [31m[1m-[22m[39m workspace related commands                                                     
  [94mresource[39m                                                                         [31m[1m-[22m[39m resource related commands                                                      
  [94mresource-type[39m                                                                    [31m[1m-[22m[39m resource type related commands                                                 
  [94muser[39m                                                                             [31m[1m-[22m[39m user related commands                                                          
  [94mvariable[39m                                                                         [31m[1m-[22m[39m variable related commands                                                      
  [94mhub[39m                                                                              [31m[1m-[22m[39m Hub related commands. EXPERIMENTAL. INTERNAL USE ONLY.                         
  [94mfolder[39m                                                                           [31m[1m-[22m[39m folder related commands                                                        
  [94mschedule[39m                                                                         [31m[1m-[22m[39m schedule related commands                                                      
  [94mtrigger[39m                                                                          [31m[1m-[22m[39m trigger related commands                                                       
  [94mdev[39m                                                                              [31m[1m-[22m[39m Launch a dev server that watches for local file changes and auto-pushes them to
                                                                                     the remote workspace. Provides live reload for scripts and flows during        
                                                                                     development.                                                                   
  [94msync[39m                                                                             [31m[1m-[22m[39m sync local with a remote workspaces or the opposite (push or pull)             
  [94mlint[39m                [33m[[39m[95mdirectory[39m[33m][39m                                                  [31m[1m-[22m[39m Validate Windmill flow, schedule, and trigger YAML files in a directory        
  [94mgitsync-settings[39m                                                                 [31m[1m-[22m[39m Manage git-sync settings between local wmill.yaml and Windmill backend         
  [94minstance[39m                                                                         [31m[1m-[22m[39m sync local with a remote instance or the opposite (push or pull)               
  [94mworker-groups[39m                                                                    [31m[1m-[22m[39m display worker groups, pull and push worker groups configs                     
  [94mworkers[39m                                                                          [31m[1m-[22m[39m List all workers grouped by worker groups                                      
  [94mqueues[39m              [33m[[39m[95mworkspace[39m[33m][39m the optional workspace to filter by (default to  [31m[1m-[22m[39m List all queues with their metrics                                             
                      all workspaces)                                                                                                                               
  [94mdependencies[39m, [94mdeps[39m                                                               [31m[1m-[22m[39m workspace dependencies related commands                                        
  [94mjobs[39m                                                                             [31m[1m-[22m[39m Manage jobs (import/export)                                                    
  [94mjob[39m                                                                              [31m[1m-[22m[39m Manage jobs (list, inspect, cancel)                                            
  [94mgroup[39m                                                                            [31m[1m-[22m[39m Manage workspace groups                                                        
  [94maudit[39m                                                                            [31m[1m-[22m[39m View audit logs (requires admin)                                               
  [94mtoken[39m                                                                            [31m[1m-[22m[39m Manage API tokens                                                              
  [94mgenerate-metadata[39m   [33m[[39m[95mfolder[39m[33m][39m                                                     [31m[1m-[22m[39m Generate metadata (locks, schemas) for all scripts, flows, and apps            
  [94mdocs[39m                [33m<[39m[95mquery[39m[33m>[39m                                                      [31m[1m-[22m[39m Search Windmill documentation.                                                 
  [94mconfig[39m                                                                           [31m[1m-[22m[39m Show all available wmill.yaml configuration options                            
  [94mversion[39m, [94m--version[39m                                                               [31m[1m-[22m[39m Show version information                                                       
  [94mupgrade[39m                                                                          [31m[1m-[22m[39m Upgrade wmill executable to latest or given version.                           
  [94mcompletions[39m                                                                      [31m[1m-[22m[39m Generate shell completions.                                                    

[1mEnvironment variables:[22m

  [94mHEADERS[39m  [33m<[39m[95mheaders[39m[33m>[39m  [31m[1m-[22m[39m Specify headers to use for all requests. e.g: "HEADERS='h1: v1, h2: v2'"  

[34mWelcome to Windmill CLI 1.682.0. Use -h for help.[39m fallback and live version/workspace checks
- add operator warning for broad sync push and schedule mutation safety

Feature-Key: bd-jxclm.14.6
Agent: codex