### PR TITLE
bd-9qjof: Windmill domain-boundary POC foundation

### DIFF
--- a/backend/migrations/008_add_pipeline_domain_storage_state.sql
+++ b/backend/migrations/008_add_pipeline_domain_storage_state.sql
@@ -60,7 +60,7 @@ CREATE TABLE IF NOT EXISTS public.pipeline_command_results (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_pipeline_command_results_idempotency
-  ON public.pipeline_command_results (idempotency_key);
+  ON public.pipeline_command_results (command, idempotency_key);
 
 ALTER TABLE IF EXISTS public.pipeline_runs
   ADD COLUMN IF NOT EXISTS orchestrator text,

--- a/backend/migrations/008_add_pipeline_domain_storage_state.sql
+++ b/backend/migrations/008_add_pipeline_domain_storage_state.sql
@@ -1,0 +1,89 @@
+-- Migration: 008_add_pipeline_domain_storage_state.sql
+-- Additive schema for Windmill-domain persisted pipeline state.
+
+CREATE TABLE IF NOT EXISTS public.search_result_snapshots (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  jurisdiction_id text NOT NULL,
+  source_family text NOT NULL,
+  query text NOT NULL,
+  query_hash text NOT NULL,
+  results_hash text NOT NULL,
+  result_count integer NOT NULL DEFAULT 0,
+  snapshot_payload jsonb NOT NULL DEFAULT '[]'::jsonb,
+  contract_version text NOT NULL,
+  idempotency_key text NOT NULL,
+  captured_at timestamp with time zone NOT NULL DEFAULT now(),
+  created_at timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_search_snapshots_scope_hash
+  ON public.search_result_snapshots (jurisdiction_id, source_family, query_hash, results_hash);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_search_snapshots_idempotency
+  ON public.search_result_snapshots (idempotency_key);
+
+CREATE TABLE IF NOT EXISTS public.content_artifacts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  jurisdiction_id text NOT NULL,
+  source_family text NOT NULL,
+  artifact_kind text NOT NULL,
+  content_hash text NOT NULL,
+  storage_uri text NOT NULL,
+  media_type text NOT NULL,
+  size_bytes integer NOT NULL,
+  contract_version text NOT NULL,
+  seen_count integer NOT NULL DEFAULT 1,
+  first_seen_at timestamp with time zone NOT NULL DEFAULT now(),
+  last_seen_at timestamp with time zone NOT NULL DEFAULT now(),
+  created_at timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_content_artifacts_scope_hash
+  ON public.content_artifacts (jurisdiction_id, source_family, artifact_kind, content_hash);
+
+CREATE INDEX IF NOT EXISTS idx_content_artifacts_content_hash
+  ON public.content_artifacts (content_hash);
+
+CREATE TABLE IF NOT EXISTS public.pipeline_command_results (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id uuid REFERENCES public.pipeline_runs(id) ON DELETE CASCADE,
+  command text NOT NULL,
+  idempotency_key text NOT NULL,
+  status text NOT NULL,
+  decision_reason text,
+  retry_class text,
+  refs jsonb NOT NULL DEFAULT '{}'::jsonb,
+  counts jsonb NOT NULL DEFAULT '{}'::jsonb,
+  details jsonb NOT NULL DEFAULT '{}'::jsonb,
+  contract_version text NOT NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pipeline_command_results_idempotency
+  ON public.pipeline_command_results (idempotency_key);
+
+ALTER TABLE IF EXISTS public.pipeline_runs
+  ADD COLUMN IF NOT EXISTS orchestrator text,
+  ADD COLUMN IF NOT EXISTS windmill_workspace text,
+  ADD COLUMN IF NOT EXISTS windmill_run_id text,
+  ADD COLUMN IF NOT EXISTS windmill_job_id text,
+  ADD COLUMN IF NOT EXISTS source_family text,
+  ADD COLUMN IF NOT EXISTS contract_version text,
+  ADD COLUMN IF NOT EXISTS idempotency_key text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pipeline_runs_windmill_scope
+  ON public.pipeline_runs (windmill_run_id, source_family, jurisdiction)
+  WHERE windmill_run_id IS NOT NULL;
+
+ALTER TABLE IF EXISTS public.pipeline_steps
+  ADD COLUMN IF NOT EXISTS command text,
+  ADD COLUMN IF NOT EXISTS retry_class text,
+  ADD COLUMN IF NOT EXISTS decision_reason text,
+  ADD COLUMN IF NOT EXISTS alerts jsonb NOT NULL DEFAULT '[]'::jsonb,
+  ADD COLUMN IF NOT EXISTS refs jsonb NOT NULL DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS windmill_job_id text,
+  ADD COLUMN IF NOT EXISTS idempotency_key text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pipeline_steps_run_command_idempotency
+  ON public.pipeline_steps (run_id, command, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1324,16 +1324,20 @@ async def get_pipeline_run_steps_read_model(
             SELECT
                 id,
                 run_id,
+                command,
                 step_name,
                 status,
                 duration_ms,
-                input_args,
+                input_context,
                 output_result,
-                error,
-                timestamp
+                retry_class,
+                decision_reason,
+                alerts,
+                refs,
+                created_at
             FROM pipeline_steps
             WHERE run_id::text = $1
-            ORDER BY timestamp ASC
+            ORDER BY created_at ASC
             """,
             run_id,
         )
@@ -1342,31 +1346,39 @@ async def get_pipeline_run_steps_read_model(
             output_result = _json_payload(row.get("output_result"))
             step_alerts = output_result.get("alerts")
             if not isinstance(step_alerts, list):
+                step_alerts = row.get("alerts")
+            if not isinstance(step_alerts, list):
                 step_alerts = []
             refs = output_result.get("refs")
             if not isinstance(refs, dict):
+                refs = row.get("refs")
+            if not isinstance(refs, dict):
                 refs = {}
+            decision_reason = _to_text(row.get("decision_reason")) or _to_text(
+                output_result.get("decision_reason")
+            )
+            retry_class = _to_text(row.get("retry_class")) or _to_text(
+                output_result.get("retry_class")
+            )
 
             steps.append(
                 {
                     "contract_version": CONTRACT_VERSION,
                     "step_id": _to_text(row.get("id")),
                     "run_id": _to_text(row.get("run_id")),
-                    "command": _to_text(row.get("step_name")),
+                    "command": _to_text(row.get("command"))
+                    or _to_text(row.get("step_name")),
                     "status": _to_text(row.get("status")),
-                    "decision_reason": _to_text(
-                        output_result.get("decision_reason")
-                    )
-                    or None,
-                    "retry_class": _to_text(output_result.get("retry_class")) or "none",
+                    "decision_reason": decision_reason or None,
+                    "retry_class": retry_class or "none",
                     "alerts": [_to_text(item) for item in step_alerts if _to_text(item)],
                     "counts": output_result.get("counts")
                     if isinstance(output_result.get("counts"), dict)
                     else {},
                     "refs": refs,
                     "duration_ms": _coerce_int(row.get("duration_ms")),
-                    "error": _to_text(row.get("error")) or None,
-                    "timestamp": str(row["timestamp"]) if row.get("timestamp") else None,
+                    "error": _to_text(output_result.get("error")) or None,
+                    "timestamp": str(row["created_at"]) if row.get("created_at") else None,
                 }
             )
         return {"contract_version": CONTRACT_VERSION, "run_id": run_id, "steps": steps}

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -2,9 +2,11 @@ from fastapi import APIRouter, Depends, Request, HTTPException
 from typing import Any, List, Optional
 from pydantic import BaseModel
 import json
+import os
 from services.glass_box import GlassBoxService, AgentStep, PipelineStep
 from auth.clerk import require_admin_user
 from db.postgres_client import PostgresDB
+from services.pipeline.domain.constants import CONTRACT_VERSION
 from scripts.substrate.substrate_inspection_report import (
     build_substrate_inspection_report,
     fetch_raw_scrapes_for_run,
@@ -15,6 +17,30 @@ router = APIRouter(
     tags=["admin"],
     dependencies=[Depends(require_admin_user)],
 )
+
+DEFAULT_SOURCE_FAMILY = "meeting_minutes"
+FRESHNESS_POLICY_BY_SOURCE_FAMILY: dict[str, dict[str, int]] = {
+    "meeting_minutes": {
+        "fresh_hours": 24,
+        "stale_usable_ceiling_hours": 72,
+        "fail_closed_ceiling_hours": 168,
+    },
+    "agendas": {
+        "fresh_hours": 24,
+        "stale_usable_ceiling_hours": 72,
+        "fail_closed_ceiling_hours": 168,
+    },
+    "legislation": {
+        "fresh_hours": 24,
+        "stale_usable_ceiling_hours": 48,
+        "fail_closed_ceiling_hours": 120,
+    },
+    "general_web_reference": {
+        "fresh_hours": 48,
+        "stale_usable_ceiling_hours": 168,
+        "fail_closed_ceiling_hours": 336,
+    },
+}
 
 
 # Dependency to get the database client
@@ -171,6 +197,129 @@ def _serialize_substrate_row(
         payload["ingestion_truth"] = truth
 
     return payload
+
+
+def _coerce_int(value: Any, default: int = 0) -> int:
+    if isinstance(value, int):
+        return value
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _normalize_source_family(source_family: Optional[str]) -> str:
+    text = _to_text(source_family).lower()
+    return text if text else DEFAULT_SOURCE_FAMILY
+
+
+def _freshness_policy(source_family: str) -> dict[str, int]:
+    return FRESHNESS_POLICY_BY_SOURCE_FAMILY.get(
+        source_family, FRESHNESS_POLICY_BY_SOURCE_FAMILY[DEFAULT_SOURCE_FAMILY]
+    )
+
+
+def _extract_counts(result: dict[str, Any]) -> dict[str, int]:
+    search_results = _coerce_int(
+        result.get("search_results_count")
+        or result.get("search_results")
+        or result.get("discovered_sources")
+        or result.get("source_count")
+    )
+    raw_scrapes = _coerce_int(
+        result.get("raw_scrapes_count")
+        or result.get("raw_scrapes")
+        or result.get("captured_count")
+        or result.get("sources_processed")
+    )
+    chunks = _coerce_int(
+        result.get("chunks")
+        or result.get("chunk_count")
+        or result.get("rag_chunks_retrieved")
+        or result.get("validated_evidence_count")
+    )
+    artifacts = _coerce_int(result.get("artifact_count") or result.get("artifacts"))
+    if artifacts == 0 and _to_bool(result.get("source_text_present")):
+        artifacts = 1
+
+    analysis_obj = result.get("analysis")
+    analyses = 1 if isinstance(analysis_obj, dict) and analysis_obj else 0
+
+    return {
+        "search_results": search_results,
+        "raw_scrapes": raw_scrapes,
+        "artifacts": artifacts,
+        "chunks": chunks,
+        "analyses": analyses,
+    }
+
+
+def _extract_latest_analysis(result: dict[str, Any], counts: dict[str, int]) -> dict[str, Any]:
+    analysis = result.get("analysis")
+    ready = isinstance(analysis, dict) and bool(analysis)
+    evidence_count = _coerce_int(result.get("validated_evidence_count") or counts.get("chunks"))
+    if ready:
+        status = "ready"
+    elif evidence_count > 0:
+        status = "not_ready"
+    else:
+        status = "blocked"
+
+    sufficiency_state = result.get("sufficiency_state")
+    if not sufficiency_state:
+        if _to_bool(result.get("quantification_eligible")):
+            sufficiency_state = "quantitative_ready"
+        elif evidence_count > 0:
+            sufficiency_state = "qualitative_only"
+        else:
+            sufficiency_state = "insufficient_evidence"
+
+    return {
+        "status": status,
+        "sufficiency_state": sufficiency_state,
+        "evidence_count": evidence_count,
+    }
+
+
+def _extract_pipeline_alerts(result: dict[str, Any]) -> list[str]:
+    alerts_raw = result.get("alerts")
+    if isinstance(alerts_raw, list):
+        return [_to_text(item) for item in alerts_raw if _to_text(item)]
+    alerts: list[str] = []
+    insufficiency_reason = _to_text(result.get("insufficiency_reason"))
+    if insufficiency_reason:
+        alerts.append(f"insufficiency:{insufficiency_reason}")
+    if _coerce_int(result.get("rag_chunks_retrieved")) == 0 and _to_bool(
+        result.get("retriever_invoked")
+    ):
+        alerts.append("retriever_returned_no_chunks")
+    return alerts
+
+
+def _derive_pipeline_status(run_status: str, freshness_status: str) -> str:
+    if freshness_status and freshness_status != "unknown":
+        return freshness_status
+    if run_status in {"completed"}:
+        return "fresh"
+    if run_status in {"failed", "prefix_halted", "interrupted", "fixture_invalid"}:
+        return "stale_blocked"
+    return "unknown"
+
+
+def _build_windmill_run_url(windmill_run_id: Optional[str]) -> Optional[str]:
+    run_id = _to_text(windmill_run_id)
+    if not run_id:
+        return None
+    base = _to_text(os.getenv("WINDMILL_BASE_URL"))
+    if not base:
+        return f"/windmill/runs/{run_id}"
+    return f"{base.rstrip('/')}/runs/{run_id}"
+
+
+def _json_payload(value: Any) -> dict[str, Any]:
+    return _to_json_dict(value)
 
 
 # ============================================================================
@@ -1011,6 +1160,316 @@ async def get_bill_truth(
     except Exception as e:
         raise HTTPException(
             status_code=500, detail=f"Bill truth diagnostic failed: {str(e)}"
+        )
+
+
+# ============================================================================
+# PIPELINE READ MODEL ENDPOINTS (bd-9qjof.5)
+# ============================================================================
+
+
+@router.get("/pipeline/jurisdictions/{jurisdiction_id}/status")
+async def get_pipeline_jurisdiction_status(
+    jurisdiction_id: str,
+    source_family: str = DEFAULT_SOURCE_FAMILY,
+    db: PostgresDB = Depends(get_db),
+):
+    """Backend-authored pipeline status for admin/frontend consumption."""
+    try:
+        jurisdiction = await find_jurisdiction(db, jurisdiction_id)
+        jur_name = _to_text(jurisdiction["name"])
+        jur_id = _to_text(jurisdiction["id"])
+        normalized_source_family = _normalize_source_family(source_family)
+        policy = _freshness_policy(normalized_source_family)
+
+        run_query = """
+            SELECT
+                id,
+                jurisdiction,
+                status,
+                started_at,
+                completed_at,
+                error,
+                result,
+                windmill_run_id
+            FROM pipeline_runs
+            WHERE LOWER(COALESCE(jurisdiction, '')) IN (LOWER($1), LOWER($2))
+            ORDER BY started_at DESC
+            LIMIT 1
+        """
+        latest_run = await db._fetchrow(run_query, jur_name, jur_id)
+
+        latest_success_query = """
+            SELECT completed_at
+            FROM pipeline_runs
+            WHERE LOWER(COALESCE(jurisdiction, '')) IN (LOWER($1), LOWER($2))
+              AND status = 'completed'
+              AND completed_at IS NOT NULL
+            ORDER BY completed_at DESC
+            LIMIT 1
+        """
+        latest_success = await db._fetchrow(latest_success_query, jur_name, jur_id)
+
+        result = _json_payload(latest_run.get("result")) if latest_run else {}
+        run_status = _to_text(latest_run.get("status")) if latest_run else ""
+        counts = _extract_counts(result)
+        latest_analysis = _extract_latest_analysis(result, counts)
+
+        freshness_result = _json_payload(result.get("freshness"))
+        freshness_status = _to_text(freshness_result.get("status")) or "unknown"
+        freshness_alerts = freshness_result.get("alerts")
+        if not isinstance(freshness_alerts, list):
+            freshness_alerts = _extract_pipeline_alerts(result)
+        pipeline_status = _derive_pipeline_status(run_status, freshness_status)
+
+        response = {
+            "contract_version": CONTRACT_VERSION,
+            "jurisdiction_id": jur_id,
+            "jurisdiction_name": jur_name,
+            "source_family": normalized_source_family,
+            "pipeline_status": pipeline_status,
+            "last_success_at": str(latest_success["completed_at"])
+            if latest_success and latest_success.get("completed_at")
+            else None,
+            "freshness": {
+                "status": freshness_status,
+                "fresh_hours": policy["fresh_hours"],
+                "stale_usable_ceiling_hours": policy["stale_usable_ceiling_hours"],
+                "fail_closed_ceiling_hours": policy["fail_closed_ceiling_hours"],
+                "alerts": [_to_text(alert) for alert in freshness_alerts if _to_text(alert)],
+            },
+            "counts": counts,
+            "latest_analysis": latest_analysis,
+            "alerts": _extract_pipeline_alerts(result),
+            "operator_links": {
+                "windmill_run_url": _build_windmill_run_url(
+                    latest_run.get("windmill_run_id") if latest_run else None
+                ),
+            },
+        }
+        return response
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, detail=f"Failed to fetch pipeline jurisdiction status: {str(e)}"
+        )
+
+
+@router.get("/pipeline/runs/{run_id}")
+async def get_pipeline_run_read_model(run_id: str, db: PostgresDB = Depends(get_db)):
+    """Return backend-authored run summary for pipeline UI."""
+    try:
+        row = await db._fetchrow(
+            """
+            SELECT
+                id,
+                bill_id,
+                jurisdiction,
+                status,
+                started_at,
+                completed_at,
+                error,
+                result,
+                trigger_source,
+                windmill_workspace,
+                windmill_run_id,
+                source_family
+            FROM pipeline_runs
+            WHERE id::text = $1
+            LIMIT 1
+            """,
+            run_id,
+        )
+        if not row:
+            raise HTTPException(status_code=404, detail="Pipeline run not found")
+
+        result = _json_payload(row.get("result"))
+        counts = _extract_counts(result)
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "run_id": _to_text(row.get("id")),
+            "status": _to_text(row.get("status")),
+            "jurisdiction": _to_text(row.get("jurisdiction")),
+            "source_family": _to_text(row.get("source_family")) or DEFAULT_SOURCE_FAMILY,
+            "bill_id": _to_text(row.get("bill_id")) or None,
+            "started_at": str(row["started_at"]) if row.get("started_at") else None,
+            "completed_at": str(row["completed_at"]) if row.get("completed_at") else None,
+            "error": _to_text(row.get("error")) or None,
+            "trigger_source": _to_text(row.get("trigger_source")) or None,
+            "counts": counts,
+            "latest_analysis": _extract_latest_analysis(result, counts),
+            "alerts": _extract_pipeline_alerts(result),
+            "operator_links": {
+                "windmill_workspace": _to_text(row.get("windmill_workspace")) or "affordabot",
+                "windmill_run_url": _build_windmill_run_url(row.get("windmill_run_id")),
+            },
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, detail=f"Failed to fetch pipeline run details: {str(e)}"
+        )
+
+
+@router.get("/pipeline/runs/{run_id}/steps")
+async def get_pipeline_run_steps_read_model(
+    run_id: str, db: PostgresDB = Depends(get_db)
+):
+    """Return run steps in a stable read-model shape."""
+    try:
+        rows = await db._fetch(
+            """
+            SELECT
+                id,
+                run_id,
+                step_name,
+                status,
+                duration_ms,
+                input_args,
+                output_result,
+                error,
+                timestamp
+            FROM pipeline_steps
+            WHERE run_id::text = $1
+            ORDER BY timestamp ASC
+            """,
+            run_id,
+        )
+        steps: list[dict[str, Any]] = []
+        for row in rows:
+            output_result = _json_payload(row.get("output_result"))
+            step_alerts = output_result.get("alerts")
+            if not isinstance(step_alerts, list):
+                step_alerts = []
+            refs = output_result.get("refs")
+            if not isinstance(refs, dict):
+                refs = {}
+
+            steps.append(
+                {
+                    "contract_version": CONTRACT_VERSION,
+                    "step_id": _to_text(row.get("id")),
+                    "run_id": _to_text(row.get("run_id")),
+                    "command": _to_text(row.get("step_name")),
+                    "status": _to_text(row.get("status")),
+                    "decision_reason": _to_text(
+                        output_result.get("decision_reason")
+                    )
+                    or None,
+                    "retry_class": _to_text(output_result.get("retry_class")) or "none",
+                    "alerts": [_to_text(item) for item in step_alerts if _to_text(item)],
+                    "counts": output_result.get("counts")
+                    if isinstance(output_result.get("counts"), dict)
+                    else {},
+                    "refs": refs,
+                    "duration_ms": _coerce_int(row.get("duration_ms")),
+                    "error": _to_text(row.get("error")) or None,
+                    "timestamp": str(row["timestamp"]) if row.get("timestamp") else None,
+                }
+            )
+        return {"contract_version": CONTRACT_VERSION, "run_id": run_id, "steps": steps}
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, detail=f"Failed to fetch pipeline run steps: {str(e)}"
+        )
+
+
+@router.get("/pipeline/runs/{run_id}/evidence")
+async def get_pipeline_run_evidence(run_id: str, db: PostgresDB = Depends(get_db)):
+    """Return evidence refs for a run without exposing storage internals."""
+    try:
+        row = await db._fetchrow(
+            """
+            SELECT id, result
+            FROM pipeline_runs
+            WHERE id::text = $1
+            LIMIT 1
+            """,
+            run_id,
+        )
+        if not row:
+            raise HTTPException(status_code=404, detail="Pipeline run not found")
+
+        result = _json_payload(row.get("result"))
+        analysis = result.get("analysis")
+        evidence_items: list[dict[str, Any]] = []
+        if isinstance(analysis, dict):
+            citations = analysis.get("citations")
+            if isinstance(citations, list):
+                for idx, citation in enumerate(citations):
+                    citation_dict = citation if isinstance(citation, dict) else {"value": citation}
+                    evidence_items.append(
+                        {
+                            "id": f"citation-{idx + 1}",
+                            "type": _to_text(citation_dict.get("type")) or "citation",
+                            "label": _to_text(citation_dict.get("label"))
+                            or _to_text(citation_dict.get("source"))
+                            or f"Citation {idx + 1}",
+                            "confidence": citation_dict.get("confidence"),
+                            "source_ref": _to_text(citation_dict.get("source_ref"))
+                            or _to_text(citation_dict.get("source"))
+                            or None,
+                        }
+                    )
+
+        if not evidence_items:
+            evidence_count = _coerce_int(result.get("validated_evidence_count"))
+            for idx in range(evidence_count):
+                evidence_items.append(
+                    {
+                        "id": f"evidence-{idx + 1}",
+                        "type": "validated_chunk",
+                        "label": f"Evidence {idx + 1}",
+                        "confidence": None,
+                        "source_ref": None,
+                    }
+                )
+
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "run_id": run_id,
+            "evidence_count": len(evidence_items),
+            "items": evidence_items,
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, detail=f"Failed to fetch pipeline run evidence: {str(e)}"
+        )
+
+
+@router.post("/pipeline/jurisdictions/{jurisdiction_id}/refresh")
+async def refresh_pipeline_jurisdiction(
+    jurisdiction_id: str,
+    source_family: str = DEFAULT_SOURCE_FAMILY,
+    db: PostgresDB = Depends(get_db),
+):
+    """
+    Backend-mediated manual refresh request.
+
+    In Wave 2 this is an accepted contract endpoint; live Windmill trigger wiring
+    is implemented in the integration wave.
+    """
+    try:
+        jurisdiction = await find_jurisdiction(db, jurisdiction_id)
+        normalized_source_family = _normalize_source_family(source_family)
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "status": "accepted",
+            "decision_reason": "manual_refresh_queued",
+            "jurisdiction_id": _to_text(jurisdiction["id"]),
+            "jurisdiction_name": _to_text(jurisdiction["name"]),
+            "source_family": normalized_source_family,
+            "message": "Manual refresh accepted. Windmill dispatch wiring is pending integration.",
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, detail=f"Failed to queue manual refresh: {str(e)}"
         )
 
 

--- a/backend/scripts/verification/verify_windmill_domain_boundary_local_integration.py
+++ b/backend/scripts/verification/verify_windmill_domain_boundary_local_integration.py
@@ -14,6 +14,9 @@ from pathlib import Path
 from typing import Any
 
 
+STABLE_CREATED_AT = "2026-04-13T00:00:00+00:00"
+
+
 def _load_windmill_script() -> Any:
     repo_root = Path(__file__).resolve().parents[3]
     script_path = (
@@ -58,7 +61,7 @@ def _default_md_path(repo_root: Path) -> Path:
 
 def run_verification() -> dict[str, Any]:
     module = _load_windmill_script()
-    return module.main(
+    report = module.main(
         step="run_local_integration_harness",
         idempotency_key="run:bd-9qjof.6:san-jose",
         scope_item={"jurisdiction": "San Jose CA", "source_family": "meeting_minutes"},
@@ -67,6 +70,18 @@ def run_verification() -> dict[str, Any]:
         windmill_run_id="wm-local-bd9qjof6",
         windmill_job_id="wm-local-job-bd9qjof6",
     )
+    return _stabilize_report(report)
+
+
+def _stabilize_report(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: STABLE_CREATED_AT if key == "created_at" else _stabilize_report(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_stabilize_report(item) for item in value]
+    return value
 
 
 def _to_markdown(report: dict[str, Any]) -> str:

--- a/backend/scripts/verification/verify_windmill_domain_boundary_local_integration.py
+++ b/backend/scripts/verification/verify_windmill_domain_boundary_local_integration.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Local integration verifier for Windmill-shaped domain boundary orchestration.
+
+This script does not perform network or external storage calls. It runs a deterministic
+in-memory chain:
+Windmill script shape -> coarse domain commands -> in-memory state -> evidence artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_windmill_script() -> Any:
+    repo_root = Path(__file__).resolve().parents[3]
+    script_path = (
+        repo_root
+        / "ops"
+        / "windmill"
+        / "f"
+        / "affordabot"
+        / "pipeline_daily_refresh_domain_boundary.py"
+    )
+    spec = __import__("importlib.util").util.spec_from_file_location(
+        "pipeline_daily_refresh_domain_boundary", script_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load windmill script module")
+    module = __import__("importlib.util").util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _default_json_path(repo_root: Path) -> Path:
+    return (
+        repo_root
+        / "docs"
+        / "poc"
+        / "windmill-domain-boundary-integration"
+        / "artifacts"
+        / "local_integration_report.json"
+    )
+
+
+def _default_md_path(repo_root: Path) -> Path:
+    return (
+        repo_root
+        / "docs"
+        / "poc"
+        / "windmill-domain-boundary-integration"
+        / "artifacts"
+        / "local_integration_report.md"
+    )
+
+
+def run_verification() -> dict[str, Any]:
+    module = _load_windmill_script()
+    return module.main(
+        step="run_local_integration_harness",
+        idempotency_key="run:bd-9qjof.6:san-jose",
+        scope_item={"jurisdiction": "San Jose CA", "source_family": "meeting_minutes"},
+        search_query="San Jose city council meeting minutes housing",
+        analysis_question="Summarize housing and planning actions from the minutes.",
+        windmill_run_id="wm-local-bd9qjof6",
+        windmill_job_id="wm-local-job-bd9qjof6",
+    )
+
+
+def _to_markdown(report: dict[str, Any]) -> str:
+    evidence = report["evidence"]
+    scenarios = report["scenarios"]
+    happy = scenarios["happy_first"]
+    rerun = scenarios["happy_rerun"]
+    blocked = scenarios["stale_blocked"]
+    lines = [
+        "# Windmill Domain Boundary Local Integration Evidence",
+        "",
+        "## Run Verdict",
+        f"- status: `{report['status']}`",
+        "",
+        "## Evidence Checks",
+        f"- happy_status: `{evidence['happy_status']}`",
+        f"- rerun_status: `{evidence['rerun_status']}`",
+        f"- stale_blocked_status: `{evidence['stale_blocked_status']}`",
+        f"- rerun_index_idempotent_reuse: `{evidence['rerun_index_idempotent_reuse']}`",
+        f"- rerun_chunk_count_stable: `{evidence['rerun_chunk_count_stable']}`",
+        f"- stale_blocked_short_circuit: `{evidence['stale_blocked_short_circuit']}`",
+        f"- windmill_refs_propagated: `{evidence['windmill_refs_propagated']}`",
+        "",
+        "## Scenario Summaries",
+        f"- happy_first steps: `{', '.join(happy['steps'].keys())}`",
+        f"- happy_rerun steps: `{', '.join(rerun['steps'].keys())}`",
+        f"- stale_blocked steps: `{', '.join(blocked['steps'].keys())}`",
+        "",
+        "## Notes",
+        "- Windmill path uses coarse commands only.",
+        "- No external network/database/object/vector service calls were made.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out-json", type=Path, default=None)
+    parser.add_argument("--out-md", type=Path, default=None)
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[3]
+    out_json = args.out_json or _default_json_path(repo_root)
+    out_md = args.out_md or _default_md_path(repo_root)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+
+    report = run_verification()
+    out_json.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    out_md.write_text(_to_markdown(report), encoding="utf-8")
+
+    print(f"Wrote JSON report: {out_json}")
+    print(f"Wrote Markdown report: {out_md}")
+    print(f"Run status: {report['status']}")
+    return 0 if report["status"] == "succeeded" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/verification/windmill_bakeoff_direct_storage.py
+++ b/backend/scripts/verification/windmill_bakeoff_direct_storage.py
@@ -841,6 +841,8 @@ def write_markdown(path: Path, content: str) -> None:
 def render_run_evidence(suite: dict[str, Any]) -> str:
     first = suite["runs"]["first"]
     rerun = suite["runs"]["rerun"]
+    stale_usable = suite["stale_gate"]["stale_usable"]
+    stale_blocked = suite["stale_gate"]["stale_blocked"]
     return textwrap.dedent(
         f"""
         # Path A Run Evidence
@@ -877,6 +879,23 @@ def render_run_evidence(suite: dict[str, Any]) -> str:
         - chunks stable: `{suite["checks"]["chunks_stable"]}`
         - analyses stable: `{suite["checks"]["analyses_stable"]}`
         - overall idempotent: `{suite["checks"]["idempotent"]}`
+
+        ## Freshness Gate Drills
+
+        - stale usable status: `{stale_usable["status"]}`
+        - stale usable alert count: `{len(stale_usable["alerts"])}`
+        - stale usable freshness step: `{stale_usable["steps"][1]["status"] if len(stale_usable["steps"]) > 1 else "n/a"}`
+        - stale blocked status: `{stale_blocked["status"]}`
+        - stale blocked reason: `{stale_blocked["reason"]}`
+        - stale blocked terminal freshness step: `{stale_blocked["steps"][1]["status"] if len(stale_blocked["steps"]) > 1 else "n/a"}`
+
+        ## Windmill Mapping Limitation
+
+        The committed flow export is Windmill-shaped, but Path A execution still concentrates
+        most domain-like behavior in one script implementation. This proves direct-storage viability,
+        not full Windmill-native step decomposition. A truly maximal Windmill implementation would
+        require step-level storage context handoff or more granular scripts, which shifts more domain
+        invariants into Windmill code.
         """
     ).strip()
 
@@ -898,13 +917,36 @@ def render_storage_snapshots(suite: dict[str, Any]) -> str:
 
 
 def render_failure_drills(suite: dict[str, Any]) -> str:
-    rows = []
-    for name, result in suite["failures"].items():
-        rows.append(f"- `{name}` => status `{result['status']}` reason `{result['reason']}`")
-    bullets = "\n".join(rows)
+    warm_rows = []
+    for name, result in suite["failures"]["warm_state"].items():
+        warm_rows.append(
+            "- `{name}` => status `{status}` reason `{reason}` objects `{objects}`".format(
+                name=name,
+                status=result["status"],
+                reason=result["reason"],
+                objects=result["counts"]["objects_total"],
+            )
+        )
+    cold_rows = []
+    for name, payload in suite["failures"]["cold_state"].items():
+        result = payload["result"]
+        cold_rows.append(
+            "- `{name}` => status `{status}` reason `{reason}` objects `{objects}` state_dir `{state_dir}`".format(
+                name=name,
+                status=result["status"],
+                reason=result["reason"],
+                objects=result["counts"]["objects_total"],
+                state_dir=payload["state_dir"],
+            )
+        )
+    warm_bullets = "\n".join(warm_rows)
+    cold_bullets = "\n".join(cold_rows)
     return (
         "# Path A Failure Drills\n\n"
-        f"{bullets}\n\n"
+        "## Warm-State Failures (after successful baseline run)\n\n"
+        f"{warm_bullets}\n\n"
+        "## Cold-State Failures (isolated fresh state per drill)\n\n"
+        f"{cold_bullets}\n\n"
         "Expected terminal statuses:\n"
         f"- SearXNG failure => `{STATUS_SOURCE_ERROR}`\n"
         f"- Reader failure => `{STATUS_READER_ERROR}`\n"
@@ -924,16 +966,48 @@ def run_suite(args: argparse.Namespace) -> dict[str, Any]:
     run_date = args.run_date or now_utc().date().isoformat()
     first = runner.run(run_date=run_date, scenario="normal")
     rerun = runner.run(run_date=run_date, scenario="normal")
+    stale_usable = runner.run(
+        run_date=run_date,
+        scenario="normal",
+        stale_usable_hours=args.stale_usable_hours,
+        stale_blocked_hours=args.stale_blocked_hours,
+        force_stale_hours=max(args.stale_usable_hours + 12, 36),
+    )
+    stale_blocked = runner.run(
+        run_date=run_date,
+        scenario="normal",
+        stale_usable_hours=args.stale_usable_hours,
+        stale_blocked_hours=args.stale_blocked_hours,
+        force_stale_hours=max(args.stale_blocked_hours + 24, 96),
+    )
+
     searx_failure = runner.run(run_date=run_date, scenario="searx_failure")
     reader_failure = runner.run(run_date=run_date, scenario="reader_failure")
     storage_failure = runner.run(run_date=run_date, scenario="storage_failure")
+
+    def run_cold_failure(scenario: str) -> dict[str, Any]:
+        isolated_dir = state_dir.parent / f"{state_dir.name}__cold_{scenario}"
+        if isolated_dir.exists():
+            shutil.rmtree(isolated_dir)
+        isolated_runner = DirectStoragePipelineRunner(
+            state_dir=isolated_dir,
+            searx_endpoint=args.searx_endpoint,
+            allow_live_zai=args.allow_live_zai,
+        )
+        result = isolated_runner.run(run_date=run_date, scenario=scenario)
+        return {"state_dir": str(isolated_dir), "result": result}
 
     checks = {
         "documents_stable": first["counts"]["documents_total"] == rerun["counts"]["documents_total"],
         "chunks_stable": first["counts"]["chunks_total"] == rerun["counts"]["chunks_total"],
         "analyses_stable": first["counts"]["analyses_total"] == rerun["counts"]["analyses_total"],
+        "stale_usable_status": stale_usable["status"] == STATUS_SUCCEEDED,
+        "stale_usable_alerted": "stale_backed=true" in stale_usable.get("alerts", []),
+        "stale_blocked_status": stale_blocked["status"] == STATUS_STALE_BLOCKED,
     }
-    checks["idempotent"] = all(checks.values())
+    checks["idempotent"] = (
+        checks["documents_stable"] and checks["chunks_stable"] and checks["analyses_stable"]
+    )
 
     suite = {
         "generated_at": utc_iso(),
@@ -941,10 +1015,21 @@ def run_suite(args: argparse.Namespace) -> dict[str, Any]:
         "run_date": run_date,
         "checks": checks,
         "runs": {"first": first, "rerun": rerun},
+        "stale_gate": {
+            "stale_usable": stale_usable,
+            "stale_blocked": stale_blocked,
+        },
         "failures": {
-            "searx_failure": searx_failure,
-            "reader_failure": reader_failure,
-            "storage_failure": storage_failure,
+            "warm_state": {
+                "searx_failure": searx_failure,
+                "reader_failure": reader_failure,
+                "storage_failure": storage_failure,
+            },
+            "cold_state": {
+                "searx_failure": run_cold_failure("searx_failure"),
+                "reader_failure": run_cold_failure("reader_failure"),
+                "storage_failure": run_cold_failure("storage_failure"),
+            },
         },
         "live_flags": {
             "searx_endpoint_configured": bool(args.searx_endpoint),
@@ -1016,6 +1101,8 @@ def build_parser() -> argparse.ArgumentParser:
     suite_parser.add_argument("--searx-endpoint", default=None)
     suite_parser.add_argument("--allow-live-zai", action="store_true")
     suite_parser.add_argument("--reset-state", action="store_true")
+    suite_parser.add_argument("--stale-usable-hours", type=int, default=24)
+    suite_parser.add_argument("--stale-blocked-hours", type=int, default=72)
 
     return parser
 

--- a/backend/scripts/verification/windmill_bakeoff_direct_storage.py
+++ b/backend/scripts/verification/windmill_bakeoff_direct_storage.py
@@ -1,0 +1,1035 @@
+#!/usr/bin/env python3
+"""Windmill-shaped Path A bakeoff runner: direct storage writes without backend endpoints."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import textwrap
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from urllib.error import URLError, HTTPError
+from urllib.parse import urlencode, urlparse
+from urllib.request import Request, urlopen
+
+
+CONTRACT_VERSION = "2026-04-12.windmill-storage-bakeoff.v1"
+ARCH_PATH = "windmill_direct_storage"
+DEFAULT_STATE_DIR = (
+    Path("docs/poc/windmill-storage-bakeoff/path-a-direct-storage/runtime_state")
+)
+DEFAULT_EVIDENCE_DIR = Path("docs/poc/windmill-storage-bakeoff/path-a-direct-storage")
+DEFAULT_SEARX_QUERY = "San Jose CA city council meeting minutes"
+DEFAULT_SOURCE_FAMILY = "meeting_minutes"
+DEFAULT_JURISDICTION = "San Jose CA"
+
+STATUS_FRESH = "fresh"
+STATUS_STALE_USABLE = "stale_but_usable"
+STATUS_STALE_BLOCKED = "stale_blocked"
+STATUS_EMPTY = "empty_result"
+STATUS_SOURCE_ERROR = "source_error"
+STATUS_READER_ERROR = "reader_error"
+STATUS_STORAGE_ERROR = "storage_error"
+STATUS_ANALYSIS_ERROR = "analysis_error"
+STATUS_SUCCEEDED = "succeeded"
+
+TERMINAL_FAILURE_STATUSES = {
+    STATUS_SOURCE_ERROR,
+    STATUS_READER_ERROR,
+    STATUS_STORAGE_ERROR,
+    STATUS_ANALYSIS_ERROR,
+    STATUS_STALE_BLOCKED,
+}
+
+DEFAULT_SEARX_FIXTURE: dict[str, Any] = {
+    "query": DEFAULT_SEARX_QUERY,
+    "number_of_results": 3,
+    "results": [
+        {
+            "title": "City Council Meetings - City of San Jose",
+            "url": "https://www.sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meetings",
+            "content": "Public agendas and minutes for San Jose City Council meetings.",
+        },
+        {
+            "title": "Meeting Agenda and Minutes | City of San Jose",
+            "url": "https://sanjose.legistar.com/Calendar.aspx",
+            "content": "Calendar portal with agendas, minutes, and archived packets.",
+        },
+        {
+            "title": "San Jose Open Data - Council Minutes",
+            "url": "https://data.sanjoseca.gov/",
+            "content": "Open data portal with civic documents including meeting records.",
+        },
+    ],
+}
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def utc_iso(value: datetime | None = None) -> str:
+    ts = value or now_utc()
+    return ts.astimezone(timezone.utc).isoformat()
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def load_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def slugify(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+
+
+def canonical_document_key(url: str) -> str:
+    parsed = urlparse(url)
+    host = parsed.netloc.lower().replace("www.", "")
+    path = parsed.path.rstrip("/") or "/"
+    key = f"{host}{path}"
+    return key.lower()
+
+
+def chunk_text(text: str, chunk_size: int = 450, overlap: int = 80) -> list[str]:
+    cleaned = " ".join(text.split())
+    if not cleaned:
+        return []
+    if len(cleaned) <= chunk_size:
+        return [cleaned]
+    chunks: list[str] = []
+    start = 0
+    while start < len(cleaned):
+        end = min(len(cleaned), start + chunk_size)
+        chunk = cleaned[start:end].strip()
+        if chunk:
+            chunks.append(chunk)
+        if end >= len(cleaned):
+            break
+        start = max(0, end - overlap)
+    return chunks
+
+
+def deterministic_embedding(text: str, dims: int = 12) -> list[float]:
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    vec: list[float] = []
+    for i in range(dims):
+        raw = digest[i] / 255.0
+        vec.append((raw * 2.0) - 1.0)
+    return vec
+
+
+def cosine_similarity(a: list[float], b: list[float]) -> float:
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    mag_a = sum(x * x for x in a) ** 0.5
+    mag_b = sum(y * y for y in b) ** 0.5
+    if mag_a == 0 or mag_b == 0:
+        return 0.0
+    return dot / (mag_a * mag_b)
+
+
+@dataclass
+class ArtifactRef:
+    ref: str
+    key: str
+    sha256: str
+    bytes: int
+    content_type: str
+
+
+class DirectObjectStore:
+    """Deterministic MinIO-compatible local adapter with stable refs."""
+
+    def __init__(self, root: Path):
+        self.root = root
+        self.bucket = "affordabot-artifacts"
+        self.index_path = self.root / "object_store_index.json"
+        self.objects_dir = self.root / "objects"
+        self.index: dict[str, Any] = load_json(self.index_path, {"objects": {}})
+        self.objects_dir.mkdir(parents=True, exist_ok=True)
+
+    def put(
+        self,
+        key: str,
+        payload: bytes,
+        content_type: str = "application/octet-stream",
+        fail: bool = False,
+    ) -> ArtifactRef:
+        if fail:
+            raise RuntimeError("simulated_storage_error")
+        sha = hashlib.sha256(payload).hexdigest()
+        ext = ".json" if content_type == "application/json" else ".txt"
+        object_name = f"{sha}{ext}"
+        object_path = self.objects_dir / object_name
+        if not object_path.exists():
+            object_path.write_bytes(payload)
+        ref = f"minio://{self.bucket}/{key}#{sha}"
+        self.index["objects"][key] = {
+            "ref": ref,
+            "sha256": sha,
+            "bytes": len(payload),
+            "content_type": content_type,
+            "object_path": str(object_path),
+            "updated_at": utc_iso(),
+        }
+        write_json(self.index_path, self.index)
+        return ArtifactRef(
+            ref=ref,
+            key=key,
+            sha256=sha,
+            bytes=len(payload),
+            content_type=content_type,
+        )
+
+    def get(self, key: str) -> bytes:
+        record = self.index["objects"][key]
+        return Path(record["object_path"]).read_bytes()
+
+    def count(self) -> int:
+        return len(self.index.get("objects", {}))
+
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "object_count": self.count(),
+            "keys": sorted(self.index.get("objects", {}).keys()),
+        }
+
+
+class DirectVectorStore:
+    """Deterministic pgvector-compatible adapter with idempotent upsert."""
+
+    def __init__(self, root: Path):
+        self.path = root / "vector_store.json"
+        self.data: dict[str, Any] = load_json(self.path, {"chunks": {}})
+
+    def upsert_document_chunks(
+        self,
+        canonical_key: str,
+        artifact_ref: str,
+        text: str,
+        metadata: dict[str, Any],
+    ) -> dict[str, int]:
+        chunks = chunk_text(text)
+        created = 0
+        reused = 0
+        for idx, chunk in enumerate(chunks):
+            chunk_hash = sha256_text(chunk)
+            chunk_id = f"{canonical_key}::chunk-{idx}::{chunk_hash[:12]}"
+            if chunk_id in self.data["chunks"]:
+                reused += 1
+                continue
+            self.data["chunks"][chunk_id] = {
+                "chunk_id": chunk_id,
+                "canonical_document_key": canonical_key,
+                "content": chunk,
+                "embedding": deterministic_embedding(chunk),
+                "artifact_ref": artifact_ref,
+                "metadata": metadata,
+                "created_at": utc_iso(),
+            }
+            created += 1
+        write_json(self.path, self.data)
+        return {"created": created, "reused": reused, "total": len(chunks)}
+
+    def query(self, query: str, top_k: int = 5) -> list[dict[str, Any]]:
+        query_vec = deterministic_embedding(query)
+        scored: list[tuple[float, dict[str, Any]]] = []
+        for chunk in self.data["chunks"].values():
+            score = cosine_similarity(query_vec, chunk["embedding"])
+            scored.append((score, chunk))
+        scored.sort(key=lambda item: item[0], reverse=True)
+        results: list[dict[str, Any]] = []
+        for score, chunk in scored[:top_k]:
+            payload = dict(chunk)
+            payload["score"] = score
+            results.append(payload)
+        return results
+
+    def count(self) -> int:
+        return len(self.data.get("chunks", {}))
+
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "chunk_count": self.count(),
+            "chunk_ids": sorted(self.data.get("chunks", {}).keys()),
+        }
+
+
+class DirectRelationalStore:
+    """Deterministic Postgres-like adapter for snapshots/documents/analysis rows."""
+
+    def __init__(self, root: Path):
+        self.path = root / "relational_store.json"
+        self.data: dict[str, Any] = load_json(
+            self.path,
+            {
+                "search_snapshots": {},
+                "documents": {},
+                "analyses": {},
+                "runs": {},
+            },
+        )
+
+    def upsert_search_snapshot(
+        self,
+        idempotency_key: str,
+        query: str,
+        payload: dict[str, Any],
+        artifact_ref: str,
+        status: str,
+    ) -> dict[str, Any]:
+        normalized_results = [
+            {
+                "title": item.get("title", ""),
+                "url": item.get("url", ""),
+                "content": item.get("content", ""),
+            }
+            for item in payload.get("results", [])
+        ]
+        snapshot_hash = sha256_text(json.dumps(normalized_results, sort_keys=True))
+        snapshot_id = f"{idempotency_key}::{snapshot_hash[:16]}"
+        exists = snapshot_id in self.data["search_snapshots"]
+        row = self.data["search_snapshots"].setdefault(
+            snapshot_id,
+            {
+                "snapshot_id": snapshot_id,
+                "idempotency_key": idempotency_key,
+                "query": query,
+                "status": status,
+                "snapshot_hash": snapshot_hash,
+                "result_count": len(normalized_results),
+                "artifact_ref": artifact_ref,
+                "created_at": utc_iso(),
+                "updated_at": utc_iso(),
+            },
+        )
+        row["updated_at"] = utc_iso()
+        row["artifact_ref"] = artifact_ref
+        row["status"] = status
+        write_json(self.path, self.data)
+        return {"snapshot_id": snapshot_id, "created": not exists, "row": row}
+
+    def upsert_document(
+        self,
+        canonical_key: str,
+        title: str,
+        source_url: str,
+        reader_artifact_ref: str,
+        content_hash: str,
+    ) -> dict[str, Any]:
+        exists = canonical_key in self.data["documents"]
+        row = self.data["documents"].setdefault(
+            canonical_key,
+            {
+                "canonical_document_key": canonical_key,
+                "title": title,
+                "source_url": source_url,
+                "reader_artifact_ref": reader_artifact_ref,
+                "content_hash": content_hash,
+                "first_seen_at": utc_iso(),
+            },
+        )
+        row["reader_artifact_ref"] = reader_artifact_ref
+        row["content_hash"] = content_hash
+        row["updated_at"] = utc_iso()
+        write_json(self.path, self.data)
+        return {"created": not exists, "row": row}
+
+    def upsert_analysis(
+        self, idempotency_key: str, analysis_payload: dict[str, Any], artifact_ref: str
+    ) -> dict[str, Any]:
+        exists = idempotency_key in self.data["analyses"]
+        row = self.data["analyses"].setdefault(
+            idempotency_key,
+            {
+                "idempotency_key": idempotency_key,
+                "analysis": analysis_payload,
+                "artifact_ref": artifact_ref,
+                "first_written_at": utc_iso(),
+            },
+        )
+        row["analysis"] = analysis_payload
+        row["artifact_ref"] = artifact_ref
+        row["updated_at"] = utc_iso()
+        write_json(self.path, self.data)
+        return {"created": not exists, "row": row}
+
+    def write_run(self, run_id: str, payload: dict[str, Any]) -> None:
+        self.data["runs"][run_id] = payload
+        write_json(self.path, self.data)
+
+    def previous_snapshot_time(self, idempotency_key: str) -> datetime | None:
+        rows = [
+            row
+            for row in self.data["search_snapshots"].values()
+            if row["idempotency_key"] == idempotency_key
+        ]
+        if not rows:
+            return None
+        latest = max(rows, key=lambda row: row.get("updated_at", row["created_at"]))
+        return datetime.fromisoformat(latest.get("updated_at", latest["created_at"]))
+
+    def count_snapshots(self) -> int:
+        return len(self.data["search_snapshots"])
+
+    def count_documents(self) -> int:
+        return len(self.data["documents"])
+
+    def count_analyses(self) -> int:
+        return len(self.data["analyses"])
+
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "search_snapshot_count": self.count_snapshots(),
+            "document_count": self.count_documents(),
+            "analysis_count": self.count_analyses(),
+        }
+
+
+class SearxClient:
+    """SearXNG-compatible search adapter with deterministic fallback fixture."""
+
+    def __init__(self, endpoint: str | None = None):
+        self.endpoint = endpoint
+
+    def search(
+        self,
+        query: str,
+        limit: int = 5,
+        force_failure: bool = False,
+    ) -> dict[str, Any]:
+        if force_failure:
+            raise RuntimeError("simulated_searx_failure")
+
+        if self.endpoint:
+            params = urlencode({"q": query, "format": "json"})
+            url = f"{self.endpoint.rstrip('/')}" + f"?{params}"
+            request = Request(url, method="GET")
+            try:
+                with urlopen(request, timeout=20) as response:
+                    payload = json.loads(response.read().decode("utf-8"))
+            except (HTTPError, URLError, TimeoutError) as exc:
+                raise RuntimeError(f"live_searx_unreachable: {exc}") from exc
+        else:
+            payload = DEFAULT_SEARX_FIXTURE
+        payload["results"] = payload.get("results", [])[:limit]
+        return payload
+
+
+class ReaderClient:
+    """Z.ai direct reader contract shape with deterministic fallback."""
+
+    def __init__(self, allow_live: bool = False):
+        self.allow_live = allow_live
+        self.api_key = os.getenv("ZAI_API_KEY")
+        self.endpoint = "https://api.z.ai/api/coding/paas/v4/reader"
+
+    def read(self, url: str, force_failure: bool = False) -> dict[str, Any]:
+        if force_failure:
+            raise RuntimeError("simulated_reader_failure")
+        if self.allow_live and self.api_key:
+            request = Request(
+                self.endpoint,
+                data=json.dumps({"url": url, "extract_main": True}).encode("utf-8"),
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                },
+                method="POST",
+            )
+            try:
+                with urlopen(request, timeout=45) as response:
+                    payload = json.loads(response.read().decode("utf-8"))
+                    data = payload.get("reader_result", payload)
+                    return {
+                        "mode": "live",
+                        "title": data.get("title") or "Untitled",
+                        "content": data.get("content") or "",
+                        "url": url,
+                    }
+            except Exception as exc:  # noqa: BLE001
+                raise RuntimeError(f"live_reader_failed: {exc}") from exc
+        text = textwrap.dedent(
+            f"""
+            # San Jose City Council Minutes (Deterministic Reader)
+
+            Source URL: {url}
+
+            Agenda highlights:
+            - Approved transit corridor grant allocation updates.
+            - Discussed affordable housing permit acceleration.
+            - Published meeting minutes and attachments for public review.
+            """
+        ).strip()
+        return {"mode": "deterministic", "title": "San Jose Minutes", "content": text, "url": url}
+
+
+class AnalysisClient:
+    """Z.ai LLM contract shape with deterministic analysis fallback."""
+
+    def __init__(self, allow_live: bool = False):
+        self.allow_live = allow_live
+        self.api_key = os.getenv("ZAI_API_KEY")
+        self.endpoint = "https://api.z.ai/api/coding/paas/v4/chat/completions"
+        self.model = os.getenv("LLM_MODEL_RESEARCH", "glm-4.7")
+
+    def analyze(
+        self,
+        prompt: str,
+        chunks: list[dict[str, Any]],
+        artifact_ref: str,
+        force_failure: bool = False,
+    ) -> dict[str, Any]:
+        if force_failure:
+            raise RuntimeError("simulated_analysis_failure")
+        if self.allow_live and self.api_key:
+            messages = [
+                {"role": "system", "content": "Return concise JSON with findings and citations."},
+                {"role": "user", "content": prompt},
+            ]
+            request = Request(
+                self.endpoint,
+                data=json.dumps({"model": self.model, "messages": messages, "stream": False}).encode("utf-8"),
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                },
+                method="POST",
+            )
+            try:
+                with urlopen(request, timeout=45) as response:
+                    payload = json.loads(response.read().decode("utf-8"))
+                content = payload["choices"][0]["message"]["content"]
+                return {
+                    "mode": "live",
+                    "summary": content[:1200],
+                    "citations": [chunk["chunk_id"] for chunk in chunks[:2]],
+                    "artifact_ref": artifact_ref,
+                }
+            except Exception as exc:  # noqa: BLE001
+                raise RuntimeError(f"live_analysis_failed: {exc}") from exc
+        top = chunks[:2]
+        citations = [
+            {
+                "chunk_id": chunk["chunk_id"],
+                "artifact_ref": chunk["artifact_ref"],
+                "source_url": chunk["metadata"]["source_url"],
+            }
+            for chunk in top
+        ]
+        summary = (
+            "San Jose meeting minutes indicate transit funding decisions and housing permit "
+            "acceleration updates were discussed in recent sessions."
+        )
+        return {
+            "mode": "deterministic",
+            "summary": summary,
+            "citations": citations,
+            "artifact_ref": artifact_ref,
+        }
+
+
+def freshness_status(
+    previous_snapshot: datetime | None,
+    now: datetime,
+    stale_usable_hours: int,
+    stale_blocked_hours: int,
+    force_stale_hours: int | None = None,
+) -> tuple[str, str]:
+    if force_stale_hours is not None:
+        age = timedelta(hours=force_stale_hours)
+    elif previous_snapshot is None:
+        age = timedelta(0)
+    else:
+        age = now - previous_snapshot
+    if age <= timedelta(hours=stale_usable_hours):
+        return STATUS_FRESH, f"age_hours={age.total_seconds() / 3600:.2f}"
+    if age <= timedelta(hours=stale_blocked_hours):
+        return STATUS_STALE_USABLE, f"age_hours={age.total_seconds() / 3600:.2f}"
+    return STATUS_STALE_BLOCKED, f"age_hours={age.total_seconds() / 3600:.2f}"
+
+
+class DirectStoragePipelineRunner:
+    def __init__(
+        self,
+        state_dir: Path,
+        searx_endpoint: str | None = None,
+        allow_live_zai: bool = False,
+    ):
+        self.state_dir = state_dir
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self.object_store = DirectObjectStore(self.state_dir)
+        self.vector_store = DirectVectorStore(self.state_dir)
+        self.relational = DirectRelationalStore(self.state_dir)
+        self.searx = SearxClient(searx_endpoint)
+        self.reader = ReaderClient(allow_live=allow_live_zai)
+        self.analysis = AnalysisClient(allow_live=allow_live_zai)
+
+    def _envelope(self, run_id: str, run_date: str) -> dict[str, Any]:
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "architecture_path": ARCH_PATH,
+            "orchestrator": "windmill",
+            "windmill_workspace": "affordabot",
+            "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_direct_storage",
+            "windmill_run_id": run_id,
+            "windmill_job_id": f"job-{run_id}",
+            "idempotency_key": f"san-jose-ca:meeting_minutes:{run_date}",
+            "jurisdiction": DEFAULT_JURISDICTION,
+            "source_family": DEFAULT_SOURCE_FAMILY,
+        }
+
+    def run(
+        self,
+        *,
+        run_date: str,
+        scenario: str = "normal",
+        stale_usable_hours: int = 24,
+        stale_blocked_hours: int = 72,
+        force_stale_hours: int | None = None,
+    ) -> dict[str, Any]:
+        run_id = f"local-{uuid.uuid4()}"
+        envelope = self._envelope(run_id, run_date)
+        now = now_utc()
+        steps: list[dict[str, Any]] = []
+        alerts: list[str] = []
+        status = STATUS_SUCCEEDED
+        reason = "completed"
+        counts = {
+            "search_results": 0,
+            "objects_total": self.object_store.count(),
+            "chunks_total": self.vector_store.count(),
+            "documents_total": self.relational.count_documents(),
+            "analyses_total": self.relational.count_analyses(),
+        }
+
+        force_searx_failure = scenario == "searx_failure"
+        force_reader_failure = scenario == "reader_failure"
+        force_storage_failure = scenario == "storage_failure"
+
+        query = DEFAULT_SEARX_QUERY
+        search_payload: dict[str, Any] | None = None
+        selected_result: dict[str, Any] | None = None
+        reader_result: dict[str, Any] | None = None
+        reader_artifact: ArtifactRef | None = None
+        previous_snapshot_before_run = self.relational.previous_snapshot_time(
+            envelope["idempotency_key"]
+        )
+
+        # Step 1: search/materialize
+        try:
+            search_payload = self.searx.search(
+                query=query,
+                limit=5,
+                force_failure=force_searx_failure,
+            )
+            result_count = len(search_payload.get("results", []))
+            counts["search_results"] = result_count
+            if result_count == 0:
+                status = STATUS_EMPTY
+                reason = "search returned zero candidates"
+            raw_artifact = self.object_store.put(
+                key=f"idempotency/{envelope['idempotency_key']}/search/{sha256_text(json.dumps(search_payload, sort_keys=True))[:16]}.json",
+                payload=json.dumps(search_payload, indent=2, sort_keys=True).encode("utf-8"),
+                content_type="application/json",
+                fail=force_storage_failure,
+            )
+            snapshot = self.relational.upsert_search_snapshot(
+                idempotency_key=envelope["idempotency_key"],
+                query=query,
+                payload=search_payload,
+                artifact_ref=raw_artifact.ref,
+                status=status if status == STATUS_EMPTY else STATUS_SUCCEEDED,
+            )
+            steps.append(
+                {
+                    "step": "search_materialize",
+                    "status": status if status == STATUS_EMPTY else STATUS_SUCCEEDED,
+                    "result_count": result_count,
+                    "snapshot_id": snapshot["snapshot_id"],
+                    "snapshot_created": snapshot["created"],
+                    "artifact_ref": raw_artifact.ref,
+                }
+            )
+            if result_count > 0:
+                selected_result = search_payload["results"][0]
+        except Exception as exc:  # noqa: BLE001
+            status = STATUS_STORAGE_ERROR if "storage" in str(exc) else STATUS_SOURCE_ERROR
+            reason = str(exc)
+            steps.append({"step": "search_materialize", "status": status, "error": reason})
+
+        # Step 2: freshness gate
+        if status not in TERMINAL_FAILURE_STATUSES and status != STATUS_EMPTY:
+            gate_status, gate_reason = freshness_status(
+                previous_snapshot=previous_snapshot_before_run,
+                now=now,
+                stale_usable_hours=stale_usable_hours,
+                stale_blocked_hours=stale_blocked_hours,
+                force_stale_hours=force_stale_hours,
+            )
+            steps.append(
+                {"step": "freshness_gate", "status": gate_status, "reason": gate_reason}
+            )
+            if gate_status == STATUS_STALE_USABLE:
+                alerts.append("stale_backed=true")
+            if gate_status == STATUS_STALE_BLOCKED:
+                status = STATUS_STALE_BLOCKED
+                reason = gate_reason
+
+        # Step 3: reader
+        if status not in TERMINAL_FAILURE_STATUSES and status != STATUS_EMPTY and selected_result:
+            try:
+                reader_result = self.reader.read(
+                    selected_result["url"], force_failure=force_reader_failure
+                )
+                content = reader_result.get("content", "").strip()
+                if not content:
+                    raise RuntimeError("reader returned empty content")
+                key_slug = slugify(canonical_document_key(selected_result["url"]))
+                content_hash = sha256_text(content)
+                reader_artifact = self.object_store.put(
+                    key=f"documents/{key_slug}/reader/{content_hash[:16]}.md",
+                    payload=content.encode("utf-8"),
+                    content_type="text/markdown",
+                    fail=force_storage_failure,
+                )
+                upsert_doc = self.relational.upsert_document(
+                    canonical_key=canonical_document_key(selected_result["url"]),
+                    title=selected_result["title"],
+                    source_url=selected_result["url"],
+                    reader_artifact_ref=reader_artifact.ref,
+                    content_hash=content_hash,
+                )
+                steps.append(
+                    {
+                        "step": "read_fetch",
+                        "status": STATUS_SUCCEEDED,
+                        "reader_mode": reader_result["mode"],
+                        "canonical_document_key": canonical_document_key(selected_result["url"]),
+                        "document_created": upsert_doc["created"],
+                        "artifact_ref": reader_artifact.ref,
+                    }
+                )
+            except Exception as exc:  # noqa: BLE001
+                status = STATUS_STORAGE_ERROR if "storage" in str(exc) else STATUS_READER_ERROR
+                reason = str(exc)
+                steps.append({"step": "read_fetch", "status": status, "error": reason})
+
+        # Step 4: chunk/index
+        indexed_chunks: list[dict[str, Any]] = []
+        if (
+            status not in TERMINAL_FAILURE_STATUSES
+            and status != STATUS_EMPTY
+            and selected_result
+            and reader_result
+            and reader_artifact
+        ):
+            stats = self.vector_store.upsert_document_chunks(
+                canonical_key=canonical_document_key(selected_result["url"]),
+                artifact_ref=reader_artifact.ref,
+                text=reader_result["content"],
+                metadata={
+                    "jurisdiction": DEFAULT_JURISDICTION,
+                    "source_family": DEFAULT_SOURCE_FAMILY,
+                    "source_url": selected_result["url"],
+                },
+            )
+            indexed_chunks = self.vector_store.query("San Jose meeting minutes", top_k=5)
+            steps.append(
+                {
+                    "step": "index_chunks",
+                    "status": STATUS_SUCCEEDED,
+                    "chunks_created": stats["created"],
+                    "chunks_reused": stats["reused"],
+                    "chunks_total_for_document": stats["total"],
+                }
+            )
+
+        # Step 5: analyze
+        analysis_payload: dict[str, Any] | None = None
+        if (
+            status not in TERMINAL_FAILURE_STATUSES
+            and status != STATUS_EMPTY
+            and reader_artifact
+        ):
+            try:
+                analysis_payload = self.analysis.analyze(
+                    prompt=(
+                        "Summarize key municipal decisions in San Jose meeting minutes. "
+                        "Return concise findings with citations."
+                    ),
+                    chunks=indexed_chunks,
+                    artifact_ref=reader_artifact.ref,
+                    force_failure=False,
+                )
+                analysis_artifact = self.object_store.put(
+                    key=(
+                        f"idempotency/{envelope['idempotency_key']}/analysis/"
+                        f"{sha256_text(json.dumps(analysis_payload, sort_keys=True))[:16]}.json"
+                    ),
+                    payload=json.dumps(analysis_payload, indent=2, sort_keys=True).encode("utf-8"),
+                    content_type="application/json",
+                    fail=force_storage_failure,
+                )
+                upsert_analysis = self.relational.upsert_analysis(
+                    idempotency_key=envelope["idempotency_key"],
+                    analysis_payload=analysis_payload,
+                    artifact_ref=analysis_artifact.ref,
+                )
+                steps.append(
+                    {
+                        "step": "analyze",
+                        "status": STATUS_SUCCEEDED,
+                        "analysis_mode": analysis_payload["mode"],
+                        "analysis_created": upsert_analysis["created"],
+                        "analysis_artifact_ref": analysis_artifact.ref,
+                    }
+                )
+            except Exception as exc:  # noqa: BLE001
+                status = STATUS_STORAGE_ERROR if "storage" in str(exc) else STATUS_ANALYSIS_ERROR
+                reason = str(exc)
+                steps.append({"step": "analyze", "status": status, "error": reason})
+
+        counts["objects_total"] = self.object_store.count()
+        counts["chunks_total"] = self.vector_store.count()
+        counts["documents_total"] = self.relational.count_documents()
+        counts["analyses_total"] = self.relational.count_analyses()
+
+        run_payload = {
+            "envelope": envelope,
+            "scenario": scenario,
+            "status": status,
+            "reason": reason,
+            "alerts": alerts,
+            "steps": steps,
+            "counts": counts,
+            "storage_snapshot": {
+                "object_store": self.object_store.snapshot(),
+                "vector_store": self.vector_store.snapshot(),
+                "relational_store": self.relational.snapshot(),
+            },
+            "analysis_preview": (analysis_payload or {}).get("summary"),
+            "created_at": utc_iso(now),
+        }
+        self.relational.write_run(run_id, run_payload)
+        return run_payload
+
+
+def write_markdown(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content.rstrip() + "\n", encoding="utf-8")
+
+
+def render_run_evidence(suite: dict[str, Any]) -> str:
+    first = suite["runs"]["first"]
+    rerun = suite["runs"]["rerun"]
+    return textwrap.dedent(
+        f"""
+        # Path A Run Evidence
+
+        Contract version: `{CONTRACT_VERSION}`
+        Architecture path: `{ARCH_PATH}`
+
+        ## First Run
+
+        - status: `{first["status"]}`
+        - reason: `{first["reason"]}`
+        - search results: `{first["counts"]["search_results"]}`
+        - objects total: `{first["counts"]["objects_total"]}`
+        - chunks total: `{first["counts"]["chunks_total"]}`
+        - documents total: `{first["counts"]["documents_total"]}`
+        - analyses total: `{first["counts"]["analyses_total"]}`
+
+        ## Rerun (Idempotency)
+
+        - status: `{rerun["status"]}`
+        - reason: `{rerun["reason"]}`
+        - objects total: `{rerun["counts"]["objects_total"]}`
+        - chunks total: `{rerun["counts"]["chunks_total"]}`
+        - documents total: `{rerun["counts"]["documents_total"]}`
+        - analyses total: `{rerun["counts"]["analyses_total"]}`
+
+        Idempotency assertion:
+        - canonical documents should remain stable across rerun with same idempotency key
+        - vector chunks should be reused rather than duplicated
+        - analysis row should be upserted by idempotency key
+
+        Computed checks:
+        - documents stable: `{suite["checks"]["documents_stable"]}`
+        - chunks stable: `{suite["checks"]["chunks_stable"]}`
+        - analyses stable: `{suite["checks"]["analyses_stable"]}`
+        - overall idempotent: `{suite["checks"]["idempotent"]}`
+        """
+    ).strip()
+
+
+def render_storage_snapshots(suite: dict[str, Any]) -> str:
+    first = suite["runs"]["first"]["storage_snapshot"]
+    rerun = suite["runs"]["rerun"]["storage_snapshot"]
+    return (
+        "# Path A Storage Snapshots\n\n"
+        "## First Run Snapshot\n\n"
+        "```json\n"
+        f"{json.dumps(first, indent=2, sort_keys=True)}\n"
+        "```\n\n"
+        "## Rerun Snapshot\n\n"
+        "```json\n"
+        f"{json.dumps(rerun, indent=2, sort_keys=True)}\n"
+        "```"
+    )
+
+
+def render_failure_drills(suite: dict[str, Any]) -> str:
+    rows = []
+    for name, result in suite["failures"].items():
+        rows.append(f"- `{name}` => status `{result['status']}` reason `{result['reason']}`")
+    bullets = "\n".join(rows)
+    return (
+        "# Path A Failure Drills\n\n"
+        f"{bullets}\n\n"
+        "Expected terminal statuses:\n"
+        f"- SearXNG failure => `{STATUS_SOURCE_ERROR}`\n"
+        f"- Reader failure => `{STATUS_READER_ERROR}`\n"
+        f"- Storage failure => `{STATUS_STORAGE_ERROR}`"
+    )
+
+
+def run_suite(args: argparse.Namespace) -> dict[str, Any]:
+    state_dir = Path(args.state_dir)
+    if args.reset_state and state_dir.exists():
+        shutil.rmtree(state_dir)
+    runner = DirectStoragePipelineRunner(
+        state_dir=state_dir,
+        searx_endpoint=args.searx_endpoint,
+        allow_live_zai=args.allow_live_zai,
+    )
+    run_date = args.run_date or now_utc().date().isoformat()
+    first = runner.run(run_date=run_date, scenario="normal")
+    rerun = runner.run(run_date=run_date, scenario="normal")
+    searx_failure = runner.run(run_date=run_date, scenario="searx_failure")
+    reader_failure = runner.run(run_date=run_date, scenario="reader_failure")
+    storage_failure = runner.run(run_date=run_date, scenario="storage_failure")
+
+    checks = {
+        "documents_stable": first["counts"]["documents_total"] == rerun["counts"]["documents_total"],
+        "chunks_stable": first["counts"]["chunks_total"] == rerun["counts"]["chunks_total"],
+        "analyses_stable": first["counts"]["analyses_total"] == rerun["counts"]["analyses_total"],
+    }
+    checks["idempotent"] = all(checks.values())
+
+    suite = {
+        "generated_at": utc_iso(),
+        "state_dir": str(state_dir),
+        "run_date": run_date,
+        "checks": checks,
+        "runs": {"first": first, "rerun": rerun},
+        "failures": {
+            "searx_failure": searx_failure,
+            "reader_failure": reader_failure,
+            "storage_failure": storage_failure,
+        },
+        "live_flags": {
+            "searx_endpoint_configured": bool(args.searx_endpoint),
+            "allow_live_zai": bool(args.allow_live_zai),
+            "zai_api_key_present": bool(os.getenv("ZAI_API_KEY")),
+        },
+        "live_blockers": [],
+    }
+    if not args.searx_endpoint:
+        suite["live_blockers"].append("SEARX_ENDPOINT not configured; used deterministic SearX fixture.")
+    if not args.allow_live_zai or not os.getenv("ZAI_API_KEY"):
+        suite["live_blockers"].append(
+            "Z.ai reader/analysis live call unavailable; used deterministic contract-shape substitutes."
+        )
+
+    evidence_dir = Path(args.evidence_dir)
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    write_json(evidence_dir / "suite-results.json", suite)
+    write_markdown(evidence_dir / "run-evidence.md", render_run_evidence(suite))
+    write_markdown(evidence_dir / "storage-snapshots.md", render_storage_snapshots(suite))
+    write_markdown(evidence_dir / "failure-drills.md", render_failure_drills(suite))
+    return suite
+
+
+def run_single(args: argparse.Namespace) -> dict[str, Any]:
+    runner = DirectStoragePipelineRunner(
+        state_dir=Path(args.state_dir),
+        searx_endpoint=args.searx_endpoint,
+        allow_live_zai=args.allow_live_zai,
+    )
+    run_date = args.run_date or now_utc().date().isoformat()
+    result = runner.run(
+        run_date=run_date,
+        scenario=args.scenario,
+        stale_usable_hours=args.stale_usable_hours,
+        stale_blocked_hours=args.stale_blocked_hours,
+        force_stale_hours=args.force_stale_hours,
+    )
+    if args.output_json:
+        write_json(Path(args.output_json), result)
+    return result
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Path A Windmill-heavy direct storage bakeoff runner."
+    )
+    sub = parser.add_subparsers(dest="mode", required=False)
+
+    run_parser = sub.add_parser("run", help="Run one scenario.")
+    run_parser.add_argument(
+        "--scenario",
+        choices=["normal", "searx_failure", "reader_failure", "storage_failure"],
+        default="normal",
+    )
+    run_parser.add_argument("--run-date", default=None, help="YYYY-MM-DD idempotency date.")
+    run_parser.add_argument("--state-dir", default=str(DEFAULT_STATE_DIR))
+    run_parser.add_argument("--searx-endpoint", default=None)
+    run_parser.add_argument("--allow-live-zai", action="store_true")
+    run_parser.add_argument("--output-json", default=None)
+    run_parser.add_argument("--stale-usable-hours", type=int, default=24)
+    run_parser.add_argument("--stale-blocked-hours", type=int, default=72)
+    run_parser.add_argument("--force-stale-hours", type=int, default=None)
+
+    suite_parser = sub.add_parser("suite", help="Run first/rerun/failure drills and emit docs.")
+    suite_parser.add_argument("--run-date", default=None, help="YYYY-MM-DD idempotency date.")
+    suite_parser.add_argument("--state-dir", default=str(DEFAULT_STATE_DIR))
+    suite_parser.add_argument("--evidence-dir", default=str(DEFAULT_EVIDENCE_DIR))
+    suite_parser.add_argument("--searx-endpoint", default=None)
+    suite_parser.add_argument("--allow-live-zai", action="store_true")
+    suite_parser.add_argument("--reset-state", action="store_true")
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    mode = args.mode or "run"
+    if mode == "suite":
+        result = run_suite(args)
+    else:
+        result = run_single(args)
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/verification/windmill_bakeoff_domain_boundary.py
+++ b/backend/scripts/verification/windmill_bakeoff_domain_boundary.py
@@ -255,7 +255,9 @@ class DomainBoundaryService:
         status = "empty_result" if len(results) == 0 else "fresh"
         return {"status": status, "snapshot_id": snapshot_id, "result_count": len(results)}
 
-    def freshness_gate(self, env: Envelope, snapshot_id: str, max_stale_hours: int) -> Dict[str, Any]:
+    def freshness_gate(
+        self, env: Envelope, snapshot_id: str, max_stale_hours: int, fallback_stale_hours: int
+    ) -> Dict[str, Any]:
         """Invariant: explicit stale policy; zero results are not transport failures."""
         snap = self.store.search_snapshots.get(snapshot_id)
         if not snap:
@@ -266,6 +268,8 @@ class DomainBoundaryService:
             return {"status": "empty_result", "age_seconds": int(age.total_seconds())}
         if age <= timedelta(hours=max_stale_hours):
             return {"status": "fresh", "age_seconds": int(age.total_seconds())}
+        if age <= timedelta(hours=fallback_stale_hours):
+            return {"status": "stale_but_usable", "age_seconds": int(age.total_seconds())}
         return {"status": "stale_blocked", "age_seconds": int(age.total_seconds())}
 
     def read_fetch(self, env: Envelope, snapshot_id: str) -> Dict[str, Any]:
@@ -370,8 +374,11 @@ class DomainBoundaryService:
         summary_id = f"summary-{env.windmill_run_id}"
         status = "succeeded"
         alerts: List[str] = []
-        for step_name in ("search_materialize", "freshness_gate", "read_fetch", "index", "analyze"):
-            step_status = step_results.get(step_name, {}).get("status", "unknown")
+        for step_name, step_payload in step_results.items():
+            step_status = step_payload.get("status", "unknown")
+            if step_name == "freshness_gate" and step_status == "stale_but_usable":
+                alerts.append("freshness_gate:stale_but_usable")
+                continue
             if step_status not in {"fresh", "succeeded"}:
                 status = "failed"
                 alerts.append(f"{step_name}:{step_status}")
@@ -414,6 +421,7 @@ class WindmillShapedRunner:
         question: str,
         jurisdiction: str = DEFAULT_JURISDICTION,
         source_family: str = DEFAULT_SOURCE_FAMILY,
+        snapshot_age_hours: int = 0,
     ) -> Dict[str, Any]:
         env = Envelope(
             architecture_path="affordabot_domain_boundary",
@@ -432,10 +440,13 @@ class WindmillShapedRunner:
             return self.domain.summarize_run(env, steps)
 
         snapshot_id = steps["search_materialize"].get("snapshot_id", "")
+        if snapshot_age_hours > 0 and snapshot_id in self.domain.store.search_snapshots:
+            aged = utc_now() - timedelta(hours=snapshot_age_hours)
+            self.domain.store.search_snapshots[snapshot_id]["captured_at"] = aged.isoformat()
         steps["freshness_gate"] = self._safe_step(
-            "freshness_gate", self.domain.freshness_gate, env, snapshot_id, 24
+            "freshness_gate", self.domain.freshness_gate, env, snapshot_id, 24, 72
         )
-        if steps["freshness_gate"].get("status") != "fresh":
+        if steps["freshness_gate"].get("status") not in {"fresh", "stale_but_usable"}:
             return self.domain.summarize_run(env, steps)
 
         steps["read_fetch"] = self._safe_step("read_fetch", self.domain.read_fetch, env, snapshot_id)
@@ -491,6 +502,32 @@ def run_scenario(scenario: str) -> Dict[str, Any]:
         runner = WindmillShapedRunner(domain)
         return runner.run_once("run-storage-failure", "job-index", idempotency, query, question)
 
+    if scenario == "stale_usable":
+        domain = DomainBoundaryService(
+            store=store,
+            search_client=SearxLikeClient(fail_mode=False),
+            reader_client=ReaderContractClient(fail_mode=False),
+            vector_adapter=VectorAdapter(),
+            analysis_adapter=AnalysisAdapter(),
+        )
+        runner = WindmillShapedRunner(domain)
+        return runner.run_once(
+            "run-stale-usable", "job-freshness", idempotency, query, question, snapshot_age_hours=30
+        )
+
+    if scenario == "stale_blocked":
+        domain = DomainBoundaryService(
+            store=store,
+            search_client=SearxLikeClient(fail_mode=False),
+            reader_client=ReaderContractClient(fail_mode=False),
+            vector_adapter=VectorAdapter(),
+            analysis_adapter=AnalysisAdapter(),
+        )
+        runner = WindmillShapedRunner(domain)
+        return runner.run_once(
+            "run-stale-blocked", "job-freshness", idempotency, query, question, snapshot_age_hours=80
+        )
+
     domain = DomainBoundaryService(
         store=store,
         search_client=SearxLikeClient(fail_mode=False),
@@ -510,7 +547,14 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--scenario",
-        choices=["happy_rerun", "source_failure", "reader_failure", "storage_failure"],
+        choices=[
+            "happy_rerun",
+            "source_failure",
+            "reader_failure",
+            "storage_failure",
+            "stale_usable",
+            "stale_blocked",
+        ],
         default="happy_rerun",
         help="Scenario to execute.",
     )

--- a/backend/scripts/verification/windmill_bakeoff_domain_boundary.py
+++ b/backend/scripts/verification/windmill_bakeoff_domain_boundary.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""Path B POC: Windmill-style orchestration with an affordabot domain boundary.
+
+This script is intentionally deterministic and local-first. It models Windmill step
+boundaries while keeping product-data writes inside coarse domain commands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
+
+
+CONTRACT_VERSION = "2026-04-12.windmill-storage-bakeoff.v1"
+DEFAULT_QUERY = "San Jose CA city council meeting minutes housing"
+DEFAULT_JURISDICTION = "San Jose CA"
+DEFAULT_SOURCE_FAMILY = "meeting_minutes"
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def iso_now() -> str:
+    return utc_now().isoformat()
+
+
+def stable_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def normalize_for_key(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", text.strip().lower()).strip("-")
+
+
+def canonical_document_key(jurisdiction: str, url: str) -> str:
+    """Domain invariant: stable document identity from jurisdiction + canonical URL."""
+    parsed = urlparse(url)
+    host = parsed.netloc.lower()
+    path = parsed.path.rstrip("/") or "/"
+    normalized = f"{host}{path}"
+    return f"{normalize_for_key(jurisdiction)}::{stable_hash(normalized)[:16]}"
+
+
+@dataclass
+class Envelope:
+    architecture_path: str
+    windmill_run_id: str
+    windmill_job_id: str
+    idempotency_key: str
+    jurisdiction: str
+    source_family: str
+    windmill_workspace: str = "affordabot"
+    windmill_flow_path: str = "f/affordabot/pipeline_daily_refresh_domain_boundary__flow"
+    orchestrator: str = "windmill"
+    contract_version: str = CONTRACT_VERSION
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "contract_version": self.contract_version,
+            "architecture_path": self.architecture_path,
+            "orchestrator": self.orchestrator,
+            "windmill_workspace": self.windmill_workspace,
+            "windmill_flow_path": self.windmill_flow_path,
+            "windmill_run_id": self.windmill_run_id,
+            "windmill_job_id": self.windmill_job_id,
+            "idempotency_key": self.idempotency_key,
+            "jurisdiction": self.jurisdiction,
+            "source_family": self.source_family,
+        }
+
+
+class SearxLikeClient:
+    """SearXNG-compatible abstraction preserving SearX JSON response shape."""
+
+    def __init__(self, fail_mode: bool = False):
+        self.fail_mode = fail_mode
+
+    def search(self, query: str) -> Dict[str, Any]:
+        if self.fail_mode:
+            raise RuntimeError("simulated_source_error")
+        return {
+            "query": query,
+            "number_of_results": 2,
+            "results": [
+                {
+                    "url": "https://www.sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meeting-minutes",
+                    "title": "City Council Meeting Minutes",
+                    "content": "Official San Jose City Council meeting minutes archive.",
+                    "engines": ["mock-searxng"],
+                },
+                {
+                    "url": "https://www.sanjoseca.gov/news-stories/minutes-and-agendas",
+                    "title": "Minutes and Agendas",
+                    "content": "Minutes and agendas for council meetings.",
+                    "engines": ["mock-searxng"],
+                },
+            ],
+            "answers": [],
+            "infoboxes": [],
+        }
+
+
+class ReaderContractClient:
+    """Z.ai reader contract shape; deterministic local body unless fail_mode is set."""
+
+    def __init__(self, fail_mode: bool = False):
+        self.fail_mode = fail_mode
+
+    def fetch(self, url: str) -> Dict[str, Any]:
+        if self.fail_mode:
+            raise RuntimeError("simulated_reader_error")
+        markdown = (
+            "# San Jose City Council Meeting Minutes\n\n"
+            "2026-04-10 meeting highlights:\n"
+            "- Housing permit processing timelines discussed.\n"
+            "- Fee schedule update hearing moved to next session.\n"
+            "- Public comments on affordable housing expansion."
+        )
+        return {
+            "reader_result": {
+                "url": url,
+                "title": "San Jose Meeting Minutes",
+                "markdown": markdown,
+                "fetched_at": iso_now(),
+            }
+        }
+
+
+class VectorAdapter:
+    """pgvector-compatible adapter with deterministic embeddings."""
+
+    dimension = 8
+
+    def embed(self, text: str) -> List[float]:
+        digest = stable_hash(text)
+        vals = []
+        for i in range(self.dimension):
+            chunk = digest[i * 8 : (i + 1) * 8]
+            vals.append((int(chunk, 16) % 1000) / 1000.0)
+        return vals
+
+
+class AnalysisAdapter:
+    """Deterministic stand-in for Z.ai analysis with explicit evidence references."""
+
+    def analyze(self, question: str, chunks: List[Dict[str, Any]]) -> Dict[str, Any]:
+        if not chunks:
+            raise RuntimeError("analysis_requires_evidence")
+        evidence_refs = [
+            {
+                "chunk_id": c["chunk_id"],
+                "canonical_document_key": c["canonical_document_key"],
+                "artifact_ref": c["artifact_ref"],
+            }
+            for c in chunks
+        ]
+        return {
+            "status": "succeeded",
+            "question": question,
+            "summary": (
+                "San Jose meeting minutes indicate active housing policy discussions and "
+                "scheduled follow-up hearings affecting near-term planning timelines."
+            ),
+            "sufficiency_state": "qualitative_only",
+            "claims": [
+                {
+                    "claim": "Housing-related agenda items were actively discussed.",
+                    "evidence_refs": evidence_refs[:2],
+                }
+            ],
+        }
+
+
+@dataclass
+class InMemoryDomainStore:
+    """Product storage surrogate for Postgres + pgvector + MinIO interfaces."""
+
+    search_snapshots: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    documents: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    artifacts: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    chunks: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    analyses: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    run_summaries: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
+    def snapshot_counts(self) -> Dict[str, int]:
+        return {
+            "search_snapshots": len(self.search_snapshots),
+            "documents": len(self.documents),
+            "artifacts": len(self.artifacts),
+            "chunks": len(self.chunks),
+            "analyses": len(self.analyses),
+            "run_summaries": len(self.run_summaries),
+        }
+
+
+class DomainBoundaryService:
+    """Affordabot domain commands.
+
+    These are intentionally coarse commands. Each command enforces at least one
+    product invariant so this layer is not a thin SQL wrapper.
+    """
+
+    def __init__(
+        self,
+        store: InMemoryDomainStore,
+        search_client: SearxLikeClient,
+        reader_client: ReaderContractClient,
+        vector_adapter: VectorAdapter,
+        analysis_adapter: AnalysisAdapter,
+        fail_storage_step: Optional[str] = None,
+    ):
+        self.store = store
+        self.search_client = search_client
+        self.reader_client = reader_client
+        self.vector_adapter = vector_adapter
+        self.analysis_adapter = analysis_adapter
+        self.fail_storage_step = fail_storage_step
+
+    def _assert_storage_available(self, step_name: str) -> None:
+        if self.fail_storage_step == step_name:
+            raise RuntimeError(f"simulated_storage_error:{step_name}")
+
+    def search_materialize(self, env: Envelope, query: str) -> Dict[str, Any]:
+        """Invariant: idempotent search snapshot materialization keyed by query+scope."""
+        try:
+            raw = self.search_client.search(query)
+        except Exception as exc:
+            return {"status": "source_error", "error": str(exc)}
+
+        results = raw.get("results", [])
+        snapshot_key = stable_hash(
+            f"{env.jurisdiction}|{env.source_family}|{query}|{json.dumps(results, sort_keys=True)}"
+        )[:16]
+        snapshot_id = f"snapshot-{snapshot_key}"
+        if snapshot_id not in self.store.search_snapshots:
+            self._assert_storage_available("search_materialize")
+            self.store.search_snapshots[snapshot_id] = {
+                "snapshot_id": snapshot_id,
+                "query": query,
+                "result_count": len(results),
+                "results": results,
+                "captured_at": iso_now(),
+                "jurisdiction": env.jurisdiction,
+                "source_family": env.source_family,
+            }
+        status = "empty_result" if len(results) == 0 else "fresh"
+        return {"status": status, "snapshot_id": snapshot_id, "result_count": len(results)}
+
+    def freshness_gate(self, env: Envelope, snapshot_id: str, max_stale_hours: int) -> Dict[str, Any]:
+        """Invariant: explicit stale policy; zero results are not transport failures."""
+        snap = self.store.search_snapshots.get(snapshot_id)
+        if not snap:
+            return {"status": "source_error", "error": "missing_snapshot"}
+        captured_at = datetime.fromisoformat(snap["captured_at"])
+        age = utc_now() - captured_at
+        if snap["result_count"] == 0:
+            return {"status": "empty_result", "age_seconds": int(age.total_seconds())}
+        if age <= timedelta(hours=max_stale_hours):
+            return {"status": "fresh", "age_seconds": int(age.total_seconds())}
+        return {"status": "stale_blocked", "age_seconds": int(age.total_seconds())}
+
+    def read_fetch(self, env: Envelope, snapshot_id: str) -> Dict[str, Any]:
+        """Invariant: canonical document identity + artifact reference dedup."""
+        snap = self.store.search_snapshots.get(snapshot_id)
+        if not snap:
+            return {"status": "reader_error", "error": "missing_snapshot"}
+        if not snap["results"]:
+            return {"status": "reader_error", "error": "no_results_to_read"}
+        target = snap["results"][0]
+        url = target["url"]
+        doc_key = canonical_document_key(env.jurisdiction, url)
+        try:
+            payload = self.reader_client.fetch(url)
+        except Exception as exc:
+            return {"status": "reader_error", "error": str(exc)}
+        reader_result = payload.get("reader_result", payload)
+        markdown = reader_result.get("markdown", "")
+        artifact_hash = stable_hash(markdown)[:16]
+        artifact_ref = f"minio://affordabot-artifacts/{env.jurisdiction.replace(' ', '_')}/{artifact_hash}.md"
+
+        self._assert_storage_available("read_fetch")
+        if artifact_ref not in self.store.artifacts:
+            self.store.artifacts[artifact_ref] = {
+                "artifact_ref": artifact_ref,
+                "content_hash": artifact_hash,
+                "content_type": "text/markdown",
+                "body": markdown,
+                "source_url": url,
+                "created_at": iso_now(),
+            }
+        if doc_key not in self.store.documents:
+            self.store.documents[doc_key] = {
+                "canonical_document_key": doc_key,
+                "source_url": url,
+                "artifact_ref": artifact_ref,
+                "jurisdiction": env.jurisdiction,
+                "source_family": env.source_family,
+                "created_at": iso_now(),
+            }
+        return {
+            "status": "fresh",
+            "canonical_document_key": doc_key,
+            "artifact_ref": artifact_ref,
+            "source_url": url,
+        }
+
+    def index(self, env: Envelope, canonical_key: str) -> Dict[str, Any]:
+        """Invariant: chunk provenance includes canonical key + artifact ref, with upsert idempotency."""
+        doc = self.store.documents.get(canonical_key)
+        if not doc:
+            return {"status": "storage_error", "error": "missing_document"}
+        artifact = self.store.artifacts.get(doc["artifact_ref"])
+        if not artifact:
+            return {"status": "storage_error", "error": "missing_artifact"}
+        text = artifact["body"]
+        lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+        chunks_created = 0
+        self._assert_storage_available("index")
+        for idx, line in enumerate(lines):
+            chunk_id = f"chunk-{stable_hash(f'{canonical_key}|{line}')[:20]}"
+            if chunk_id in self.store.chunks:
+                continue
+            self.store.chunks[chunk_id] = {
+                "chunk_id": chunk_id,
+                "canonical_document_key": canonical_key,
+                "artifact_ref": doc["artifact_ref"],
+                "chunk_index": idx,
+                "content": line,
+                "embedding": self.vector_adapter.embed(line),
+                "created_at": iso_now(),
+            }
+            chunks_created += 1
+        return {"status": "fresh", "chunks_total": len(lines), "chunks_created": chunks_created}
+
+    def analyze(self, env: Envelope, question: str) -> Dict[str, Any]:
+        """Invariant: no analysis without evidence chunks and traceable provenance."""
+        usable_chunks = [
+            c
+            for c in self.store.chunks.values()
+            if self.store.documents.get(c["canonical_document_key"], {}).get("jurisdiction")
+            == env.jurisdiction
+        ]
+        if not usable_chunks:
+            return {"status": "analysis_error", "error": "insufficient_evidence"}
+        analysis_id = f"analysis-{stable_hash(env.idempotency_key)[:16]}"
+        if analysis_id in self.store.analyses:
+            return {"status": "fresh", "analysis_id": analysis_id, "reused": True}
+        self._assert_storage_available("analyze")
+        analysis_payload = self.analysis_adapter.analyze(question, usable_chunks)
+        self.store.analyses[analysis_id] = {
+            "analysis_id": analysis_id,
+            "question": question,
+            "payload": analysis_payload,
+            "created_at": iso_now(),
+            "evidence_chunk_ids": [c["chunk_id"] for c in usable_chunks],
+        }
+        return {"status": "fresh", "analysis_id": analysis_id, "reused": False}
+
+    def summarize_run(self, env: Envelope, step_results: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
+        """Invariant: run summary links orchestration IDs to domain storage state."""
+        summary_id = f"summary-{env.windmill_run_id}"
+        status = "succeeded"
+        alerts: List[str] = []
+        for step_name in ("search_materialize", "freshness_gate", "read_fetch", "index", "analyze"):
+            step_status = step_results.get(step_name, {}).get("status", "unknown")
+            if step_status not in {"fresh", "succeeded"}:
+                status = "failed"
+                alerts.append(f"{step_name}:{step_status}")
+        summary = {
+            "summary_id": summary_id,
+            "status": status,
+            "alerts": alerts,
+            "step_results": step_results,
+            "storage_counts": self.store.snapshot_counts(),
+            "envelope": env.as_dict(),
+            "created_at": iso_now(),
+        }
+        self.store.run_summaries[summary_id] = summary
+        return summary
+
+
+class WindmillShapedRunner:
+    """Local flow runner with Windmill-like step graph."""
+
+    def __init__(self, domain: DomainBoundaryService):
+        self.domain = domain
+
+    @staticmethod
+    def _safe_step(name: str, fn: Any, *args: Any) -> Dict[str, Any]:
+        try:
+            return fn(*args)
+        except Exception as exc:
+            error_text = str(exc)
+            status = "storage_error" if "storage_error" in error_text else "source_error"
+            if "reader_error" in error_text:
+                status = "reader_error"
+            return {"status": status, "error": error_text, "step": name}
+
+    def run_once(
+        self,
+        run_id: str,
+        job_id: str,
+        idempotency_key: str,
+        query: str,
+        question: str,
+        jurisdiction: str = DEFAULT_JURISDICTION,
+        source_family: str = DEFAULT_SOURCE_FAMILY,
+    ) -> Dict[str, Any]:
+        env = Envelope(
+            architecture_path="affordabot_domain_boundary",
+            windmill_run_id=run_id,
+            windmill_job_id=job_id,
+            idempotency_key=idempotency_key,
+            jurisdiction=jurisdiction,
+            source_family=source_family,
+        )
+
+        steps: Dict[str, Dict[str, Any]] = {}
+        steps["search_materialize"] = self._safe_step(
+            "search_materialize", self.domain.search_materialize, env, query
+        )
+        if steps["search_materialize"].get("status") not in {"fresh", "empty_result"}:
+            return self.domain.summarize_run(env, steps)
+
+        snapshot_id = steps["search_materialize"].get("snapshot_id", "")
+        steps["freshness_gate"] = self._safe_step(
+            "freshness_gate", self.domain.freshness_gate, env, snapshot_id, 24
+        )
+        if steps["freshness_gate"].get("status") != "fresh":
+            return self.domain.summarize_run(env, steps)
+
+        steps["read_fetch"] = self._safe_step("read_fetch", self.domain.read_fetch, env, snapshot_id)
+        if steps["read_fetch"].get("status") != "fresh":
+            return self.domain.summarize_run(env, steps)
+
+        canonical_key = steps["read_fetch"]["canonical_document_key"]
+        steps["index"] = self._safe_step("index", self.domain.index, env, canonical_key)
+        if steps["index"].get("status") != "fresh":
+            return self.domain.summarize_run(env, steps)
+
+        steps["analyze"] = self._safe_step("analyze", self.domain.analyze, env, question)
+        return self.domain.summarize_run(env, steps)
+
+
+def run_scenario(scenario: str) -> Dict[str, Any]:
+    store = InMemoryDomainStore()
+    query = DEFAULT_QUERY
+    question = "Summarize housing-related signals from recent San Jose meeting minutes."
+    idempotency = "san-jose-ca:meeting_minutes:2026-04-12"
+
+    if scenario == "source_failure":
+        domain = DomainBoundaryService(
+            store=store,
+            search_client=SearxLikeClient(fail_mode=True),
+            reader_client=ReaderContractClient(fail_mode=False),
+            vector_adapter=VectorAdapter(),
+            analysis_adapter=AnalysisAdapter(),
+        )
+        runner = WindmillShapedRunner(domain)
+        return runner.run_once("run-source-failure", "job-search", idempotency, query, question)
+
+    if scenario == "reader_failure":
+        domain = DomainBoundaryService(
+            store=store,
+            search_client=SearxLikeClient(fail_mode=False),
+            reader_client=ReaderContractClient(fail_mode=True),
+            vector_adapter=VectorAdapter(),
+            analysis_adapter=AnalysisAdapter(),
+        )
+        runner = WindmillShapedRunner(domain)
+        return runner.run_once("run-reader-failure", "job-reader", idempotency, query, question)
+
+    if scenario == "storage_failure":
+        domain = DomainBoundaryService(
+            store=store,
+            search_client=SearxLikeClient(fail_mode=False),
+            reader_client=ReaderContractClient(fail_mode=False),
+            vector_adapter=VectorAdapter(),
+            analysis_adapter=AnalysisAdapter(),
+            fail_storage_step="index",
+        )
+        runner = WindmillShapedRunner(domain)
+        return runner.run_once("run-storage-failure", "job-index", idempotency, query, question)
+
+    domain = DomainBoundaryService(
+        store=store,
+        search_client=SearxLikeClient(fail_mode=False),
+        reader_client=ReaderContractClient(fail_mode=False),
+        vector_adapter=VectorAdapter(),
+        analysis_adapter=AnalysisAdapter(),
+    )
+    runner = WindmillShapedRunner(domain)
+    first = runner.run_once("run-first", "job-main", idempotency, query, question)
+    second = runner.run_once("run-second", "job-main", idempotency, query, question)
+    return {"first_run": first, "rerun": second}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run Path B Windmill storage-boundary bakeoff (domain boundary model)."
+    )
+    parser.add_argument(
+        "--scenario",
+        choices=["happy_rerun", "source_failure", "reader_failure", "storage_failure"],
+        default="happy_rerun",
+        help="Scenario to execute.",
+    )
+    parser.add_argument(
+        "--out",
+        default="",
+        help="Optional JSON output file path.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    result = run_scenario(args.scenario)
+    if args.pretty:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(json.dumps(result, sort_keys=True))
+    if args.out:
+        out_path = Path(args.out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            json.dumps(result, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/verification/windmill_bakeoff_domain_boundary.py
+++ b/backend/scripts/verification/windmill_bakeoff_domain_boundary.py
@@ -10,12 +10,11 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import os
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
 

--- a/backend/services/pipeline/domain/__init__.py
+++ b/backend/services/pipeline/domain/__init__.py
@@ -35,4 +35,3 @@ __all__ = [
     "WindmillMetadata",
     "build_v2_canonical_document_key",
 ]
-

--- a/backend/services/pipeline/domain/__init__.py
+++ b/backend/services/pipeline/domain/__init__.py
@@ -1,0 +1,38 @@
+"""Affordabot pipeline domain package for Windmill boundary commands."""
+
+from services.pipeline.domain.commands import PipelineDomainCommands
+from services.pipeline.domain.constants import CONTRACT_VERSION
+from services.pipeline.domain.identity import build_v2_canonical_document_key
+from services.pipeline.domain.in_memory import (
+    InMemoryAnalyzer,
+    InMemoryArtifactStore,
+    InMemoryDomainState,
+    InMemoryReaderProvider,
+    InMemorySearchProvider,
+    InMemoryVectorStore,
+)
+from services.pipeline.domain.models import (
+    CommandEnvelope,
+    CommandResponse,
+    FreshnessPolicy,
+    WindmillMetadata,
+)
+from services.pipeline.domain.ports import SearchResultItem
+
+__all__ = [
+    "CONTRACT_VERSION",
+    "CommandEnvelope",
+    "CommandResponse",
+    "FreshnessPolicy",
+    "InMemoryAnalyzer",
+    "InMemoryArtifactStore",
+    "InMemoryDomainState",
+    "InMemoryReaderProvider",
+    "InMemorySearchProvider",
+    "InMemoryVectorStore",
+    "PipelineDomainCommands",
+    "SearchResultItem",
+    "WindmillMetadata",
+    "build_v2_canonical_document_key",
+]
+

--- a/backend/services/pipeline/domain/__init__.py
+++ b/backend/services/pipeline/domain/__init__.py
@@ -18,6 +18,12 @@ from services.pipeline.domain.models import (
     WindmillMetadata,
 )
 from services.pipeline.domain.ports import SearchResultItem
+from services.pipeline.domain.storage import (
+    InMemoryArtifactBlobStore,
+    InMemoryChunkVectorStore,
+    InMemoryPipelineStateStore,
+    PipelineStorageCoordinator,
+)
 
 __all__ = [
     "CONTRACT_VERSION",
@@ -26,10 +32,14 @@ __all__ = [
     "FreshnessPolicy",
     "InMemoryAnalyzer",
     "InMemoryArtifactStore",
+    "InMemoryArtifactBlobStore",
     "InMemoryDomainState",
+    "InMemoryChunkVectorStore",
+    "InMemoryPipelineStateStore",
     "InMemoryReaderProvider",
     "InMemorySearchProvider",
     "InMemoryVectorStore",
+    "PipelineStorageCoordinator",
     "PipelineDomainCommands",
     "SearchResultItem",
     "WindmillMetadata",

--- a/backend/services/pipeline/domain/commands.py
+++ b/backend/services/pipeline/domain/commands.py
@@ -1,0 +1,623 @@
+"""Domain command service for Windmill/orchestrator integration."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime, timezone
+import hashlib
+from typing import Any
+
+from services.pipeline.domain.constants import CONTRACT_VERSION
+from services.pipeline.domain.identity import build_v2_canonical_document_key
+from services.pipeline.domain.in_memory import InMemoryDomainState, stable_json_hash
+from services.pipeline.domain.models import CommandEnvelope, CommandResponse, FreshnessPolicy
+from services.pipeline.domain.ports import (
+    Analyzer,
+    ArtifactStore,
+    ReaderProvider,
+    SearchProvider,
+    SearchResultItem,
+    VectorStore,
+)
+
+
+def _hash_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _as_utc(value: datetime) -> datetime:
+    return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+
+
+def _stable_chunk_id(
+    *,
+    canonical_document_key: str,
+    content_hash: str,
+    chunk_index: int,
+    chunk_text: str,
+) -> str:
+    chunk_text_hash = _hash_text(chunk_text)
+    material = (
+        f"{CONTRACT_VERSION}|{canonical_document_key}|{content_hash}|{chunk_index}|{chunk_text_hash}"
+    )
+    return f"chunk_{_hash_text(material)}"
+
+
+def _split_chunks(text: str) -> list[str]:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        return []
+    return lines
+
+
+class PipelineDomainCommands:
+    """Implements the six coarse commands with deterministic in-memory semantics."""
+
+    def __init__(
+        self,
+        *,
+        state: InMemoryDomainState,
+        search_provider: SearchProvider,
+        reader_provider: ReaderProvider,
+        artifact_store: ArtifactStore,
+        vector_store: VectorStore,
+        analyzer: Analyzer,
+    ) -> None:
+        self.state = state
+        self.search_provider = search_provider
+        self.reader_provider = reader_provider
+        self.artifact_store = artifact_store
+        self.vector_store = vector_store
+        self.analyzer = analyzer
+
+    def _reuse_if_idempotent(self, envelope: CommandEnvelope) -> CommandResponse | None:
+        cached = self.state.command_results.get(envelope.idempotency_key)
+        if not cached:
+            return None
+        return CommandResponse(**cached)
+
+    def _store_result(self, envelope: CommandEnvelope, response: CommandResponse) -> CommandResponse:
+        self.state.command_results[envelope.idempotency_key] = asdict(response)
+        return response
+
+    def _windmill_refs(self, envelope: CommandEnvelope) -> dict[str, str]:
+        return {
+            "windmill_run_id": envelope.windmill.run_id,
+            "windmill_job_id": envelope.windmill.job_id,
+        }
+
+    def search_materialize(
+        self, *, envelope: CommandEnvelope, query: str, max_results: int = 10
+    ) -> CommandResponse:
+        envelope.validate()
+        reused = self._reuse_if_idempotent(envelope)
+        if reused:
+            reused.status = "skipped"
+            reused.decision_reason = "idempotent_reuse"
+            return reused
+
+        try:
+            results = self.search_provider.search(
+                query=query,
+                jurisdiction_id=envelope.jurisdiction_id,
+                source_family=envelope.source_family,
+                max_results=max_results,
+            )
+        except Exception as exc:
+            return self._store_result(
+                envelope,
+                CommandResponse(
+                    command="search_materialize",
+                    status="failed_retryable",
+                    decision_reason="search_transport_error",
+                    retry_class="transport",
+                    alerts=[f"search_provider_error:{exc}"],
+                    refs=self._windmill_refs(envelope),
+                ),
+            )
+
+        snapshot_hash = stable_json_hash(
+            {
+                "query": query,
+                "jurisdiction_id": envelope.jurisdiction_id,
+                "source_family": envelope.source_family,
+                "results": [asdict(item) for item in results],
+            }
+        )
+        snapshot_id = f"snapshot_{snapshot_hash[:16]}"
+        self.state.search_snapshots[snapshot_id] = {
+            "snapshot_id": snapshot_id,
+            "query": query,
+            "jurisdiction_id": envelope.jurisdiction_id,
+            "source_family": envelope.source_family,
+            "captured_at": self.state.now.isoformat(),
+            "results": [asdict(item) for item in results],
+        }
+
+        status = "succeeded" if results else "succeeded_with_alerts"
+        decision_reason = "fresh_snapshot_materialized" if results else "search_empty_result"
+        alerts = [] if results else ["search_results_empty"]
+
+        return self._store_result(
+            envelope,
+            CommandResponse(
+                command="search_materialize",
+                status=status,
+                decision_reason=decision_reason,
+                retry_class="none",
+                alerts=alerts,
+                counts={"search_results": len(results)},
+                refs={**self._windmill_refs(envelope), "search_snapshot_id": snapshot_id},
+                details={"query": query},
+            ),
+        )
+
+    def freshness_gate(
+        self,
+        *,
+        envelope: CommandEnvelope,
+        snapshot_id: str,
+        policy: FreshnessPolicy,
+        latest_success_at: datetime | None,
+    ) -> CommandResponse:
+        envelope.validate()
+        reused = self._reuse_if_idempotent(envelope)
+        if reused:
+            reused.status = "skipped"
+            reused.decision_reason = "idempotent_reuse"
+            return reused
+
+        snapshot = self.state.search_snapshots.get(snapshot_id)
+        if not snapshot:
+            return self._store_result(
+                envelope,
+                CommandResponse(
+                    command="freshness_gate",
+                    status="failed_terminal",
+                    decision_reason="missing_snapshot",
+                    retry_class="contract_violation",
+                    refs=self._windmill_refs(envelope),
+                ),
+            )
+
+        captured_at = datetime.fromisoformat(snapshot["captured_at"])
+        snapshot_age_hours = int((_as_utc(self.state.now) - _as_utc(captured_at)).total_seconds() / 3600)
+        result_count = len(snapshot["results"])
+
+        fallback_age_hours = None
+        if latest_success_at:
+            fallback_age_hours = int(
+                (_as_utc(self.state.now) - _as_utc(latest_success_at)).total_seconds() / 3600
+            )
+
+        freshness_status = "fresh"
+        alerts: list[str] = []
+        status = "succeeded"
+
+        if result_count == 0:
+            if fallback_age_hours is not None and fallback_age_hours <= policy.stale_usable_ceiling_hours:
+                freshness_status = "empty_but_usable"
+                status = "succeeded_with_alerts"
+                alerts.append("source_search_failed_using_last_success")
+            else:
+                freshness_status = "empty_blocked"
+                status = "blocked"
+                alerts.append("empty_search_results_fail_closed")
+        elif snapshot_age_hours <= policy.fresh_hours:
+            freshness_status = "fresh"
+        elif snapshot_age_hours <= policy.stale_usable_ceiling_hours:
+            freshness_status = "stale_but_usable"
+            status = "succeeded_with_alerts"
+            alerts.append("source_search_failed_using_last_success")
+        else:
+            freshness_status = "stale_blocked"
+            status = "blocked"
+            alerts.append("stale_search_results_fail_closed")
+
+        retry_class = "none" if status != "blocked" else "operator_required"
+        return self._store_result(
+            envelope,
+            CommandResponse(
+                command="freshness_gate",
+                status=status,
+                decision_reason=freshness_status,
+                retry_class=retry_class,
+                alerts=alerts,
+                counts={"search_results": result_count},
+                refs={**self._windmill_refs(envelope), "search_snapshot_id": snapshot_id},
+                details={
+                    "freshness_status": freshness_status,
+                    "fresh_hours": policy.fresh_hours,
+                    "stale_usable_ceiling_hours": policy.stale_usable_ceiling_hours,
+                    "fail_closed_ceiling_hours": policy.fail_closed_ceiling_hours,
+                    "snapshot_age_hours": snapshot_age_hours,
+                    "fallback_age_hours": fallback_age_hours,
+                },
+            ),
+        )
+
+    def read_fetch(
+        self, *, envelope: CommandEnvelope, snapshot_id: str, max_reads: int = 1
+    ) -> CommandResponse:
+        envelope.validate()
+        reused = self._reuse_if_idempotent(envelope)
+        if reused:
+            reused.status = "skipped"
+            reused.decision_reason = "idempotent_reuse"
+            return reused
+
+        snapshot = self.state.search_snapshots.get(snapshot_id)
+        if not snapshot:
+            return self._store_result(
+                envelope,
+                CommandResponse(
+                    command="read_fetch",
+                    status="failed_terminal",
+                    decision_reason="missing_snapshot",
+                    retry_class="contract_violation",
+                    refs=self._windmill_refs(envelope),
+                ),
+            )
+
+        selected: list[SearchResultItem] = [
+            SearchResultItem(
+                url=item["url"],
+                title=item.get("title", ""),
+                snippet=item.get("snippet", ""),
+            )
+            for item in snapshot["results"][:max_reads]
+        ]
+        if not selected:
+            return self._store_result(
+                envelope,
+                CommandResponse(
+                    command="read_fetch",
+                    status="blocked",
+                    decision_reason="no_candidate_urls",
+                    retry_class="insufficient_evidence",
+                    refs=self._windmill_refs(envelope),
+                ),
+            )
+
+        raw_scrape_ids: list[str] = []
+        artifact_refs: list[str] = []
+        for candidate in selected:
+            try:
+                doc = self.reader_provider.fetch(url=candidate.url)
+            except Exception as exc:
+                return self._store_result(
+                    envelope,
+                    CommandResponse(
+                        command="read_fetch",
+                        status="failed_retryable",
+                        decision_reason="reader_provider_error",
+                        retry_class="provider_unavailable",
+                        alerts=[f"reader_error:{exc}"],
+                        refs=self._windmill_refs(envelope),
+                    ),
+                )
+
+            canonical_key = build_v2_canonical_document_key(
+                jurisdiction_id=envelope.jurisdiction_id,
+                source_family=envelope.source_family,
+                url=doc.url,
+                metadata={"document_type": doc.document_type, "title": doc.title},
+                data={"published_date": doc.published_date},
+            )
+            content_hash = _hash_text(doc.text)
+            scrape_id = f"raw_{_hash_text(f'{canonical_key}|{content_hash}')[:16]}"
+            existing = self.state.raw_scrapes.get(scrape_id)
+            if existing:
+                existing["seen_count"] += 1
+                existing["last_seen_at"] = self.state.now.isoformat()
+                raw_scrape_ids.append(scrape_id)
+                artifact_refs.append(existing["artifact_ref"])
+                continue
+
+            try:
+                artifact = self.artifact_store.put(
+                    contract_version=CONTRACT_VERSION,
+                    jurisdiction_id=envelope.jurisdiction_id,
+                    source_family=envelope.source_family,
+                    artifact_kind="reader_output",
+                    body=doc.text,
+                    media_type=doc.media_type,
+                )
+            except Exception as exc:
+                return self._store_result(
+                    envelope,
+                    CommandResponse(
+                        command="read_fetch",
+                        status="failed_terminal",
+                        decision_reason="reader_artifact_write_failed",
+                        retry_class="transient_storage",
+                        alerts=[f"artifact_store_error:{exc}"],
+                        refs=self._windmill_refs(envelope),
+                    ),
+                )
+
+            self.state.raw_scrapes[scrape_id] = {
+                "raw_scrape_id": scrape_id,
+                "canonical_document_key": canonical_key,
+                "content_hash": content_hash,
+                "artifact_ref": artifact.artifact_ref,
+                "jurisdiction_id": envelope.jurisdiction_id,
+                "source_family": envelope.source_family,
+                "seen_count": 1,
+                "last_seen_at": self.state.now.isoformat(),
+                "title": doc.title,
+                "text": doc.text,
+            }
+            raw_scrape_ids.append(scrape_id)
+            artifact_refs.append(artifact.artifact_ref)
+
+        return self._store_result(
+            envelope,
+            CommandResponse(
+                command="read_fetch",
+                status="succeeded",
+                decision_reason="raw_scrapes_materialized",
+                retry_class="none",
+                counts={"raw_scrapes": len(raw_scrape_ids), "artifacts": len(artifact_refs)},
+                refs={
+                    **self._windmill_refs(envelope),
+                    "raw_scrape_ids": raw_scrape_ids,
+                    "artifact_refs": artifact_refs,
+                },
+            ),
+        )
+
+    def index(self, *, envelope: CommandEnvelope, raw_scrape_ids: list[str]) -> CommandResponse:
+        envelope.validate()
+        reused = self._reuse_if_idempotent(envelope)
+        if reused:
+            reused.status = "skipped"
+            reused.decision_reason = "idempotent_reuse"
+            return reused
+
+        rows = [self.state.raw_scrapes.get(raw_id) for raw_id in raw_scrape_ids]
+        valid_rows = [row for row in rows if row]
+        if not valid_rows:
+            return self._store_result(
+                envelope,
+                CommandResponse(
+                    command="index",
+                    status="blocked",
+                    decision_reason="no_raw_scrapes",
+                    retry_class="insufficient_evidence",
+                    refs=self._windmill_refs(envelope),
+                ),
+            )
+
+        chunks: list[dict[str, Any]] = []
+        for row in valid_rows:
+            for idx, chunk_text in enumerate(_split_chunks(row["text"])):
+                chunk_id = _stable_chunk_id(
+                    canonical_document_key=row["canonical_document_key"],
+                    content_hash=row["content_hash"],
+                    chunk_index=idx,
+                    chunk_text=chunk_text,
+                )
+                chunks.append(
+                    {
+                        "chunk_id": chunk_id,
+                        "raw_scrape_id": row["raw_scrape_id"],
+                        "canonical_document_key": row["canonical_document_key"],
+                        "artifact_ref": row["artifact_ref"],
+                        "jurisdiction_id": row["jurisdiction_id"],
+                        "source_family": row["source_family"],
+                        "contract_version": CONTRACT_VERSION,
+                        "chunk_index": idx,
+                        "text": chunk_text,
+                    }
+                )
+
+        try:
+            upserted = self.vector_store.upsert_chunks(chunks)
+        except Exception as exc:
+            return self._store_result(
+                envelope,
+                CommandResponse(
+                    command="index",
+                    status="failed_retryable",
+                    decision_reason="vector_write_failed",
+                    retry_class="transient_storage",
+                    alerts=[f"vector_store_error:{exc}"],
+                    refs=self._windmill_refs(envelope),
+                ),
+            )
+
+        return self._store_result(
+            envelope,
+            CommandResponse(
+                command="index",
+                status="succeeded",
+                decision_reason="chunks_indexed",
+                retry_class="none",
+                counts={"chunks": upserted},
+                refs={**self._windmill_refs(envelope), "raw_scrape_ids": raw_scrape_ids},
+            ),
+        )
+
+    def analyze(
+        self,
+        *,
+        envelope: CommandEnvelope,
+        question: str,
+        jurisdiction_id: str,
+        source_family: str,
+    ) -> CommandResponse:
+        envelope.validate()
+        reused = self._reuse_if_idempotent(envelope)
+        if reused:
+            reused.status = "skipped"
+            reused.decision_reason = "idempotent_reuse"
+            return reused
+
+        evidence = [
+            chunk
+            for chunk in self.state.chunks.values()
+            if chunk["jurisdiction_id"] == jurisdiction_id and chunk["source_family"] == source_family
+        ]
+        if not evidence:
+            return self._store_result(
+                envelope,
+                CommandResponse(
+                    command="analyze",
+                    status="blocked",
+                    decision_reason="no_evidence_chunks",
+                    retry_class="insufficient_evidence",
+                    refs=self._windmill_refs(envelope),
+                    counts={"evidence_chunks": 0},
+                ),
+            )
+
+        try:
+            payload = self.analyzer.analyze(question=question, evidence_chunks=evidence)
+        except Exception as exc:
+            return self._store_result(
+                envelope,
+                CommandResponse(
+                    command="analyze",
+                    status="failed_terminal",
+                    decision_reason="analysis_failed",
+                    retry_class="contract_violation",
+                    alerts=[f"analysis_error:{exc}"],
+                    refs=self._windmill_refs(envelope),
+                ),
+            )
+
+        analysis_id = f"analysis_{_hash_text(stable_json_hash(payload))[:16]}"
+        self.state.analyses[analysis_id] = {
+            "analysis_id": analysis_id,
+            "question": question,
+            "jurisdiction_id": jurisdiction_id,
+            "source_family": source_family,
+            "payload": payload,
+            "contract_version": CONTRACT_VERSION,
+        }
+        self.state.previous_success_by_scope[f"{jurisdiction_id}|{source_family}"] = self.state.now
+        return self._store_result(
+            envelope,
+            CommandResponse(
+                command="analyze",
+                status="succeeded",
+                decision_reason="analysis_completed",
+                retry_class="none",
+                counts={"analyses": 1, "evidence_chunks": len(evidence)},
+                refs={**self._windmill_refs(envelope), "analysis_id": analysis_id},
+                details={"sufficiency_state": payload.get("sufficiency_state")},
+            ),
+        )
+
+    def summarize_run(
+        self,
+        *,
+        envelope: CommandEnvelope,
+        command_responses: list[CommandResponse],
+    ) -> CommandResponse:
+        envelope.validate()
+        reused = self._reuse_if_idempotent(envelope)
+        if reused:
+            reused.status = "skipped"
+            reused.decision_reason = "idempotent_reuse"
+            return reused
+
+        counts: dict[str, int] = {}
+        refs: dict[str, Any] = self._windmill_refs(envelope)
+        alerts: list[str] = []
+        statuses: list[str] = []
+        step_map: dict[str, str] = {}
+        for result in command_responses:
+            statuses.append(result.status)
+            alerts.extend(result.alerts)
+            for key, value in result.counts.items():
+                counts[key] = counts.get(key, 0) + value
+            step_map[result.command] = result.status
+            refs.update({f"{result.command}_reason": result.decision_reason})
+            refs.update({f"{result.command}_retry_class": result.retry_class})
+
+        summary_status = "succeeded"
+        if any(status == "failed_terminal" for status in statuses):
+            summary_status = "failed_terminal"
+        elif any(status == "failed_retryable" for status in statuses):
+            summary_status = "failed_retryable"
+        elif any(status == "blocked" for status in statuses):
+            summary_status = "blocked"
+        elif any(status == "succeeded_with_alerts" for status in statuses):
+            summary_status = "succeeded_with_alerts"
+
+        run_id = f"run_{envelope.windmill.run_id}"
+        self.state.run_summaries[run_id] = {
+            "run_id": run_id,
+            "summary_status": summary_status,
+            "step_statuses": step_map,
+            "counts": counts,
+            "alerts": list(dict.fromkeys(alerts)),
+        }
+        return self._store_result(
+            envelope,
+            CommandResponse(
+                command="summarize_run",
+                status=summary_status,
+                decision_reason="run_summary_materialized",
+                retry_class="none" if summary_status.startswith("succeeded") else "operator_required",
+                alerts=list(dict.fromkeys(alerts)),
+                counts=counts,
+                refs=refs | {"run_id": run_id},
+                details={"step_statuses": step_map},
+            ),
+        )
+
+    def full_refresh(
+        self,
+        *,
+        query: str,
+        question: str,
+        search_envelope: CommandEnvelope,
+        freshness_envelope: CommandEnvelope,
+        read_envelope: CommandEnvelope,
+        index_envelope: CommandEnvelope,
+        analyze_envelope: CommandEnvelope,
+        summarize_envelope: CommandEnvelope,
+        policy: FreshnessPolicy,
+    ) -> list[CommandResponse]:
+        search_result = self.search_materialize(envelope=search_envelope, query=query)
+        snapshot_id = str(search_result.refs.get("search_snapshot_id", ""))
+        latest_success = self.state.previous_success_by_scope.get(
+            f"{search_envelope.jurisdiction_id}|{search_envelope.source_family}"
+        )
+        freshness_result = self.freshness_gate(
+            envelope=freshness_envelope,
+            snapshot_id=snapshot_id,
+            policy=policy,
+            latest_success_at=latest_success,
+        )
+        responses = [search_result, freshness_result]
+        freshness_state = freshness_result.decision_reason
+
+        if freshness_state in {"stale_blocked", "empty_blocked"}:
+            responses.append(self.summarize_run(envelope=summarize_envelope, command_responses=responses))
+            return responses
+
+        read_result = self.read_fetch(envelope=read_envelope, snapshot_id=snapshot_id)
+        responses.append(read_result)
+        if read_result.status not in {"succeeded", "succeeded_with_alerts", "skipped"}:
+            responses.append(self.summarize_run(envelope=summarize_envelope, command_responses=responses))
+            return responses
+
+        index_result = self.index(
+            envelope=index_envelope,
+            raw_scrape_ids=list(read_result.refs.get("raw_scrape_ids", [])),
+        )
+        responses.append(index_result)
+
+        analyze_result = self.analyze(
+            envelope=analyze_envelope,
+            question=question,
+            jurisdiction_id=search_envelope.jurisdiction_id,
+            source_family=search_envelope.source_family,
+        )
+        responses.append(analyze_result)
+        responses.append(self.summarize_run(envelope=summarize_envelope, command_responses=responses))
+        return responses

--- a/backend/services/pipeline/domain/commands.py
+++ b/backend/services/pipeline/domain/commands.py
@@ -71,14 +71,22 @@ class PipelineDomainCommands:
         self.analyzer = analyzer
 
     def _reuse_if_idempotent(self, envelope: CommandEnvelope) -> CommandResponse | None:
-        cached = self.state.command_results.get(envelope.idempotency_key)
+        cached = self.state.command_results.get(self._command_result_key(envelope))
         if not cached:
             return None
-        return CommandResponse(**cached)
+        response = CommandResponse(**cached)
+        response.details = {
+            **response.details,
+            "idempotent_reuse": True,
+        }
+        return response
 
     def _store_result(self, envelope: CommandEnvelope, response: CommandResponse) -> CommandResponse:
-        self.state.command_results[envelope.idempotency_key] = asdict(response)
+        self.state.command_results[self._command_result_key(envelope)] = asdict(response)
         return response
+
+    def _command_result_key(self, envelope: CommandEnvelope) -> str:
+        return f"{envelope.command}:{envelope.idempotency_key}"
 
     def _windmill_refs(self, envelope: CommandEnvelope) -> dict[str, str]:
         return {
@@ -92,8 +100,6 @@ class PipelineDomainCommands:
         envelope.validate()
         reused = self._reuse_if_idempotent(envelope)
         if reused:
-            reused.status = "skipped"
-            reused.decision_reason = "idempotent_reuse"
             return reused
 
         try:
@@ -163,8 +169,6 @@ class PipelineDomainCommands:
         envelope.validate()
         reused = self._reuse_if_idempotent(envelope)
         if reused:
-            reused.status = "skipped"
-            reused.decision_reason = "idempotent_reuse"
             return reused
 
         snapshot = self.state.search_snapshots.get(snapshot_id)
@@ -242,8 +246,6 @@ class PipelineDomainCommands:
         envelope.validate()
         reused = self._reuse_if_idempotent(envelope)
         if reused:
-            reused.status = "skipped"
-            reused.decision_reason = "idempotent_reuse"
             return reused
 
         snapshot = self.state.search_snapshots.get(snapshot_id)
@@ -371,8 +373,6 @@ class PipelineDomainCommands:
         envelope.validate()
         reused = self._reuse_if_idempotent(envelope)
         if reused:
-            reused.status = "skipped"
-            reused.decision_reason = "idempotent_reuse"
             return reused
 
         rows = [self.state.raw_scrapes.get(raw_id) for raw_id in raw_scrape_ids]
@@ -450,8 +450,6 @@ class PipelineDomainCommands:
         envelope.validate()
         reused = self._reuse_if_idempotent(envelope)
         if reused:
-            reused.status = "skipped"
-            reused.decision_reason = "idempotent_reuse"
             return reused
 
         evidence = [
@@ -519,8 +517,6 @@ class PipelineDomainCommands:
         envelope.validate()
         reused = self._reuse_if_idempotent(envelope)
         if reused:
-            reused.status = "skipped"
-            reused.decision_reason = "idempotent_reuse"
             return reused
 
         counts: dict[str, int] = {}

--- a/backend/services/pipeline/domain/constants.py
+++ b/backend/services/pipeline/domain/constants.py
@@ -34,4 +34,3 @@ RetryClass = Literal[
     "insufficient_evidence",
     "operator_required",
 ]
-

--- a/backend/services/pipeline/domain/constants.py
+++ b/backend/services/pipeline/domain/constants.py
@@ -1,0 +1,37 @@
+"""Shared contract constants for Windmill/domain boundary commands."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+CONTRACT_VERSION = "2026-04-13.windmill-domain.v1"
+
+CommandName = Literal[
+    "search_materialize",
+    "freshness_gate",
+    "read_fetch",
+    "index",
+    "analyze",
+    "summarize_run",
+]
+
+StatusName = Literal[
+    "succeeded",
+    "succeeded_with_alerts",
+    "skipped",
+    "blocked",
+    "failed_retryable",
+    "failed_terminal",
+]
+
+RetryClass = Literal[
+    "none",
+    "transport",
+    "rate_limited",
+    "transient_storage",
+    "provider_unavailable",
+    "contract_violation",
+    "insufficient_evidence",
+    "operator_required",
+]
+

--- a/backend/services/pipeline/domain/identity.py
+++ b/backend/services/pipeline/domain/identity.py
@@ -74,4 +74,3 @@ def build_v2_canonical_document_key(
         f"v2|jurisdiction={jurisdiction_slug}|family={family}|doctype={document_type}"
         f"|title={title}|date={date_hint}"
     )
-

--- a/backend/services/pipeline/domain/identity.py
+++ b/backend/services/pipeline/domain/identity.py
@@ -1,0 +1,77 @@
+"""Canonical identity helpers for the v2 pipeline boundary contract."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+from services.revision_identity import normalize_canonical_url
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.strip().lower()).strip("-")
+    return slug or "unknown"
+
+
+def _normalize_text(value: Any, fallback: str) -> str:
+    text = re.sub(r"\s+", " ", str(value or "")).strip().lower()
+    return text if text else fallback
+
+
+def _normalize_date_hint(value: Any) -> str:
+    if not value:
+        return "unknown"
+    text = str(value).strip()
+    match = re.search(r"\d{4}-\d{2}-\d{2}", text)
+    if match:
+        return match.group(0)
+    return _normalize_text(text, "unknown")
+
+
+def _normalize_document_type(metadata: Mapping[str, Any], data: Mapping[str, Any]) -> str:
+    value = (
+        metadata.get("document_type")
+        or data.get("document_type")
+        or metadata.get("manual_asset_class")
+        or "unknown"
+    )
+    normalized = re.sub(r"\s+", "_", str(value).strip().lower())
+    return normalized or "unknown"
+
+
+def build_v2_canonical_document_key(
+    *,
+    jurisdiction_id: str,
+    source_family: str,
+    url: str | None,
+    metadata: Mapping[str, Any] | None = None,
+    data: Mapping[str, Any] | None = None,
+) -> str:
+    """Build v2 canonical document identity scoped by jurisdiction and source family."""
+    jurisdiction_slug = slugify(jurisdiction_id)
+    family = slugify(source_family).replace("-", "_")
+    meta = dict(metadata or {})
+    payload = dict(data or {})
+    document_type = _normalize_document_type(meta, payload)
+
+    canonical_url = normalize_canonical_url(
+        meta.get("canonical_url") or payload.get("canonical_url") or url
+    )
+    if canonical_url and not canonical_url.startswith("unknown://"):
+        return (
+            f"v2|jurisdiction={jurisdiction_slug}|family={family}|doctype={document_type}"
+            f"|url={canonical_url}"
+        )
+
+    title = _normalize_text(meta.get("title") or payload.get("title"), "untitled")
+    date_hint = _normalize_date_hint(
+        payload.get("published_date")
+        or meta.get("published_date")
+        or payload.get("meeting_date")
+        or meta.get("meeting_date")
+    )
+    return (
+        f"v2|jurisdiction={jurisdiction_slug}|family={family}|doctype={document_type}"
+        f"|title={title}|date={date_hint}"
+    )
+

--- a/backend/services/pipeline/domain/in_memory.py
+++ b/backend/services/pipeline/domain/in_memory.py
@@ -1,0 +1,163 @@
+"""Deterministic in-memory adapters and state for domain command tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import hashlib
+import json
+from typing import Any
+
+from services.pipeline.domain.ports import (
+    Analyzer,
+    ArtifactRecord,
+    ArtifactStore,
+    ReaderDocument,
+    ReaderProvider,
+    SearchProvider,
+    SearchResultItem,
+    VectorStore,
+)
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass
+class InMemoryDomainState:
+    command_results: dict[str, dict[str, Any]] = field(default_factory=dict)
+    search_snapshots: dict[str, dict[str, Any]] = field(default_factory=dict)
+    raw_scrapes: dict[str, dict[str, Any]] = field(default_factory=dict)
+    artifacts: dict[str, ArtifactRecord] = field(default_factory=dict)
+    chunks: dict[str, dict[str, Any]] = field(default_factory=dict)
+    analyses: dict[str, dict[str, Any]] = field(default_factory=dict)
+    run_summaries: dict[str, dict[str, Any]] = field(default_factory=dict)
+    previous_success_by_scope: dict[str, datetime] = field(default_factory=dict)
+    now: datetime = field(default_factory=utc_now)
+
+
+class InMemorySearchProvider(SearchProvider):
+    def __init__(
+        self, *, results: list[SearchResultItem] | None = None, fail_mode: str | None = None
+    ) -> None:
+        self.results = results or []
+        self.fail_mode = fail_mode
+
+    def search(
+        self, *, query: str, jurisdiction_id: str, source_family: str, max_results: int
+    ) -> list[SearchResultItem]:
+        _ = (query, jurisdiction_id, source_family)
+        if self.fail_mode:
+            raise RuntimeError(self.fail_mode)
+        return self.results[:max_results]
+
+
+class InMemoryReaderProvider(ReaderProvider):
+    def __init__(self, *, fail_mode: str | None = None) -> None:
+        self.fail_mode = fail_mode
+
+    def fetch(self, *, url: str) -> ReaderDocument:
+        if self.fail_mode:
+            raise RuntimeError(self.fail_mode)
+        return ReaderDocument(
+            url=url,
+            title="San Jose Meeting Minutes",
+            text=(
+                "# Minutes\n"
+                "Housing permit processing timelines discussed.\n"
+                "Fee schedule hearing moved.\n"
+                "Public comments on affordable housing expansion."
+            ),
+            fetched_at=utc_now(),
+            document_type="meeting_minutes",
+            published_date="2026-04-10",
+        )
+
+
+class InMemoryArtifactStore(ArtifactStore):
+    def __init__(self, state: InMemoryDomainState, *, fail_mode: str | None = None) -> None:
+        self.state = state
+        self.fail_mode = fail_mode
+
+    def put(
+        self,
+        *,
+        contract_version: str,
+        jurisdiction_id: str,
+        source_family: str,
+        artifact_kind: str,
+        body: str,
+        media_type: str,
+    ) -> ArtifactRecord:
+        if self.fail_mode:
+            raise RuntimeError(self.fail_mode)
+
+        content_hash = sha256_text(body)
+        ext = "json" if media_type == "application/json" else "md"
+        artifact_ref = (
+            f"artifacts/{contract_version}/{jurisdiction_id}/{source_family}/"
+            f"{artifact_kind}/{content_hash}.{ext}"
+        )
+        existing = self.state.artifacts.get(artifact_ref)
+        if existing:
+            return existing
+
+        record = ArtifactRecord(
+            artifact_ref=artifact_ref,
+            content_hash=content_hash,
+            media_type=media_type,
+            size_bytes=len(body.encode("utf-8")),
+            kind=artifact_kind,
+        )
+        self.state.artifacts[artifact_ref] = record
+        return record
+
+
+class InMemoryVectorStore(VectorStore):
+    def __init__(self, state: InMemoryDomainState, *, fail_mode: str | None = None) -> None:
+        self.state = state
+        self.fail_mode = fail_mode
+
+    def upsert_chunks(self, chunks: list[dict[str, Any]]) -> int:
+        if self.fail_mode:
+            raise RuntimeError(self.fail_mode)
+        for chunk in chunks:
+            self.state.chunks[chunk["chunk_id"]] = dict(chunk)
+        return len(chunks)
+
+
+class InMemoryAnalyzer(Analyzer):
+    def analyze(
+        self, *, question: str, evidence_chunks: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        if not evidence_chunks:
+            raise RuntimeError("insufficient_evidence")
+        claims = [
+            {
+                "claim": "Housing-related agenda items were discussed.",
+                "evidence_refs": [
+                    {
+                        "chunk_id": chunk["chunk_id"],
+                        "canonical_document_key": chunk["canonical_document_key"],
+                        "artifact_ref": chunk["artifact_ref"],
+                    }
+                    for chunk in evidence_chunks[:2]
+                ],
+            }
+        ]
+        return {
+            "question": question,
+            "summary": "Meeting minutes indicate active housing policy discussion.",
+            "claims": claims,
+            "sufficiency_state": "qualitative_only",
+        }
+
+
+def stable_json_hash(value: Any) -> str:
+    return sha256_text(json.dumps(value, sort_keys=True, separators=(",", ":")))
+

--- a/backend/services/pipeline/domain/in_memory.py
+++ b/backend/services/pipeline/domain/in_memory.py
@@ -160,4 +160,3 @@ class InMemoryAnalyzer(Analyzer):
 
 def stable_json_hash(value: Any) -> str:
     return sha256_text(json.dumps(value, sort_keys=True, separators=(",", ":")))
-

--- a/backend/services/pipeline/domain/models.py
+++ b/backend/services/pipeline/domain/models.py
@@ -76,4 +76,3 @@ class FreshnessPolicy:
     fresh_hours: int
     stale_usable_ceiling_hours: int
     fail_closed_ceiling_hours: int
-

--- a/backend/services/pipeline/domain/models.py
+++ b/backend/services/pipeline/domain/models.py
@@ -1,0 +1,79 @@
+"""Typed request/response models for pipeline domain commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from services.pipeline.domain.constants import CONTRACT_VERSION, CommandName, RetryClass, StatusName
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(frozen=True)
+class WindmillMetadata:
+    run_id: str
+    job_id: str
+    workspace: str = "affordabot"
+    flow_path: str = "f/affordabot/pipeline_daily_refresh_domain_boundary__flow"
+
+
+@dataclass(frozen=True)
+class CommandEnvelope:
+    command: CommandName
+    jurisdiction_id: str
+    source_family: str
+    idempotency_key: str
+    windmill: WindmillMetadata
+    contract_version: str = CONTRACT_VERSION
+
+    def validate(self) -> None:
+        if self.contract_version != CONTRACT_VERSION:
+            raise ValueError(
+                f"contract_version mismatch: expected {CONTRACT_VERSION}, got {self.contract_version}"
+            )
+        if not self.jurisdiction_id.strip():
+            raise ValueError("jurisdiction_id is required")
+        if not self.source_family.strip():
+            raise ValueError("source_family is required")
+        if not self.idempotency_key.strip():
+            raise ValueError("idempotency_key is required")
+
+
+@dataclass
+class CommandResponse:
+    command: CommandName
+    status: StatusName
+    decision_reason: str
+    retry_class: RetryClass
+    alerts: list[str] = field(default_factory=list)
+    counts: dict[str, int] = field(default_factory=dict)
+    refs: dict[str, Any] = field(default_factory=dict)
+    details: dict[str, Any] = field(default_factory=dict)
+    contract_version: str = CONTRACT_VERSION
+    created_at: datetime = field(default_factory=utc_now)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "contract_version": self.contract_version,
+            "command": self.command,
+            "status": self.status,
+            "decision_reason": self.decision_reason,
+            "retry_class": self.retry_class,
+            "alerts": self.alerts,
+            "counts": self.counts,
+            "refs": self.refs,
+            "details": self.details,
+            "created_at": self.created_at.isoformat(),
+        }
+
+
+@dataclass(frozen=True)
+class FreshnessPolicy:
+    fresh_hours: int
+    stale_usable_ceiling_hours: int
+    fail_closed_ceiling_hours: int
+

--- a/backend/services/pipeline/domain/ports.py
+++ b/backend/services/pipeline/domain/ports.py
@@ -70,4 +70,3 @@ class Analyzer(Protocol):
         self, *, question: str, evidence_chunks: list[dict[str, Any]]
     ) -> dict[str, Any]:
         ...
-

--- a/backend/services/pipeline/domain/ports.py
+++ b/backend/services/pipeline/domain/ports.py
@@ -1,0 +1,73 @@
+"""Ports for domain command dependencies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True)
+class SearchResultItem:
+    url: str
+    title: str
+    snippet: str
+
+
+class SearchProvider(Protocol):
+    def search(
+        self, *, query: str, jurisdiction_id: str, source_family: str, max_results: int
+    ) -> list[SearchResultItem]:
+        ...
+
+
+@dataclass(frozen=True)
+class ReaderDocument:
+    url: str
+    title: str
+    text: str
+    fetched_at: datetime
+    media_type: str = "text/markdown"
+    document_type: str = "meeting_minutes"
+    published_date: str | None = None
+
+
+class ReaderProvider(Protocol):
+    def fetch(self, *, url: str) -> ReaderDocument:
+        ...
+
+
+@dataclass(frozen=True)
+class ArtifactRecord:
+    artifact_ref: str
+    content_hash: str
+    media_type: str
+    size_bytes: int
+    kind: str
+
+
+class ArtifactStore(Protocol):
+    def put(
+        self,
+        *,
+        contract_version: str,
+        jurisdiction_id: str,
+        source_family: str,
+        artifact_kind: str,
+        body: str,
+        media_type: str,
+    ) -> ArtifactRecord:
+        ...
+
+
+class VectorStore(Protocol):
+    def upsert_chunks(self, chunks: list[dict[str, Any]]) -> int:
+        ...
+
+
+class Analyzer(Protocol):
+    def analyze(
+        self, *, question: str, evidence_chunks: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        ...
+

--- a/backend/services/pipeline/domain/storage.py
+++ b/backend/services/pipeline/domain/storage.py
@@ -1,0 +1,426 @@
+"""Storage adapters and recovery coordinator for pipeline domain writes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import hashlib
+from typing import Protocol
+
+from services.pipeline.domain.constants import CONTRACT_VERSION
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _artifact_extension(media_type: str) -> str:
+    if media_type == "application/json":
+        return "json"
+    if media_type == "text/html":
+        return "html"
+    if media_type == "application/pdf":
+        return "pdf"
+    return "md"
+
+
+def build_artifact_object_key(
+    *,
+    contract_version: str,
+    jurisdiction_id: str,
+    source_family: str,
+    artifact_kind: str,
+    content_hash: str,
+    media_type: str,
+) -> str:
+    ext = _artifact_extension(media_type)
+    return (
+        f"artifacts/{contract_version}/{jurisdiction_id}/{source_family}/"
+        f"{artifact_kind}/{content_hash}.{ext}"
+    )
+
+
+def build_deterministic_chunk_id(
+    *,
+    canonical_document_key: str,
+    content_hash: str,
+    chunk_index: int,
+    chunk_text: str,
+) -> str:
+    chunk_text_hash = sha256_text(chunk_text)
+    material = (
+        f"{CONTRACT_VERSION}|{canonical_document_key}|{content_hash}|{chunk_index}|{chunk_text_hash}"
+    )
+    return f"chunk_{sha256_text(material)}"
+
+
+def chunk_markdown_lines(markdown_text: str) -> list[str]:
+    return [line.strip() for line in markdown_text.splitlines() if line.strip()]
+
+
+@dataclass(frozen=True)
+class ArtifactRef:
+    artifact_ref: str
+    content_hash: str
+    media_type: str
+    size_bytes: int
+    artifact_kind: str
+
+
+@dataclass(frozen=True)
+class RawScrapeRef:
+    raw_scrape_id: str
+    canonical_document_key: str
+    content_hash: str
+    artifact_ref: str
+    processed: bool
+    chunk_count: int
+
+
+@dataclass(frozen=True)
+class ChunkRecord:
+    chunk_id: str
+    raw_scrape_id: str
+    canonical_document_key: str
+    content_hash: str
+    artifact_ref: str
+    chunk_index: int
+    text: str
+    jurisdiction_id: str
+    source_family: str
+
+
+@dataclass(frozen=True)
+class IndexMaterializationResult:
+    idempotency_key: str
+    raw_scrape_id: str
+    artifact_ref: str
+    chunk_ids: list[str]
+    chunk_count: int
+    reused_raw_scrape: bool
+    reused_artifact: bool
+    idempotent_reuse: bool = False
+
+
+class PipelineStateStore(Protocol):
+    def get_index_command_result(
+        self, *, idempotency_key: str
+    ) -> IndexMaterializationResult | None:
+        ...
+
+    def put_index_command_result(self, *, result: IndexMaterializationResult) -> None:
+        ...
+
+    def find_content_artifact(
+        self,
+        *,
+        jurisdiction_id: str,
+        source_family: str,
+        artifact_kind: str,
+        content_hash: str,
+    ) -> ArtifactRef | None:
+        ...
+
+    def upsert_content_artifact(
+        self,
+        *,
+        jurisdiction_id: str,
+        source_family: str,
+        artifact_kind: str,
+        content_hash: str,
+        artifact_ref: str,
+        media_type: str,
+        size_bytes: int,
+        contract_version: str,
+    ) -> ArtifactRef:
+        ...
+
+    def get_or_create_raw_scrape(
+        self,
+        *,
+        canonical_document_key: str,
+        content_hash: str,
+        artifact_ref: str,
+        jurisdiction_id: str,
+        source_family: str,
+        markdown_body: str,
+    ) -> tuple[RawScrapeRef, bool]:
+        ...
+
+    def mark_raw_scrape_retrievable(self, *, raw_scrape_id: str, chunk_count: int) -> None:
+        ...
+
+
+class ArtifactBlobStore(Protocol):
+    def put_if_absent(
+        self, *, object_key: str, body: bytes, media_type: str
+    ) -> str:
+        ...
+
+
+class ChunkVectorStore(Protocol):
+    def upsert_chunks(self, *, chunks: list[ChunkRecord]) -> int:
+        ...
+
+    def count_chunks_for_raw_scrape(self, *, raw_scrape_id: str) -> int:
+        ...
+
+
+class PipelineStorageCoordinator:
+    """Coordinates Postgres/MinIO/pgvector writes with rerun-safe behavior."""
+
+    def __init__(
+        self,
+        *,
+        state_store: PipelineStateStore,
+        blob_store: ArtifactBlobStore,
+        vector_store: ChunkVectorStore,
+    ) -> None:
+        self.state_store = state_store
+        self.blob_store = blob_store
+        self.vector_store = vector_store
+
+    def index_reader_document(
+        self,
+        *,
+        idempotency_key: str,
+        jurisdiction_id: str,
+        source_family: str,
+        canonical_document_key: str,
+        markdown_body: str,
+        media_type: str = "text/markdown",
+        artifact_kind: str = "reader_output",
+    ) -> IndexMaterializationResult:
+        cached = self.state_store.get_index_command_result(idempotency_key=idempotency_key)
+        if cached:
+            return replace(cached, idempotent_reuse=True)
+
+        content_hash = sha256_text(markdown_body)
+        size_bytes = len(markdown_body.encode("utf-8"))
+
+        artifact = self.state_store.find_content_artifact(
+            jurisdiction_id=jurisdiction_id,
+            source_family=source_family,
+            artifact_kind=artifact_kind,
+            content_hash=content_hash,
+        )
+        reused_artifact = artifact is not None
+
+        if artifact is None:
+            object_key = build_artifact_object_key(
+                contract_version=CONTRACT_VERSION,
+                jurisdiction_id=jurisdiction_id,
+                source_family=source_family,
+                artifact_kind=artifact_kind,
+                content_hash=content_hash,
+                media_type=media_type,
+            )
+            artifact_ref = self.blob_store.put_if_absent(
+                object_key=object_key,
+                body=markdown_body.encode("utf-8"),
+                media_type=media_type,
+            )
+            artifact = self.state_store.upsert_content_artifact(
+                jurisdiction_id=jurisdiction_id,
+                source_family=source_family,
+                artifact_kind=artifact_kind,
+                content_hash=content_hash,
+                artifact_ref=artifact_ref,
+                media_type=media_type,
+                size_bytes=size_bytes,
+                contract_version=CONTRACT_VERSION,
+            )
+
+        raw_scrape, reused_raw_scrape = self.state_store.get_or_create_raw_scrape(
+            canonical_document_key=canonical_document_key,
+            content_hash=content_hash,
+            artifact_ref=artifact.artifact_ref,
+            jurisdiction_id=jurisdiction_id,
+            source_family=source_family,
+            markdown_body=markdown_body,
+        )
+
+        chunks = [
+            ChunkRecord(
+                chunk_id=build_deterministic_chunk_id(
+                    canonical_document_key=canonical_document_key,
+                    content_hash=content_hash,
+                    chunk_index=idx,
+                    chunk_text=text,
+                ),
+                raw_scrape_id=raw_scrape.raw_scrape_id,
+                canonical_document_key=canonical_document_key,
+                content_hash=content_hash,
+                artifact_ref=artifact.artifact_ref,
+                chunk_index=idx,
+                text=text,
+                jurisdiction_id=jurisdiction_id,
+                source_family=source_family,
+            )
+            for idx, text in enumerate(chunk_markdown_lines(markdown_body))
+        ]
+
+        if chunks:
+            self.vector_store.upsert_chunks(chunks=chunks)
+
+        chunk_count = self.vector_store.count_chunks_for_raw_scrape(
+            raw_scrape_id=raw_scrape.raw_scrape_id
+        )
+        if not raw_scrape.processed and chunk_count > 0:
+            self.state_store.mark_raw_scrape_retrievable(
+                raw_scrape_id=raw_scrape.raw_scrape_id,
+                chunk_count=chunk_count,
+            )
+
+        result = IndexMaterializationResult(
+            idempotency_key=idempotency_key,
+            raw_scrape_id=raw_scrape.raw_scrape_id,
+            artifact_ref=artifact.artifact_ref,
+            chunk_ids=[chunk.chunk_id for chunk in chunks],
+            chunk_count=chunk_count,
+            reused_raw_scrape=reused_raw_scrape,
+            reused_artifact=reused_artifact,
+        )
+        self.state_store.put_index_command_result(result=result)
+        return result
+
+
+class InMemoryPipelineStateStore(PipelineStateStore):
+    """Deterministic state store for unit tests."""
+
+    def __init__(self) -> None:
+        self.command_results: dict[str, IndexMaterializationResult] = {}
+        self.artifacts: dict[tuple[str, str, str, str], ArtifactRef] = {}
+        self.raw_scrapes: dict[tuple[str, str], RawScrapeRef] = {}
+        self.raw_scrape_payloads: dict[str, str] = {}
+        self.fail_upsert_artifact_once = False
+        self.fail_mark_processed_once = False
+        self._raw_counter = 0
+
+    def get_index_command_result(
+        self, *, idempotency_key: str
+    ) -> IndexMaterializationResult | None:
+        return self.command_results.get(idempotency_key)
+
+    def put_index_command_result(self, *, result: IndexMaterializationResult) -> None:
+        self.command_results[result.idempotency_key] = result
+
+    def find_content_artifact(
+        self,
+        *,
+        jurisdiction_id: str,
+        source_family: str,
+        artifact_kind: str,
+        content_hash: str,
+    ) -> ArtifactRef | None:
+        key = (jurisdiction_id, source_family, artifact_kind, content_hash)
+        return self.artifacts.get(key)
+
+    def upsert_content_artifact(
+        self,
+        *,
+        jurisdiction_id: str,
+        source_family: str,
+        artifact_kind: str,
+        content_hash: str,
+        artifact_ref: str,
+        media_type: str,
+        size_bytes: int,
+        contract_version: str,
+    ) -> ArtifactRef:
+        _ = contract_version
+        if self.fail_upsert_artifact_once:
+            self.fail_upsert_artifact_once = False
+            raise RuntimeError("artifact_row_write_failed")
+        key = (jurisdiction_id, source_family, artifact_kind, content_hash)
+        existing = self.artifacts.get(key)
+        if existing:
+            return existing
+        row = ArtifactRef(
+            artifact_ref=artifact_ref,
+            content_hash=content_hash,
+            media_type=media_type,
+            size_bytes=size_bytes,
+            artifact_kind=artifact_kind,
+        )
+        self.artifacts[key] = row
+        return row
+
+    def get_or_create_raw_scrape(
+        self,
+        *,
+        canonical_document_key: str,
+        content_hash: str,
+        artifact_ref: str,
+        jurisdiction_id: str,
+        source_family: str,
+        markdown_body: str,
+    ) -> tuple[RawScrapeRef, bool]:
+        key = (canonical_document_key, content_hash)
+        existing = self.raw_scrapes.get(key)
+        if existing:
+            return existing, True
+
+        _ = (jurisdiction_id, source_family)
+        self._raw_counter += 1
+        raw_id = f"raw_{self._raw_counter:04d}"
+        row = RawScrapeRef(
+            raw_scrape_id=raw_id,
+            canonical_document_key=canonical_document_key,
+            content_hash=content_hash,
+            artifact_ref=artifact_ref,
+            processed=False,
+            chunk_count=0,
+        )
+        self.raw_scrapes[key] = row
+        self.raw_scrape_payloads[raw_id] = markdown_body
+        return row, False
+
+    def mark_raw_scrape_retrievable(self, *, raw_scrape_id: str, chunk_count: int) -> None:
+        if self.fail_mark_processed_once:
+            self.fail_mark_processed_once = False
+            raise RuntimeError("mark_processed_failed")
+        for key, row in self.raw_scrapes.items():
+            if row.raw_scrape_id == raw_scrape_id:
+                self.raw_scrapes[key] = RawScrapeRef(
+                    raw_scrape_id=row.raw_scrape_id,
+                    canonical_document_key=row.canonical_document_key,
+                    content_hash=row.content_hash,
+                    artifact_ref=row.artifact_ref,
+                    processed=True,
+                    chunk_count=chunk_count,
+                )
+                return
+        raise KeyError(f"raw scrape not found: {raw_scrape_id}")
+
+
+class InMemoryArtifactBlobStore(ArtifactBlobStore):
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+        self.put_calls = 0
+
+    def put_if_absent(
+        self, *, object_key: str, body: bytes, media_type: str
+    ) -> str:
+        _ = media_type
+        self.put_calls += 1
+        self.objects.setdefault(object_key, body)
+        return object_key
+
+
+class InMemoryChunkVectorStore(ChunkVectorStore):
+    def __init__(self) -> None:
+        self.chunks_by_id: dict[str, ChunkRecord] = {}
+        self.fail_upsert_once = False
+
+    def upsert_chunks(self, *, chunks: list[ChunkRecord]) -> int:
+        if self.fail_upsert_once:
+            self.fail_upsert_once = False
+            raise RuntimeError("vector_upsert_failed")
+        for chunk in chunks:
+            self.chunks_by_id[chunk.chunk_id] = chunk
+        return len(chunks)
+
+    def count_chunks_for_raw_scrape(self, *, raw_scrape_id: str) -> int:
+        return sum(
+            1 for chunk in self.chunks_by_id.values() if chunk.raw_scrape_id == raw_scrape_id
+        )

--- a/backend/tests/ops/test_pipeline_daily_refresh_domain_boundary_orchestration.py
+++ b/backend/tests/ops/test_pipeline_daily_refresh_domain_boundary_orchestration.py
@@ -1,0 +1,133 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+WINDMILL_DIR = ROOT / "ops" / "windmill" / "f" / "affordabot"
+SCRIPT_PATH = WINDMILL_DIR / "pipeline_daily_refresh_domain_boundary.py"
+FLOW_PATH = WINDMILL_DIR / "pipeline_daily_refresh_domain_boundary__flow" / "flow.yaml"
+
+
+spec = spec_from_file_location("windmill_domain_boundary", SCRIPT_PATH)
+module = module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+
+def test_scope_pipeline_happy_path_passes_windmill_envelope_between_steps():
+    result = module.main(
+        step="run_scope_pipeline",
+        idempotency_key="run:2026-04-13",
+        scope_item={"jurisdiction": "San Jose CA", "source_family": "meeting_minutes"},
+        scope_index=0,
+        stale_status="fresh",
+        search_query="San Jose housing minutes",
+        analysis_question="Summarize housing items",
+    )
+
+    assert result["status"] == "succeeded"
+    assert set(result["steps"].keys()) == {
+        "search_materialize",
+        "freshness_gate",
+        "read_fetch",
+        "index",
+        "analyze",
+        "summarize_run",
+    }
+    for step_name, payload in result["steps"].items():
+        assert payload["envelope"]["orchestrator"] == "windmill"
+        assert payload["envelope"]["windmill_workspace"] == "affordabot"
+        assert payload["envelope"]["windmill_step_id"] == step_name
+        assert payload["invoked_command"] in {
+            "search_materialize",
+            "freshness_gate",
+            "read_fetch",
+            "index",
+            "analyze",
+            "summarize_run",
+        }
+
+
+def test_scope_pipeline_stale_blocked_short_circuits_to_summary():
+    result = module.main(
+        step="run_scope_pipeline",
+        idempotency_key="run:2026-04-13",
+        scope_item={"jurisdiction": "San Jose CA", "source_family": "meeting_minutes"},
+        scope_index=0,
+        stale_status="stale_blocked",
+        search_query="San Jose housing minutes",
+        analysis_question="Summarize housing items",
+    )
+
+    assert result["status"] == "blocked"
+    assert "read_fetch" not in result["steps"]
+    assert "index" not in result["steps"]
+    assert "analyze" not in result["steps"]
+    assert result["steps"]["freshness_gate"]["status"] == "stale_blocked"
+    assert result["steps"]["summarize_run"]["status"] == "blocked"
+
+
+def test_run_summary_aggregates_fanout_scope_results():
+    scope_matrix = module.main(
+        step="build_scope_matrix",
+        jurisdictions=["San Jose CA", "Santa Clara County CA"],
+        source_families=["meeting_minutes"],
+    )
+    assert scope_matrix["scope_count"] == 2
+
+    first_scope = module.main(
+        step="run_scope_pipeline",
+        scope_item=scope_matrix["scope_items"][0],
+        scope_index=0,
+        stale_status="fresh",
+        search_query="query",
+        analysis_question="question",
+    )
+    second_scope = module.main(
+        step="run_scope_pipeline",
+        scope_item=scope_matrix["scope_items"][1],
+        scope_index=1,
+        stale_status="stale_blocked",
+        search_query="query",
+        analysis_question="question",
+    )
+
+    summary = module.main(
+        step="aggregate_run_summary",
+        scope_results=[first_scope, second_scope],
+    )
+
+    assert summary["scope_total"] == 2
+    assert summary["scope_succeeded"] == 1
+    assert summary["scope_blocked"] == 1
+    assert summary["scope_failed"] == 0
+    assert summary["status"] == "failed"
+    assert "freshness_gate:stale_blocked" in summary["alerts"]
+
+
+def test_windmill_assets_reference_coarse_command_stubs_not_storage_apis():
+    text = SCRIPT_PATH.read_text(encoding="utf-8") + "\n" + FLOW_PATH.read_text(encoding="utf-8")
+    forbidden_terms = [
+        "sqlalchemy",
+        "psycopg",
+        "postgres_client",
+        "local_pgvector",
+        "s3_storage",
+        "minio",
+        "insert into",
+    ]
+    for term in forbidden_terms:
+        assert term not in text.lower()
+
+    for required in [
+        "search_materialize",
+        "freshness_gate",
+        "read_fetch",
+        "index",
+        "analyze",
+        "summarize_run",
+        "forloopflow",
+        "branchone",
+        "failure_module",
+    ]:
+        assert required in text

--- a/backend/tests/ops/test_pipeline_daily_refresh_domain_boundary_orchestration.py
+++ b/backend/tests/ops/test_pipeline_daily_refresh_domain_boundary_orchestration.py
@@ -35,9 +35,12 @@ def test_scope_pipeline_happy_path_passes_windmill_envelope_between_steps():
         "summarize_run",
     }
     for step_name, payload in result["steps"].items():
+        assert payload["envelope"]["contract_version"] == "2026-04-13.windmill-domain.v1"
         assert payload["envelope"]["orchestrator"] == "windmill"
         assert payload["envelope"]["windmill_workspace"] == "affordabot"
         assert payload["envelope"]["windmill_step_id"] == step_name
+        assert payload["envelope"]["jurisdiction_id"] == "San Jose CA"
+        assert payload["envelope"]["jurisdiction_name"] == "San Jose CA"
         assert payload["invoked_command"] in {
             "search_materialize",
             "freshness_gate",

--- a/backend/tests/routers/test_admin_pipeline_read_model.py
+++ b/backend/tests/routers/test_admin_pipeline_read_model.py
@@ -154,18 +154,20 @@ def test_get_pipeline_run_steps_shape(client, mock_db):
             "id": "step-1",
             "run_id": "run-2",
             "step_name": "search_materialize",
+            "command": "search_materialize",
             "status": "succeeded",
             "duration_ms": 42,
-            "input_args": {"q": "san jose meeting minutes"},
+            "input_context": {"q": "san jose meeting minutes"},
             "output_result": {
                 "decision_reason": "fresh_snapshot_materialized",
                 "retry_class": "none",
-                "alerts": [],
                 "counts": {"search_results": 2},
-                "refs": {"search_snapshot_id": "snap-1"},
             },
-            "error": None,
-            "timestamp": "2026-04-13T02:00:10Z",
+            "decision_reason": "fresh_snapshot_materialized",
+            "retry_class": "none",
+            "alerts": [],
+            "refs": {"search_snapshot_id": "snap-1"},
+            "created_at": "2026-04-13T02:00:10Z",
         }
     ]
     client.set_auth("admin")

--- a/backend/tests/routers/test_admin_pipeline_read_model.py
+++ b/backend/tests/routers/test_admin_pipeline_read_model.py
@@ -1,0 +1,215 @@
+import os
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+import pytest
+
+from main import app
+from routers.admin import get_db
+from services.pipeline.domain.constants import CONTRACT_VERSION
+
+
+@pytest.fixture
+def mock_db():
+    db = AsyncMock()
+    db.connect = AsyncMock()
+    db.close = AsyncMock()
+    db._fetch = AsyncMock()
+    db._fetchrow = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def client(mock_db):
+    UNIT_TEST_SECRET = "unit-test-secret"
+
+    app.dependency_overrides[get_db] = lambda: mock_db
+
+    with patch("main.db", mock_db):
+        prev_env = os.environ.get("RAILWAY_ENVIRONMENT_NAME")
+        prev_secret = os.environ.get("TEST_AUTH_BYPASS_SECRET")
+        os.environ["RAILWAY_ENVIRONMENT_NAME"] = "dev"
+        os.environ["TEST_AUTH_BYPASS_SECRET"] = UNIT_TEST_SECRET
+        try:
+            with TestClient(app, base_url="http://localhost") as c:
+                def set_auth(role: str = "admin"):
+                    import base64
+                    import hashlib
+                    import hmac
+                    import json
+                    import time
+
+                    payload = {
+                        "sub": f"test_{role}",
+                        "role": role,
+                        "email": f"test_{role}@example.com",
+                        "exp": int(time.time()) + 3600,
+                    }
+                    payload_json = json.dumps(payload, separators=(",", ":"))
+                    payload_b64 = (
+                        base64.urlsafe_b64encode(payload_json.encode())
+                        .decode()
+                        .rstrip("=")
+                    )
+                    msg = f"v1.{payload_b64}"
+                    sig = hmac.new(
+                        UNIT_TEST_SECRET.encode(), msg.encode(), hashlib.sha256
+                    ).digest()
+                    sig_b64 = base64.urlsafe_b64encode(sig).decode().rstrip("=")
+                    token = f"{msg}.{sig_b64}"
+                    c.cookies.set("x-test-user", token)
+
+                c.set_auth = set_auth
+                yield c
+        finally:
+            if prev_env is None:
+                os.environ.pop("RAILWAY_ENVIRONMENT_NAME", None)
+            else:
+                os.environ["RAILWAY_ENVIRONMENT_NAME"] = prev_env
+            if prev_secret is None:
+                os.environ.pop("TEST_AUTH_BYPASS_SECRET", None)
+            else:
+                os.environ["TEST_AUTH_BYPASS_SECRET"] = prev_secret
+
+    app.dependency_overrides = {}
+
+
+def test_get_pipeline_jurisdiction_status_shape(client, mock_db):
+    mock_db._fetchrow.side_effect = [
+        {"id": "jur-1", "name": "San Jose CA", "type": "CITY"},
+        {
+            "id": "run-1",
+            "jurisdiction": "San Jose CA",
+            "status": "completed",
+            "started_at": "2026-04-13T01:00:00Z",
+            "completed_at": "2026-04-13T01:05:00Z",
+            "error": None,
+            "windmill_run_id": "wm-run-1",
+            "result": {
+                "freshness": {
+                    "status": "stale_but_usable",
+                    "alerts": ["source_search_failed_using_last_success"],
+                },
+                "search_results_count": 2,
+                "raw_scrapes_count": 1,
+                "artifact_count": 1,
+                "rag_chunks_retrieved": 4,
+                "analysis": {"summary": "ok"},
+                "validated_evidence_count": 4,
+                "sufficiency_state": "qualitative_only",
+                "alerts": ["source_search_failed_using_last_success"],
+            },
+        },
+        {"completed_at": "2026-04-13T01:05:00Z"},
+    ]
+    client.set_auth("admin")
+    response = client.get("/api/admin/pipeline/jurisdictions/jur-1/status")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["contract_version"] == CONTRACT_VERSION
+    assert data["jurisdiction_id"] == "jur-1"
+    assert data["source_family"] == "meeting_minutes"
+    assert data["pipeline_status"] == "stale_but_usable"
+    assert data["freshness"]["stale_usable_ceiling_hours"] == 72
+    assert data["counts"]["chunks"] == 4
+    assert data["latest_analysis"]["status"] == "ready"
+
+
+def test_get_pipeline_run_detail_shape(client, mock_db):
+    mock_db._fetchrow.return_value = {
+        "id": "run-2",
+        "bill_id": "SB-1",
+        "jurisdiction": "San Jose CA",
+        "status": "completed",
+        "started_at": "2026-04-13T02:00:00Z",
+        "completed_at": "2026-04-13T02:01:00Z",
+        "error": None,
+        "trigger_source": "windmill",
+        "windmill_workspace": "affordabot",
+        "windmill_run_id": "wm-run-2",
+        "source_family": "meeting_minutes",
+        "result": {
+            "search_results_count": 3,
+            "raw_scrapes_count": 2,
+            "artifact_count": 2,
+            "rag_chunks_retrieved": 5,
+            "analysis": {"summary": "ready"},
+            "validated_evidence_count": 5,
+        },
+    }
+    client.set_auth("admin")
+    response = client.get("/api/admin/pipeline/runs/run-2")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["contract_version"] == CONTRACT_VERSION
+    assert data["run_id"] == "run-2"
+    assert data["counts"]["search_results"] == 3
+    assert data["latest_analysis"]["evidence_count"] == 5
+    assert data["operator_links"]["windmill_run_url"].endswith("/wm-run-2")
+
+
+def test_get_pipeline_run_steps_shape(client, mock_db):
+    mock_db._fetch.return_value = [
+        {
+            "id": "step-1",
+            "run_id": "run-2",
+            "step_name": "search_materialize",
+            "status": "succeeded",
+            "duration_ms": 42,
+            "input_args": {"q": "san jose meeting minutes"},
+            "output_result": {
+                "decision_reason": "fresh_snapshot_materialized",
+                "retry_class": "none",
+                "alerts": [],
+                "counts": {"search_results": 2},
+                "refs": {"search_snapshot_id": "snap-1"},
+            },
+            "error": None,
+            "timestamp": "2026-04-13T02:00:10Z",
+        }
+    ]
+    client.set_auth("admin")
+    response = client.get("/api/admin/pipeline/runs/run-2/steps")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["contract_version"] == CONTRACT_VERSION
+    assert data["run_id"] == "run-2"
+    assert len(data["steps"]) == 1
+    assert data["steps"][0]["command"] == "search_materialize"
+    assert data["steps"][0]["refs"]["search_snapshot_id"] == "snap-1"
+
+
+def test_get_pipeline_run_evidence_shape(client, mock_db):
+    mock_db._fetchrow.return_value = {
+        "id": "run-3",
+        "result": {
+            "analysis": {
+                "citations": [
+                    {"type": "chunk", "label": "City Agenda Packet", "source_ref": "raw-1"}
+                ]
+            }
+        },
+    }
+    client.set_auth("admin")
+    response = client.get("/api/admin/pipeline/runs/run-3/evidence")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["contract_version"] == CONTRACT_VERSION
+    assert data["evidence_count"] == 1
+    assert data["items"][0]["label"] == "City Agenda Packet"
+
+
+def test_post_pipeline_jurisdiction_refresh_shape(client, mock_db):
+    mock_db._fetchrow.return_value = {
+        "id": "jur-7",
+        "name": "San Jose CA",
+        "type": "CITY",
+    }
+    client.set_auth("admin")
+    response = client.post("/api/admin/pipeline/jurisdictions/jur-7/refresh")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["contract_version"] == CONTRACT_VERSION
+    assert data["status"] == "accepted"
+    assert data["decision_reason"] == "manual_refresh_queued"
+    assert data["jurisdiction_id"] == "jur-7"

--- a/backend/tests/routers/test_admin_substrate_contract.py
+++ b/backend/tests/routers/test_admin_substrate_contract.py
@@ -15,6 +15,15 @@ def test_substrate_routes_exist_on_admin_router() -> None:
     assert '@router.get("/substrate/raw-scrapes/{raw_scrape_id}")' in source
 
 
+def test_pipeline_read_model_routes_exist_on_admin_router() -> None:
+    source = _admin_source()
+    assert '@router.get("/pipeline/jurisdictions/{jurisdiction_id}/status")' in source
+    assert '@router.get("/pipeline/runs/{run_id}")' in source
+    assert '@router.get("/pipeline/runs/{run_id}/steps")' in source
+    assert '@router.get("/pipeline/runs/{run_id}/evidence")' in source
+    assert '@router.post("/pipeline/jurisdictions/{jurisdiction_id}/refresh")' in source
+
+
 def test_substrate_run_query_uses_manual_run_stamp() -> None:
     source = _admin_source()
     assert "COALESCE(rs.metadata->>$1, '') AS run_id" in source

--- a/backend/tests/services/pipeline/test_domain_commands.py
+++ b/backend/tests/services/pipeline/test_domain_commands.py
@@ -149,8 +149,10 @@ def test_rerun_idempotency_keeps_counts_stable() -> None:
         policy=_default_policy(),
     )
     by_command = {item.command: item for item in second}
-    assert by_command["search_materialize"].status == "skipped"
-    assert by_command["index"].status == "skipped"
+    assert by_command["search_materialize"].status == "succeeded"
+    assert by_command["search_materialize"].details["idempotent_reuse"] is True
+    assert by_command["index"].status == "succeeded"
+    assert by_command["index"].details["idempotent_reuse"] is True
     assert len(state.chunks) == chunk_count
     assert first[-1].refs["run_id"] == second[-1].refs["run_id"]
 
@@ -303,4 +305,3 @@ def test_empty_blocked_flow_summarizes_and_stops() -> None:
     assert by_command["freshness_gate"].decision_reason == "empty_blocked"
     assert "read_fetch" not in by_command
     assert by_command["summarize_run"].status == "blocked"
-

--- a/backend/tests/services/pipeline/test_domain_commands.py
+++ b/backend/tests/services/pipeline/test_domain_commands.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from services.pipeline.domain import (
+    CommandEnvelope,
+    FreshnessPolicy,
+    InMemoryAnalyzer,
+    InMemoryArtifactStore,
+    InMemoryDomainState,
+    InMemoryReaderProvider,
+    InMemorySearchProvider,
+    InMemoryVectorStore,
+    PipelineDomainCommands,
+    SearchResultItem,
+    WindmillMetadata,
+    build_v2_canonical_document_key,
+)
+
+
+def _envelope(command: str, key: str) -> CommandEnvelope:
+    return CommandEnvelope(
+        command=command,  # type: ignore[arg-type]
+        jurisdiction_id="san-jose-ca",
+        source_family="meeting_minutes",
+        idempotency_key=key,
+        windmill=WindmillMetadata(run_id="wm-run-1", job_id="wm-job-1"),
+    )
+
+
+def _service(
+    *,
+    state: InMemoryDomainState | None = None,
+    search_results: list[SearchResultItem] | None = None,
+    search_fail: str | None = None,
+    reader_fail: str | None = None,
+    artifact_fail: str | None = None,
+    vector_fail: str | None = None,
+) -> tuple[InMemoryDomainState, PipelineDomainCommands]:
+    local_state = state or InMemoryDomainState()
+    service = PipelineDomainCommands(
+        state=local_state,
+        search_provider=InMemorySearchProvider(results=search_results, fail_mode=search_fail),
+        reader_provider=InMemoryReaderProvider(fail_mode=reader_fail),
+        artifact_store=InMemoryArtifactStore(local_state, fail_mode=artifact_fail),
+        vector_store=InMemoryVectorStore(local_state, fail_mode=vector_fail),
+        analyzer=InMemoryAnalyzer(),
+    )
+    return local_state, service
+
+
+def _default_policy() -> FreshnessPolicy:
+    return FreshnessPolicy(
+        fresh_hours=24,
+        stale_usable_ceiling_hours=72,
+        fail_closed_ceiling_hours=168,
+    )
+
+
+def test_v2_canonical_key_uses_jurisdiction_family_and_normalized_url() -> None:
+    key = build_v2_canonical_document_key(
+        jurisdiction_id="San Jose CA",
+        source_family="Meeting Minutes",
+        url="https://City.gov/Meetings/Agenda/?utm_source=email&b=2&a=1#download",
+        metadata={"document_type": "Agenda"},
+        data={},
+    )
+    assert key.startswith("v2|jurisdiction=san-jose-ca|family=meeting_minutes|doctype=agenda|url=")
+    assert "utm_source" not in key
+    assert "a=1&b=2" in key
+
+
+def test_v2_canonical_key_fallback_title_and_date() -> None:
+    key = build_v2_canonical_document_key(
+        jurisdiction_id="San Jose CA",
+        source_family="meeting_minutes",
+        url="unknown://jurisdiction/meetings/source-name",
+        metadata={"document_type": "minutes", "title": "City Council Minutes"},
+        data={"published_date": "2026-03-31T19:00:00Z"},
+    )
+    assert (
+        key
+        == "v2|jurisdiction=san-jose-ca|family=meeting_minutes|doctype=minutes|title=city council minutes|date=2026-03-31"
+    )
+
+
+def test_happy_path_full_refresh_and_summary() -> None:
+    state, service = _service(
+        search_results=[
+            SearchResultItem(
+                url="https://www.sanjoseca.gov/meeting-minutes/2026-04-10",
+                title="Meeting Minutes",
+                snippet="housing updates",
+            )
+        ]
+    )
+    responses = service.full_refresh(
+        query="san jose minutes housing",
+        question="What are the housing updates?",
+        search_envelope=_envelope("search_materialize", "k1"),
+        freshness_envelope=_envelope("freshness_gate", "k2"),
+        read_envelope=_envelope("read_fetch", "k3"),
+        index_envelope=_envelope("index", "k4"),
+        analyze_envelope=_envelope("analyze", "k5"),
+        summarize_envelope=_envelope("summarize_run", "k6"),
+        policy=_default_policy(),
+    )
+    by_command = {item.command: item for item in responses}
+    assert by_command["search_materialize"].status == "succeeded"
+    assert by_command["freshness_gate"].decision_reason == "fresh"
+    assert by_command["read_fetch"].status == "succeeded"
+    assert by_command["index"].counts["chunks"] > 0
+    assert by_command["analyze"].status == "succeeded"
+    assert by_command["summarize_run"].status == "succeeded"
+    assert len(state.chunks) == by_command["index"].counts["chunks"]
+
+
+def test_rerun_idempotency_keeps_counts_stable() -> None:
+    state, service = _service(
+        search_results=[
+            SearchResultItem(
+                url="https://www.sanjoseca.gov/meeting-minutes/2026-04-10",
+                title="Meeting Minutes",
+                snippet="housing updates",
+            )
+        ]
+    )
+    first = service.full_refresh(
+        query="san jose minutes housing",
+        question="What are the housing updates?",
+        search_envelope=_envelope("search_materialize", "r1"),
+        freshness_envelope=_envelope("freshness_gate", "r2"),
+        read_envelope=_envelope("read_fetch", "r3"),
+        index_envelope=_envelope("index", "r4"),
+        analyze_envelope=_envelope("analyze", "r5"),
+        summarize_envelope=_envelope("summarize_run", "r6"),
+        policy=_default_policy(),
+    )
+    chunk_count = len(state.chunks)
+    second = service.full_refresh(
+        query="san jose minutes housing",
+        question="What are the housing updates?",
+        search_envelope=_envelope("search_materialize", "r1"),
+        freshness_envelope=_envelope("freshness_gate", "r2"),
+        read_envelope=_envelope("read_fetch", "r3"),
+        index_envelope=_envelope("index", "r4"),
+        analyze_envelope=_envelope("analyze", "r5"),
+        summarize_envelope=_envelope("summarize_run", "r6"),
+        policy=_default_policy(),
+    )
+    by_command = {item.command: item for item in second}
+    assert by_command["search_materialize"].status == "skipped"
+    assert by_command["index"].status == "skipped"
+    assert len(state.chunks) == chunk_count
+    assert first[-1].refs["run_id"] == second[-1].refs["run_id"]
+
+
+def test_freshness_gate_stale_but_usable_alerts() -> None:
+    state, service = _service(
+        search_results=[
+            SearchResultItem(
+                url="https://www.sanjoseca.gov/minutes/stale",
+                title="Older Minutes",
+                snippet="older",
+            )
+        ]
+    )
+    search = service.search_materialize(envelope=_envelope("search_materialize", "s1"), query="q")
+    snapshot_id = str(search.refs["search_snapshot_id"])
+    # make snapshot stale but still under usable ceiling
+    stale_time = state.now - timedelta(hours=30)
+    state.search_snapshots[snapshot_id]["captured_at"] = stale_time.isoformat()
+    result = service.freshness_gate(
+        envelope=_envelope("freshness_gate", "s2"),
+        snapshot_id=snapshot_id,
+        policy=_default_policy(),
+        latest_success_at=state.now - timedelta(hours=10),
+    )
+    assert result.status == "succeeded_with_alerts"
+    assert result.decision_reason == "stale_but_usable"
+    assert "source_search_failed_using_last_success" in result.alerts
+
+
+def test_freshness_gate_stale_blocked() -> None:
+    state, service = _service(
+        search_results=[
+            SearchResultItem(
+                url="https://www.sanjoseca.gov/minutes/very-old",
+                title="Very Old Minutes",
+                snippet="older",
+            )
+        ]
+    )
+    search = service.search_materialize(envelope=_envelope("search_materialize", "sb1"), query="q")
+    snapshot_id = str(search.refs["search_snapshot_id"])
+    state.search_snapshots[snapshot_id]["captured_at"] = (
+        state.now - timedelta(hours=90)
+    ).isoformat()
+    result = service.freshness_gate(
+        envelope=_envelope("freshness_gate", "sb2"),
+        snapshot_id=snapshot_id,
+        policy=_default_policy(),
+        latest_success_at=state.now - timedelta(hours=10),
+    )
+    assert result.status == "blocked"
+    assert result.decision_reason == "stale_blocked"
+    assert result.retry_class == "operator_required"
+
+
+def test_empty_results_uses_empty_but_usable_with_recent_success() -> None:
+    state, service = _service(search_results=[])
+    search = service.search_materialize(envelope=_envelope("search_materialize", "e1"), query="q")
+    snapshot_id = str(search.refs["search_snapshot_id"])
+    result = service.freshness_gate(
+        envelope=_envelope("freshness_gate", "e2"),
+        snapshot_id=snapshot_id,
+        policy=_default_policy(),
+        latest_success_at=state.now - timedelta(hours=6),
+    )
+    assert search.status == "succeeded_with_alerts"
+    assert result.status == "succeeded_with_alerts"
+    assert result.decision_reason == "empty_but_usable"
+
+
+def test_source_failure_returns_retryable_transport() -> None:
+    _, service = _service(search_fail="simulated_transport_error")
+    result = service.search_materialize(
+        envelope=_envelope("search_materialize", "f1"),
+        query="q",
+    )
+    assert result.status == "failed_retryable"
+    assert result.retry_class == "transport"
+
+
+def test_reader_failure_stops_before_index() -> None:
+    state, service = _service(
+        search_results=[
+            SearchResultItem(
+                url="https://www.sanjoseca.gov/minutes/reader-error",
+                title="Minutes",
+                snippet="x",
+            )
+        ],
+        reader_fail="reader_unavailable",
+    )
+    search = service.search_materialize(envelope=_envelope("search_materialize", "rf1"), query="q")
+    read = service.read_fetch(
+        envelope=_envelope("read_fetch", "rf2"),
+        snapshot_id=str(search.refs["search_snapshot_id"]),
+    )
+    assert read.status == "failed_retryable"
+    assert read.retry_class == "provider_unavailable"
+    assert len(state.raw_scrapes) == 0
+
+
+def test_storage_failure_on_reader_artifact_is_terminal() -> None:
+    _, service = _service(
+        search_results=[
+            SearchResultItem(
+                url="https://www.sanjoseca.gov/minutes/storage-error",
+                title="Minutes",
+                snippet="x",
+            )
+        ],
+        artifact_fail="artifact_store_down",
+    )
+    search = service.search_materialize(envelope=_envelope("search_materialize", "sf1"), query="q")
+    read = service.read_fetch(
+        envelope=_envelope("read_fetch", "sf2"),
+        snapshot_id=str(search.refs["search_snapshot_id"]),
+    )
+    assert read.status == "failed_terminal"
+    assert read.retry_class == "transient_storage"
+
+
+def test_no_analysis_without_evidence_is_blocked() -> None:
+    _, service = _service()
+    result = service.analyze(
+        envelope=_envelope("analyze", "na1"),
+        question="What changed?",
+        jurisdiction_id="san-jose-ca",
+        source_family="meeting_minutes",
+    )
+    assert result.status == "blocked"
+    assert result.retry_class == "insufficient_evidence"
+
+
+def test_empty_blocked_flow_summarizes_and_stops() -> None:
+    state, service = _service(search_results=[])
+    state.now = datetime(2026, 4, 13, tzinfo=timezone.utc)
+    responses = service.full_refresh(
+        query="q",
+        question="What changed?",
+        search_envelope=_envelope("search_materialize", "b1"),
+        freshness_envelope=_envelope("freshness_gate", "b2"),
+        read_envelope=_envelope("read_fetch", "b3"),
+        index_envelope=_envelope("index", "b4"),
+        analyze_envelope=_envelope("analyze", "b5"),
+        summarize_envelope=_envelope("summarize_run", "b6"),
+        policy=_default_policy(),
+    )
+    by_command = {item.command: item for item in responses}
+    assert by_command["freshness_gate"].decision_reason == "empty_blocked"
+    assert "read_fetch" not in by_command
+    assert by_command["summarize_run"].status == "blocked"
+

--- a/backend/tests/services/pipeline/test_storage_recovery.py
+++ b/backend/tests/services/pipeline/test_storage_recovery.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import pytest
+
+from services.pipeline.domain.storage import (
+    InMemoryArtifactBlobStore,
+    InMemoryChunkVectorStore,
+    InMemoryPipelineStateStore,
+    PipelineStorageCoordinator,
+    build_artifact_object_key,
+    sha256_text,
+)
+
+
+def _coordinator(
+    *,
+    state: InMemoryPipelineStateStore | None = None,
+    blob: InMemoryArtifactBlobStore | None = None,
+    vector: InMemoryChunkVectorStore | None = None,
+) -> tuple[
+    InMemoryPipelineStateStore,
+    InMemoryArtifactBlobStore,
+    InMemoryChunkVectorStore,
+    PipelineStorageCoordinator,
+]:
+    local_state = state or InMemoryPipelineStateStore()
+    local_blob = blob or InMemoryArtifactBlobStore()
+    local_vector = vector or InMemoryChunkVectorStore()
+    service = PipelineStorageCoordinator(
+        state_store=local_state,
+        blob_store=local_blob,
+        vector_store=local_vector,
+    )
+    return local_state, local_blob, local_vector, service
+
+
+def _index_once(service: PipelineStorageCoordinator, *, key: str):
+    return service.index_reader_document(
+        idempotency_key=key,
+        jurisdiction_id="san-jose-ca",
+        source_family="meeting_minutes",
+        canonical_document_key=(
+            "v2|jurisdiction=san-jose-ca|family=meeting_minutes|doctype=meeting_minutes|"
+            "url=https://www.sanjoseca.gov/minutes/2026-04-10"
+        ),
+        markdown_body=(
+            "# Meeting Minutes\n"
+            "Housing permit processing timelines discussed.\n"
+            "Fee schedule hearing moved.\n"
+            "Public comments on affordable housing expansion.\n"
+        ),
+    )
+
+
+def test_recover_when_blob_exists_but_artifact_row_missing() -> None:
+    state, blob, _, service = _coordinator()
+    state.fail_upsert_artifact_once = True
+
+    with pytest.raises(RuntimeError, match="artifact_row_write_failed"):
+        _index_once(service, key="k-artifact-first")
+
+    expected_key = build_artifact_object_key(
+        contract_version="2026-04-13.windmill-domain.v1",
+        jurisdiction_id="san-jose-ca",
+        source_family="meeting_minutes",
+        artifact_kind="reader_output",
+        content_hash=sha256_text(
+            "# Meeting Minutes\n"
+            "Housing permit processing timelines discussed.\n"
+            "Fee schedule hearing moved.\n"
+            "Public comments on affordable housing expansion.\n"
+        ),
+        media_type="text/markdown",
+    )
+    assert expected_key in blob.objects
+    assert len(state.artifacts) == 0
+
+    result = _index_once(service, key="k-artifact-retry")
+    assert result.chunk_count == 4
+    assert result.reused_artifact is False
+    assert len(state.artifacts) == 1
+    assert result.artifact_ref == expected_key
+
+
+def test_recover_when_raw_exists_and_vector_write_failed() -> None:
+    state, _, vector, service = _coordinator()
+    vector.fail_upsert_once = True
+
+    with pytest.raises(RuntimeError, match="vector_upsert_failed"):
+        _index_once(service, key="k-vector-first")
+
+    assert len(state.raw_scrapes) == 1
+    raw_row = next(iter(state.raw_scrapes.values()))
+    assert raw_row.processed is False
+    assert raw_row.chunk_count == 0
+
+    retry = _index_once(service, key="k-vector-retry")
+    assert retry.reused_raw_scrape is True
+    assert retry.chunk_count == 4
+    assert len(vector.chunks_by_id) == 4
+
+
+def test_recover_when_vectors_written_but_raw_not_marked_processed() -> None:
+    state, _, vector, service = _coordinator()
+    state.fail_mark_processed_once = True
+
+    with pytest.raises(RuntimeError, match="mark_processed_failed"):
+        _index_once(service, key="k-mark-first")
+
+    assert len(vector.chunks_by_id) == 4
+    raw_row = next(iter(state.raw_scrapes.values()))
+    assert raw_row.processed is False
+
+    retry = _index_once(service, key="k-mark-retry")
+    assert retry.reused_raw_scrape is True
+    raw_row_after = next(iter(state.raw_scrapes.values()))
+    assert raw_row_after.processed is True
+    assert raw_row_after.chunk_count == 4
+
+
+def test_idempotent_rerun_returns_same_refs_without_duplication() -> None:
+    state, blob, vector, service = _coordinator()
+
+    first = _index_once(service, key="k-idempotent")
+    second = _index_once(service, key="k-idempotent")
+
+    assert second.idempotent_reuse is True
+    assert second.raw_scrape_id == first.raw_scrape_id
+    assert second.artifact_ref == first.artifact_ref
+    assert second.chunk_ids == first.chunk_ids
+    assert len(state.raw_scrapes) == 1
+    assert len(state.artifacts) == 1
+    assert len(vector.chunks_by_id) == 4
+    assert len(blob.objects) == 1

--- a/backend/tests/verification/test_windmill_bakeoff_direct_storage.py
+++ b/backend/tests/verification/test_windmill_bakeoff_direct_storage.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_module():
+    repo_root = Path(__file__).resolve().parents[3]
+    script_path = (
+        repo_root
+        / "backend"
+        / "scripts"
+        / "verification"
+        / "windmill_bakeoff_direct_storage.py"
+    )
+    spec = importlib.util.spec_from_file_location("windmill_bakeoff_direct_storage", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load windmill_bakeoff_direct_storage module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_idempotent_rerun_no_duplicate_documents_or_chunks(tmp_path):
+    module = _load_module()
+    runner = module.DirectStoragePipelineRunner(state_dir=tmp_path)
+    run_date = "2026-04-12"
+
+    first = runner.run(run_date=run_date, scenario="normal")
+    second = runner.run(run_date=run_date, scenario="normal")
+
+    assert first["status"] == module.STATUS_SUCCEEDED
+    assert second["status"] == module.STATUS_SUCCEEDED
+    assert first["counts"]["documents_total"] == second["counts"]["documents_total"]
+    assert first["counts"]["chunks_total"] == second["counts"]["chunks_total"]
+    assert first["counts"]["analyses_total"] == second["counts"]["analyses_total"]
+
+
+def test_failure_drill_statuses(tmp_path):
+    module = _load_module()
+    runner = module.DirectStoragePipelineRunner(state_dir=tmp_path)
+    run_date = "2026-04-12"
+
+    searx = runner.run(run_date=run_date, scenario="searx_failure")
+    reader = runner.run(run_date=run_date, scenario="reader_failure")
+    storage = runner.run(run_date=run_date, scenario="storage_failure")
+
+    assert searx["status"] == module.STATUS_SOURCE_ERROR
+    assert reader["status"] == module.STATUS_READER_ERROR
+    assert storage["status"] == module.STATUS_STORAGE_ERROR

--- a/backend/tests/verification/test_windmill_bakeoff_direct_storage.py
+++ b/backend/tests/verification/test_windmill_bakeoff_direct_storage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 
@@ -17,6 +18,7 @@ def _load_module():
     if spec is None or spec.loader is None:
         raise RuntimeError("failed to load windmill_bakeoff_direct_storage module")
     module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
 

--- a/backend/tests/verification/test_windmill_bakeoff_direct_storage.py
+++ b/backend/tests/verification/test_windmill_bakeoff_direct_storage.py
@@ -48,3 +48,27 @@ def test_failure_drill_statuses(tmp_path):
     assert searx["status"] == module.STATUS_SOURCE_ERROR
     assert reader["status"] == module.STATUS_READER_ERROR
     assert storage["status"] == module.STATUS_STORAGE_ERROR
+
+
+def test_stale_gate_statuses(tmp_path):
+    module = _load_module()
+    runner = module.DirectStoragePipelineRunner(state_dir=tmp_path)
+    run_date = "2026-04-12"
+
+    baseline = runner.run(run_date=run_date, scenario="normal")
+    stale_usable = runner.run(run_date=run_date, scenario="normal", force_stale_hours=36)
+    stale_blocked = runner.run(run_date=run_date, scenario="normal", force_stale_hours=96)
+
+    assert baseline["status"] == module.STATUS_SUCCEEDED
+    assert stale_usable["status"] == module.STATUS_SUCCEEDED
+    assert "stale_backed=true" in stale_usable.get("alerts", [])
+    freshness_step_usable = next(
+        step for step in stale_usable["steps"] if step["step"] == "freshness_gate"
+    )
+    assert freshness_step_usable["status"] == module.STATUS_STALE_USABLE
+
+    assert stale_blocked["status"] == module.STATUS_STALE_BLOCKED
+    freshness_step_blocked = next(
+        step for step in stale_blocked["steps"] if step["step"] == "freshness_gate"
+    )
+    assert freshness_step_blocked["status"] == module.STATUS_STALE_BLOCKED

--- a/backend/tests/verification/test_windmill_bakeoff_domain_boundary.py
+++ b/backend/tests/verification/test_windmill_bakeoff_domain_boundary.py
@@ -1,0 +1,74 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = ROOT / "backend" / "scripts" / "verification" / "windmill_bakeoff_domain_boundary.py"
+
+spec = spec_from_file_location("windmill_bakeoff_domain_boundary", SCRIPT_PATH)
+module = module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+
+class TestWindmillBakeoffDomainBoundary(unittest.TestCase):
+    def test_happy_rerun_is_idempotent_for_chunks_and_analysis(self):
+        result = module.run_scenario("happy_rerun")
+        first = result["first_run"]
+        rerun = result["rerun"]
+
+        self.assertEqual(first["status"], "succeeded")
+        self.assertEqual(rerun["status"], "succeeded")
+
+        self.assertGreater(first["step_results"]["index"]["chunks_created"], 0)
+        self.assertEqual(rerun["step_results"]["index"]["chunks_created"], 0)
+
+        self.assertEqual(
+            first["step_results"]["read_fetch"]["canonical_document_key"],
+            rerun["step_results"]["read_fetch"]["canonical_document_key"],
+        )
+        self.assertEqual(
+            first["step_results"]["analyze"]["analysis_id"],
+            rerun["step_results"]["analyze"]["analysis_id"],
+        )
+        self.assertIs(rerun["step_results"]["analyze"]["reused"], True)
+
+    def test_analysis_fails_closed_without_evidence(self):
+        store = module.InMemoryDomainStore()
+        domain = module.DomainBoundaryService(
+            store=store,
+            search_client=module.SearxLikeClient(fail_mode=False),
+            reader_client=module.ReaderContractClient(fail_mode=False),
+            vector_adapter=module.VectorAdapter(),
+            analysis_adapter=module.AnalysisAdapter(),
+        )
+        env = module.Envelope(
+            architecture_path="affordabot_domain_boundary",
+            windmill_run_id="run-fail-closed",
+            windmill_job_id="job-analyze",
+            idempotency_key="san-jose-ca:meeting_minutes:2026-04-12",
+            jurisdiction="San Jose CA",
+            source_family="meeting_minutes",
+        )
+
+        result = domain.analyze(env, "Any question")
+        self.assertEqual(result["status"], "analysis_error")
+        self.assertEqual(result["error"], "insufficient_evidence")
+
+    def test_stale_gate_statuses_are_emitted(self):
+        stale_usable = module.run_scenario("stale_usable")
+        stale_blocked = module.run_scenario("stale_blocked")
+
+        self.assertEqual(stale_usable["step_results"]["freshness_gate"]["status"], "stale_but_usable")
+        self.assertEqual(stale_usable["status"], "succeeded")
+        self.assertIn("freshness_gate:stale_but_usable", stale_usable["alerts"])
+
+        self.assertEqual(stale_blocked["step_results"]["freshness_gate"]["status"], "stale_blocked")
+        self.assertEqual(stale_blocked["status"], "failed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/verification/test_windmill_domain_boundary_local_integration.py
+++ b/backend/tests/verification/test_windmill_domain_boundary_local_integration.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[3]
+WINDMILL_SCRIPT_PATH = (
+    ROOT
+    / "ops"
+    / "windmill"
+    / "f"
+    / "affordabot"
+    / "pipeline_daily_refresh_domain_boundary.py"
+)
+VERIFY_SCRIPT_PATH = (
+    ROOT
+    / "backend"
+    / "scripts"
+    / "verification"
+    / "verify_windmill_domain_boundary_local_integration.py"
+)
+
+
+def _load_module(name: str, path: Path):
+    spec = spec_from_file_location(name, path)
+    module = module_from_spec(spec)
+    assert spec is not None
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_local_integration_harness_proves_happy_rerun_and_stale_blocked() -> None:
+    module = _load_module("windmill_domain_boundary_local", WINDMILL_SCRIPT_PATH)
+    result = module.main(
+        step="run_local_integration_harness",
+        idempotency_key="run:verify-local",
+        scope_item={"jurisdiction": "San Jose CA", "source_family": "meeting_minutes"},
+        search_query="San Jose housing minutes",
+        analysis_question="Summarize housing policy updates.",
+        windmill_run_id="wm-run-local",
+        windmill_job_id="wm-job-local",
+    )
+
+    assert result["status"] == "succeeded"
+    assert result["evidence"]["rerun_index_idempotent_reuse"] is True
+    assert result["evidence"]["rerun_chunk_count_stable"] is True
+    assert result["evidence"]["stale_blocked_short_circuit"] is True
+    assert result["scenarios"]["happy_first"]["status"] == "succeeded"
+    assert result["scenarios"]["happy_rerun"]["status"] == "succeeded"
+    assert result["scenarios"]["stale_blocked"]["status"] == "blocked"
+    read_step = result["scenarios"]["happy_first"]["steps"]["read_fetch"]
+    assert read_step["envelope"]["windmill_run_id"] == "wm-run-local"
+    assert read_step["refs"]["windmill_run_id"] == "wm-run-local"
+
+
+def test_verify_script_produces_report_payload_shape() -> None:
+    module = _load_module("verify_windmill_domain_boundary_local", VERIFY_SCRIPT_PATH)
+    report = module.run_verification()
+    assert report["status"] == "succeeded"
+    assert report["evidence"]["windmill_refs_propagated"] is True
+    assert "happy_first" in report["scenarios"]
+    assert "happy_rerun" in report["scenarios"]
+    assert "stale_blocked" in report["scenarios"]

--- a/docs/architecture/2026-04-12-windmill-affordabot-boundary-adr.md
+++ b/docs/architecture/2026-04-12-windmill-affordabot-boundary-adr.md
@@ -3,6 +3,7 @@
 Date: 2026-04-12
 Status: Accepted for implementation planning; production rollout still requires live Windmill validation.
 Tracking: `bd-jxclm.15` while local Beads reconciliation is offline.
+Spec lock: `docs/specs/2026-04-13-windmill-domain-brownfield-spec-lock.md`
 
 ## Decision
 

--- a/docs/architecture/2026-04-12-windmill-affordabot-boundary-adr.md
+++ b/docs/architecture/2026-04-12-windmill-affordabot-boundary-adr.md
@@ -1,0 +1,470 @@
+# ADR: Windmill / Affordabot Boundary For Data-Moat Pipeline
+
+Date: 2026-04-12
+Status: Accepted for implementation planning; production rollout still requires live Windmill validation.
+Tracking: `bd-jxclm.15` while local Beads reconciliation is offline.
+
+## Decision
+
+Adopt a layered hybrid architecture:
+
+- **Windmill** owns orchestration and operator control.
+- **Affordabot domain code** owns product-data materialization and all product invariants.
+- **Postgres** owns canonical relational product state.
+- **pgvector** owns semantic retrieval indexes over canonical chunks.
+- **MinIO** owns immutable large artifacts and raw/normalized payloads.
+- **Affordabot backend APIs** own product read models and user/operator actions.
+- **Frontend** owns visualization, review workflows, and product/operator UX through backend APIs.
+
+Windmill must not become a second application backend. It may run affordabot domain commands, but it must not own canonical document identity, source truth, freshness semantics, provenance rules, analysis sufficiency, or direct canonical product writes.
+
+The immediate implementation target is **Path B: Windmill orchestration plus affordabot domain boundary**, using a shared Python domain package first. Coarse HTTP endpoints are a later promotion path, not the starting point.
+
+## Context
+
+Affordabot differs from Prime Radiant AI. In Prime Radiant, Windmill can cleanly own ETL because ETL is support machinery. In affordabot, discovery, scraping, source ranking, canonicalization, freshness policy, evidence provenance, and analysis sufficiency are part of the product moat. Calling that whole surface "ETL" hides the core risk: moving it into Windmill would move product logic into the workflow control plane.
+
+The Windmill storage-boundary bakeoff compared:
+
+- **Path A: Windmill-heavy direct storage**
+  - Windmill scripts directly manipulate search snapshots, artifacts, chunks, embeddings, and analyses.
+  - The POC passed, but only by recreating product identity, freshness, dedupe, chunking, provenance, and idempotency inside a large script.
+
+- **Path B: Windmill plus affordabot domain boundary**
+  - Windmill owns DAG shape and calls coarse affordabot commands:
+    `search_materialize`, `freshness_gate`, `read_fetch`, `index`, `analyze`, `summarize_run`.
+  - Each command protects a product invariant and writes through affordabot-owned storage adapters.
+
+Consultant reviews converged on the same direction:
+
+- Path B is the correct boundary to lock directionally.
+- Path A proves that direct storage tends to recreate an application backend inside Windmill.
+- Before production implementation, three gaps must close:
+  - jurisdiction-scoped canonical identity
+  - write atomicity / crash-mid-step recovery
+  - multi-jurisdiction fanout and concurrency model
+- A live Windmill execution pass is required before final production lock.
+
+## Layer Model
+
+```text
+Windmill
+  orchestration/control plane
+
+Affordabot domain package
+  product materialization commands and invariants
+
+Affordabot backend API
+  product read models, user/operator actions, auth, frontend contract
+
+Postgres
+  canonical relational product state
+
+pgvector
+  semantic retrieval index over canonical chunks
+
+MinIO
+  immutable large artifacts and raw/normalized payloads
+
+Frontend
+  visualization, review queues, evidence display, operator UX
+```
+
+## Ownership Boundaries
+
+| Layer | Owns | Must Not Own |
+| --- | --- | --- |
+| Windmill | schedules, manual triggers, webhooks, DAG shape, retries, branches, loops, failure handlers, approvals, run history, operator run links | canonical identity, freshness policy, provenance, direct canonical writes, analysis sufficiency |
+| Affordabot domain package | product write commands, canonical IDs, idempotency, dedupe, freshness gates, artifact references, chunk provenance, evidence gates, analysis contract versions | schedule/runtime control, Windmill UI state |
+| Affordabot backend API | product read models, frontend contracts, auth, operator actions, optional Windmill trigger facade | low-level direct storage bypasses, hidden orchestration policy |
+| Postgres | canonical relational product truth and metadata | blob payload storage, orchestration decisions, vector ranking semantics |
+| pgvector | embeddings and similarity search over canonical chunks | canonical truth, freshness policy, provenance authority |
+| MinIO | immutable raw artifacts, reader outputs, large intermediate files, optional large LLM artifacts | product decisions, relational joins, vector search |
+| Frontend | dashboards, review queues, citations, freshness/status visualization, operator actions through backend APIs | direct Windmill orchestration, direct storage access, direct pgvector/MinIO access |
+
+## Storage Boundary Details
+
+### Postgres
+
+Postgres is the canonical source of relational product truth. It should store:
+
+- jurisdictions
+- source families and source configuration
+- search snapshots
+- canonical documents
+- artifact metadata and MinIO object references
+- document chunks metadata
+- analysis records
+- evidence links
+- pipeline run summaries that are product-visible
+- review/approval decisions
+- contract versions and migration state
+
+Postgres rows must contain enough identifiers and hashes to prove idempotency and provenance without reading MinIO.
+
+### pgvector
+
+pgvector is an access path, not product truth. Vector rows must point back to canonical chunk/document/artifact rows.
+
+Rules:
+
+- every embedding belongs to a canonical chunk row
+- retrieval must be jurisdiction-scoped by metadata/filter, not by frontend convention
+- vector hits are candidates; evidence is the chunk plus provenance chain
+- rebuilding embeddings must not change canonical document identity
+
+### MinIO
+
+MinIO stores immutable heavy artifacts:
+
+- raw HTML/PDF/source payloads
+- Z.ai reader markdown/text output
+- normalized JSON payloads
+- screenshots or visual evidence when used
+- large intermediate LLM artifacts if too large for Postgres
+
+Rules:
+
+- object keys are generated by affordabot domain code
+- object records are referenced from Postgres by key, content hash, media type, and contract version
+- MinIO never decides freshness, identity, canonicality, or evidence sufficiency
+
+## Frontend Boundary
+
+The frontend is a product visualization and review layer. It must consume affordabot backend read APIs. It must not call Windmill, Postgres, pgvector, or MinIO directly.
+
+Frontend should display affordabot concepts:
+
+- jurisdiction status
+- last successful refresh
+- fresh / stale-but-usable / stale-blocked state
+- source coverage
+- extraction/reader status
+- evidence-backed analyses
+- citation/provenance chain
+- confidence/sufficiency state
+- pipeline run summaries
+- failure reasons and retry status
+- manual rerun/review/approval actions
+
+Backend APIs should present these concepts explicitly. The frontend should not infer stale state from raw timestamps, parse Windmill job payloads, construct MinIO keys, or know pgvector schema.
+
+Example read model:
+
+```json
+{
+  "jurisdiction_id": "san-jose-ca",
+  "source_family": "meeting_minutes",
+  "freshness": {
+    "status": "stale_but_usable",
+    "last_success_at": "2026-04-12T06:00:00Z",
+    "max_stale_hours": 48,
+    "fallback_ceiling_hours": 168,
+    "alerts": ["source_search_failed_using_last_success"]
+  },
+  "latest_analysis": {
+    "status": "ready",
+    "contract_version": "2026-04-12.windmill-boundary.v1",
+    "evidence_count": 8
+  },
+  "operator_links": {
+    "windmill_run_url": "https://windmill.example/runs/..."
+  }
+}
+```
+
+Frontend actions should call backend APIs:
+
+```text
+Frontend action
+  -> affordabot backend API
+    -> validate auth/product state
+    -> trigger Windmill or write product review decision
+      -> Windmill calls affordabot domain commands when orchestration is needed
+```
+
+The frontend may show Windmill run URLs for operators, but Windmill is not the product UI.
+
+## Domain Commands To Implement First
+
+The first production-shaped boundary should be a shared Python package with coarse commands:
+
+| Command | Windmill Role | Affordabot Invariants |
+| --- | --- | --- |
+| `search_materialize` | discover and persist scoped search snapshot | query scope, source family, jurisdiction, zero-result semantics, snapshot idempotency |
+| `freshness_gate` | decide branch status | max stale hours, fallback ceiling, stale alerts, fail-closed semantics |
+| `read_fetch` | fetch/read selected URLs | canonical document identity, artifact hashing, MinIO object key policy, document dedupe |
+| `index` | embed and index content | chunk identity, jurisdiction-scoped metadata, pgvector upsert idempotency, provenance |
+| `analyze` | produce evidence-gated output | sufficiency gate, contract version, claim-to-evidence links, no-analysis-without-evidence |
+| `summarize_run` | report pipeline result | Windmill run linkage, product counts, operator-visible status |
+
+These commands must not be thin SQL wrappers. Each command must enforce at least one product invariant.
+
+## Windmill Flow Shape
+
+Windmill should run a flow shaped like:
+
+```text
+pipeline_daily_refresh
+  for each jurisdiction/source_family
+    search_materialize
+    freshness_gate
+    branch:
+      stale_blocked -> summarize_run(blocked) -> alert/fail closed
+      fresh | stale_but_usable -> read_fetch -> index -> analyze -> summarize_run
+```
+
+Windmill owns:
+
+- schedule and manual trigger
+- per-step retries/backoff
+- step timeouts
+- branch conditions
+- per-jurisdiction fanout
+- concurrency controls
+- failure handlers
+- run history
+- operator links
+
+Windmill does not own:
+
+- SQL statements for canonical product rows
+- MinIO object naming
+- chunking/provenance rules
+- stale policy calculation
+- analysis sufficiency
+- frontend read models
+
+## Shared Package First, HTTP Later
+
+Start with a shared Python package imported by Windmill worker scripts and affordabot backend code.
+
+Reasons:
+
+- fewer moving parts for pre-MVP
+- simpler local testing
+- no premature service boundary
+- one domain language shared by pipeline and backend
+- avoids turning affordabot into middleware while keeping Windmill thin
+
+Promote to coarse HTTP endpoints only when one of these triggers is met:
+
+- Windmill workers cannot reliably carry the affordabot package dependencies
+- multiple runtimes need the same domain commands
+- independent deploy/rollback cadence is needed
+- security or network policy requires a backend service boundary
+- frontend/operator actions need the same command surface synchronously
+
+If/when HTTP is introduced, endpoints must remain coarse:
+
+```text
+POST /pipeline/search-materialize
+POST /pipeline/freshness-gate
+POST /pipeline/read-fetch
+POST /pipeline/index
+POST /pipeline/analyze
+POST /pipeline/summarize-run
+```
+
+Do not create low-level `insert_row`, `upload_object`, `embed_text`, or `write_chunk` endpoints.
+
+## Required Spec Locks Before Implementation
+
+Implementation must not proceed past skeleton/live POC until these are explicitly specified:
+
+1. **Jurisdiction-scoped canonical identity**
+   - final `canonical_document_key` format
+   - URL normalization policy
+   - treatment of same URL across jurisdictions
+   - content drift/versioning policy
+
+2. **Write atomicity and crash recovery**
+   - per-command idempotency keys
+   - partial MinIO upload handling
+   - partial Postgres write handling
+   - pgvector upsert retry behavior
+   - rerun behavior after crash-mid-step
+
+3. **Concurrency model**
+   - per-jurisdiction fanout limit
+   - per-source-family rate limits
+   - SearXNG reader/LLM concurrency ceilings
+   - Postgres advisory lock or uniqueness strategy
+   - duplicate Windmill run admission policy
+
+4. **Contract versioning**
+   - command request/response envelope version
+   - artifact schema version
+   - analysis output version
+   - backwards-compatible read model policy
+
+5. **Frontend read model contract**
+   - status vocabulary
+   - freshness payload
+   - evidence/provenance payload
+   - operator action payloads
+   - Windmill run-link exposure policy
+
+## Live Validation Gate
+
+Before production implementation is considered locked, run one bounded live Windmill pass for a San Jose meeting-minutes slice:
+
+- Windmill flow executes in the shared affordabot workspace
+- private/dev SearXNG endpoint is called
+- Z.ai direct reader is called
+- Z.ai LLM analysis is called
+- Postgres writes occur through affordabot domain code
+- pgvector chunk index is written and queried
+- MinIO artifact is written and referenced from Postgres
+- rerun proves idempotency
+- stale-but-usable and stale-blocked drills are captured
+- failure handler produces operator-visible evidence
+- no 1Password GUI prompts occur
+- frontend/backend read model can display the resulting status and evidence
+
+## Implementation Strategy
+
+### Phase 0: Spec Closure
+
+Deliverables:
+
+- final canonical document key spec
+- command envelope and status vocabulary
+- write atomicity/idempotency spec
+- concurrency/admission-control spec
+- frontend read model draft
+
+Validation:
+
+- architecture review accepts the boundary and spec locks
+- tests can be written from the spec without hidden assumptions
+
+### Phase 1: Domain Package Skeleton
+
+Deliverables:
+
+- `affordabot_pipeline` or equivalent backend package
+- command interfaces and typed request/response models
+- storage ports for Postgres, pgvector, and MinIO
+- deterministic in-memory adapters for tests
+- scenario tests ported from the bakeoff
+
+Validation:
+
+- happy path
+- rerun idempotency
+- stale-but-usable
+- stale-blocked
+- source/reader/storage failures
+- crash-mid-step partial-state drills
+
+### Phase 2: Real Storage Adapters
+
+Deliverables:
+
+- Postgres schema/migration prototype
+- pgvector chunk index integration
+- MinIO artifact adapter
+- transaction/idempotency behavior around all writes
+
+Validation:
+
+- local/CI integration tests with real Postgres-compatible DB if available
+- MinIO/object-store contract tests
+- partial-write recovery tests
+
+### Phase 3: Windmill Flow Integration
+
+Deliverables:
+
+- Windmill scripts import/call the domain package
+- flow export with native retries, branch conditions, failure handler, and per-jurisdiction loop shape
+- `dx-review`/consultant review of flow shape
+
+Validation:
+
+- local flow-shaped test
+- live Windmill run evidence
+- rerun evidence
+- failure handler evidence
+
+### Phase 4: Backend Read Models And Frontend Display
+
+Deliverables:
+
+- backend status/evidence/read APIs
+- frontend jurisdiction pipeline status view
+- evidence/provenance display
+- operator action entry points for rerun/review
+
+Validation:
+
+- frontend reads only backend APIs
+- no direct Windmill/MinIO/pgvector frontend dependency
+- manual browser or Playwright evidence for key pages
+
+### Phase 5: Rollout And Parity Window
+
+Deliverables:
+
+- run new Windmill pipeline beside existing cron path where applicable
+- compare outputs for a fixed jurisdiction/source-family set
+- alerting and rollback runbook
+
+Validation:
+
+- parity window has explicit duration and pass/fail metrics
+- rollback path is one command/config switch
+
+## Beads Structure To Reconcile
+
+Beads mutations were avoided during this session because local Beads was under infra repair. When Beads is healthy, reconcile this plan as:
+
+```text
+Epic: Lock and implement affordabot Windmill/domain-boundary pipeline
+
+Children:
+1. Spec locks: identity, atomicity, concurrency, contracts, frontend read model
+2. Domain package skeleton with deterministic adapters
+3. Real Postgres/pgvector/MinIO adapters
+4. Windmill live-flow integration and validation
+5. Backend read models and frontend display
+6. Rollout/parity/rollback
+
+Blocking edges:
+1 blocks 2
+2 blocks 3 and 4
+3 blocks 4
+4 blocks 5
+5 blocks 6
+```
+
+Recommended first executable task:
+
+```text
+Write the spec-lock document for canonical identity, write atomicity, concurrency, command envelope, and frontend read model.
+```
+
+This task is first because it prevents the implementation from baking in ambiguous product identity or unsafe retry semantics.
+
+## Consequences
+
+Positive:
+
+- avoids a split-brain backend across Windmill and affordabot
+- keeps product moat logic testable in normal code
+- uses Windmill for the workflow features it is good at
+- gives frontend stable product read models
+- allows future HTTP extraction without changing domain concepts
+
+Costs:
+
+- Windmill scripts are thinner but depend on affordabot package deployment hygiene
+- domain package needs careful dependency management in Windmill workers
+- live validation remains mandatory because local POC evidence does not prove Windmill runtime semantics
+
+Rejected alternatives:
+
+- **Windmill direct storage as product backend**: rejected because Path A recreated product logic inside scripts and would scatter invariants as the DAG grows.
+- **Backend-only cron pipeline**: rejected because it underuses Windmill for retries, branches, operator controls, and run history.
+- **Frontend reading storage/Windmill directly**: rejected because it leaks implementation details and bypasses product semantics.

--- a/docs/poc/windmill-domain-boundary-integration/README.md
+++ b/docs/poc/windmill-domain-boundary-integration/README.md
@@ -1,0 +1,28 @@
+# Windmill Domain Boundary Local Integration
+
+This POC verifies the local integration chain for `bd-9qjof.6`:
+
+`Windmill-shaped orchestration -> coarse domain commands -> in-memory state surfaces -> run artifact`
+
+## Scope
+
+- Deterministic local run only (no external network or storage calls).
+- Uses `domain_package` mode in the Windmill orchestration script.
+- Proves:
+  - happy San Jose meeting-minutes run
+  - rerun idempotency behavior
+  - stale-blocked short-circuit behavior
+  - windmill envelope metadata propagation into domain command responses
+  - no direct canonical storage API usage in Windmill orchestration layer
+
+## Run
+
+```bash
+cd backend
+poetry run python scripts/verification/verify_windmill_domain_boundary_local_integration.py
+```
+
+Artifacts are written to:
+
+- `docs/poc/windmill-domain-boundary-integration/artifacts/local_integration_report.json`
+- `docs/poc/windmill-domain-boundary-integration/artifacts/local_integration_report.md`

--- a/docs/poc/windmill-domain-boundary-integration/artifacts/local_integration_report.json
+++ b/docs/poc/windmill-domain-boundary-integration/artifacts/local_integration_report.json
@@ -1,0 +1,707 @@
+{
+  "evidence": {
+    "happy_status": "succeeded",
+    "rerun_chunk_count_stable": true,
+    "rerun_index_idempotent_reuse": true,
+    "rerun_status": "succeeded",
+    "stale_blocked_short_circuit": true,
+    "stale_blocked_status": "blocked",
+    "windmill_refs_propagated": true
+  },
+  "scenarios": {
+    "happy_first": {
+      "alert": "",
+      "scope_index": 0,
+      "scope_item": {
+        "jurisdiction": "San Jose CA",
+        "source_family": "meeting_minutes"
+      },
+      "status": "succeeded",
+      "steps": {
+        "analyze": {
+          "alerts": [],
+          "command": "analyze",
+          "contract_version": "2026-04-13.windmill-domain.v1",
+          "counts": {
+            "analyses": 1,
+            "evidence_chunks": 4
+          },
+          "created_at": "2026-04-13T07:35:38.845565+00:00",
+          "decision_reason": "analysis_completed",
+          "details": {
+            "sufficiency_state": "qualitative_only"
+          },
+          "envelope": {
+            "architecture_path": "affordabot_domain_boundary",
+            "contract_version": "2026-04-13.windmill-domain.v1",
+            "idempotency_key": "run:bd-9qjof.6:san-jose:analyze",
+            "jurisdiction_id": "San Jose CA",
+            "jurisdiction_name": "San Jose CA",
+            "mode": "domain_package",
+            "orchestrator": "windmill",
+            "scope_index": 0,
+            "scope_key": "San Jose CA|meeting_minutes|0",
+            "source_family": "meeting_minutes",
+            "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:5",
+            "windmill_run_id": "wm-local-bd9qjof6",
+            "windmill_step_id": "analyze",
+            "windmill_workspace": "affordabot"
+          },
+          "invoked_command": "analyze",
+          "refs": {
+            "analysis_id": "analysis_0d847e9806531877",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:5",
+            "windmill_run_id": "wm-local-bd9qjof6"
+          },
+          "retry_class": "none",
+          "status": "succeeded"
+        },
+        "freshness_gate": {
+          "alerts": [],
+          "command": "freshness_gate",
+          "contract_version": "2026-04-13.windmill-domain.v1",
+          "counts": {
+            "search_results": 1
+          },
+          "created_at": "2026-04-13T07:35:38.845356+00:00",
+          "decision_reason": "fresh",
+          "details": {
+            "fail_closed_ceiling_hours": 168,
+            "fallback_age_hours": null,
+            "fresh_hours": 24,
+            "freshness_status": "fresh",
+            "snapshot_age_hours": 0,
+            "stale_usable_ceiling_hours": 72
+          },
+          "envelope": {
+            "architecture_path": "affordabot_domain_boundary",
+            "contract_version": "2026-04-13.windmill-domain.v1",
+            "idempotency_key": "run:bd-9qjof.6:san-jose:freshness_gate",
+            "jurisdiction_id": "San Jose CA",
+            "jurisdiction_name": "San Jose CA",
+            "mode": "domain_package",
+            "orchestrator": "windmill",
+            "scope_index": 0,
+            "scope_key": "San Jose CA|meeting_minutes|0",
+            "source_family": "meeting_minutes",
+            "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:2",
+            "windmill_run_id": "wm-local-bd9qjof6",
+            "windmill_step_id": "freshness_gate",
+            "windmill_workspace": "affordabot"
+          },
+          "invoked_command": "freshness_gate",
+          "refs": {
+            "search_snapshot_id": "snapshot_58d18f23ed3a62a1",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:2",
+            "windmill_run_id": "wm-local-bd9qjof6"
+          },
+          "retry_class": "none",
+          "status": "succeeded"
+        },
+        "index": {
+          "alerts": [],
+          "command": "index",
+          "contract_version": "2026-04-13.windmill-domain.v1",
+          "counts": {
+            "chunks": 4
+          },
+          "created_at": "2026-04-13T07:35:38.845529+00:00",
+          "decision_reason": "chunks_indexed",
+          "details": {},
+          "envelope": {
+            "architecture_path": "affordabot_domain_boundary",
+            "contract_version": "2026-04-13.windmill-domain.v1",
+            "idempotency_key": "run:bd-9qjof.6:san-jose:index",
+            "jurisdiction_id": "San Jose CA",
+            "jurisdiction_name": "San Jose CA",
+            "mode": "domain_package",
+            "orchestrator": "windmill",
+            "scope_index": 0,
+            "scope_key": "San Jose CA|meeting_minutes|0",
+            "source_family": "meeting_minutes",
+            "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:4",
+            "windmill_run_id": "wm-local-bd9qjof6",
+            "windmill_step_id": "index",
+            "windmill_workspace": "affordabot"
+          },
+          "invoked_command": "index",
+          "refs": {
+            "raw_scrape_ids": [
+              "raw_cd7d532efe76b4b7"
+            ],
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:4",
+            "windmill_run_id": "wm-local-bd9qjof6"
+          },
+          "retry_class": "none",
+          "status": "succeeded"
+        },
+        "read_fetch": {
+          "alerts": [],
+          "command": "read_fetch",
+          "contract_version": "2026-04-13.windmill-domain.v1",
+          "counts": {
+            "artifacts": 1,
+            "raw_scrapes": 1
+          },
+          "created_at": "2026-04-13T07:35:38.845492+00:00",
+          "decision_reason": "raw_scrapes_materialized",
+          "details": {},
+          "envelope": {
+            "architecture_path": "affordabot_domain_boundary",
+            "contract_version": "2026-04-13.windmill-domain.v1",
+            "idempotency_key": "run:bd-9qjof.6:san-jose:read_fetch",
+            "jurisdiction_id": "San Jose CA",
+            "jurisdiction_name": "San Jose CA",
+            "mode": "domain_package",
+            "orchestrator": "windmill",
+            "scope_index": 0,
+            "scope_key": "San Jose CA|meeting_minutes|0",
+            "source_family": "meeting_minutes",
+            "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:3",
+            "windmill_run_id": "wm-local-bd9qjof6",
+            "windmill_step_id": "read_fetch",
+            "windmill_workspace": "affordabot"
+          },
+          "invoked_command": "read_fetch",
+          "refs": {
+            "artifact_refs": [
+              "artifacts/2026-04-13.windmill-domain.v1/San Jose CA/meeting_minutes/reader_output/2ac6d83f3e9b6730204a78fa7b6211a69f0912e09f1756c4d1aee408132c66ff.md"
+            ],
+            "raw_scrape_ids": [
+              "raw_cd7d532efe76b4b7"
+            ],
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:3",
+            "windmill_run_id": "wm-local-bd9qjof6"
+          },
+          "retry_class": "none",
+          "status": "succeeded"
+        },
+        "search_materialize": {
+          "alerts": [],
+          "command": "search_materialize",
+          "contract_version": "2026-04-13.windmill-domain.v1",
+          "counts": {
+            "search_results": 1
+          },
+          "created_at": "2026-04-13T07:35:38.845304+00:00",
+          "decision_reason": "fresh_snapshot_materialized",
+          "details": {
+            "query": "San Jose city council meeting minutes housing"
+          },
+          "envelope": {
+            "architecture_path": "affordabot_domain_boundary",
+            "contract_version": "2026-04-13.windmill-domain.v1",
+            "idempotency_key": "run:bd-9qjof.6:san-jose:search_materialize",
+            "jurisdiction_id": "San Jose CA",
+            "jurisdiction_name": "San Jose CA",
+            "mode": "domain_package",
+            "orchestrator": "windmill",
+            "scope_index": 0,
+            "scope_key": "San Jose CA|meeting_minutes|0",
+            "source_family": "meeting_minutes",
+            "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:1",
+            "windmill_run_id": "wm-local-bd9qjof6",
+            "windmill_step_id": "search_materialize",
+            "windmill_workspace": "affordabot"
+          },
+          "invoked_command": "search_materialize",
+          "refs": {
+            "search_snapshot_id": "snapshot_58d18f23ed3a62a1",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:1",
+            "windmill_run_id": "wm-local-bd9qjof6"
+          },
+          "retry_class": "none",
+          "status": "succeeded"
+        },
+        "summarize_run": {
+          "alerts": [],
+          "command": "summarize_run",
+          "contract_version": "2026-04-13.windmill-domain.v1",
+          "counts": {
+            "analyses": 1,
+            "artifacts": 1,
+            "chunks": 4,
+            "evidence_chunks": 4,
+            "raw_scrapes": 1,
+            "search_results": 2
+          },
+          "created_at": "2026-04-13T07:35:38.845591+00:00",
+          "decision_reason": "run_summary_materialized",
+          "details": {
+            "step_statuses": {
+              "analyze": "succeeded",
+              "freshness_gate": "succeeded",
+              "index": "succeeded",
+              "read_fetch": "succeeded",
+              "search_materialize": "succeeded"
+            }
+          },
+          "envelope": {
+            "architecture_path": "affordabot_domain_boundary",
+            "contract_version": "2026-04-13.windmill-domain.v1",
+            "idempotency_key": "run:bd-9qjof.6:san-jose:summarize_run",
+            "jurisdiction_id": "San Jose CA",
+            "jurisdiction_name": "San Jose CA",
+            "mode": "domain_package",
+            "orchestrator": "windmill",
+            "scope_index": 0,
+            "scope_key": "San Jose CA|meeting_minutes|0",
+            "source_family": "meeting_minutes",
+            "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:6",
+            "windmill_run_id": "wm-local-bd9qjof6",
+            "windmill_step_id": "summarize_run",
+            "windmill_workspace": "affordabot"
+          },
+          "invoked_command": "summarize_run",
+          "refs": {
+            "analyze_reason": "analysis_completed",
+            "analyze_retry_class": "none",
+            "freshness_gate_reason": "fresh",
+            "freshness_gate_retry_class": "none",
+            "index_reason": "chunks_indexed",
+            "index_retry_class": "none",
+            "read_fetch_reason": "raw_scrapes_materialized",
+            "read_fetch_retry_class": "none",
+            "run_id": "run_wm-local-bd9qjof6",
+            "search_materialize_reason": "fresh_snapshot_materialized",
+            "search_materialize_retry_class": "none",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:6",
+            "windmill_run_id": "wm-local-bd9qjof6"
+          },
+          "retry_class": "none",
+          "status": "succeeded"
+        }
+      }
+    },
+    "happy_rerun": {
+      "alert": "",
+      "scope_index": 0,
+      "scope_item": {
+        "jurisdiction": "San Jose CA",
+        "source_family": "meeting_minutes"
+      },
+      "status": "succeeded",
+      "steps": {
+        "analyze": {
+          "alerts": [],
+          "command": "analyze",
+          "contract_version": "2026-04-13.windmill-domain.v1",
+          "counts": {
+            "analyses": 1,
+            "evidence_chunks": 4
+          },
+          "created_at": "2026-04-13T07:35:38.845565+00:00",
+          "decision_reason": "analysis_completed",
+          "details": {
+            "idempotent_reuse": true,
+            "sufficiency_state": "qualitative_only"
+          },
+          "envelope": {
+            "architecture_path": "affordabot_domain_boundary",
+            "contract_version": "2026-04-13.windmill-domain.v1",
+            "idempotency_key": "run:bd-9qjof.6:san-jose:analyze",
+            "jurisdiction_id": "San Jose CA",
+            "jurisdiction_name": "San Jose CA",
+            "mode": "domain_package",
+            "orchestrator": "windmill",
+            "scope_index": 0,
+            "scope_key": "San Jose CA|meeting_minutes|0",
+            "source_family": "meeting_minutes",
+            "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:5",
+            "windmill_run_id": "wm-local-bd9qjof6",
+            "windmill_step_id": "analyze",
+            "windmill_workspace": "affordabot"
+          },
+          "invoked_command": "analyze",
+          "refs": {
+            "analysis_id": "analysis_0d847e9806531877",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:5",
+            "windmill_run_id": "wm-local-bd9qjof6"
+          },
+          "retry_class": "none",
+          "status": "succeeded"
+        },
+        "freshness_gate": {
+          "alerts": [],
+          "command": "freshness_gate",
+          "contract_version": "2026-04-13.windmill-domain.v1",
+          "counts": {
+            "search_results": 1
+          },
+          "created_at": "2026-04-13T07:35:38.845356+00:00",
+          "decision_reason": "fresh",
+          "details": {
+            "fail_closed_ceiling_hours": 168,
+            "fallback_age_hours": null,
+            "fresh_hours": 24,
+            "freshness_status": "fresh",
+            "idempotent_reuse": true,
+            "snapshot_age_hours": 0,
+            "stale_usable_ceiling_hours": 72
+          },
+          "envelope": {
+            "architecture_path": "affordabot_domain_boundary",
+            "contract_version": "2026-04-13.windmill-domain.v1",
+            "idempotency_key": "run:bd-9qjof.6:san-jose:freshness_gate",
+            "jurisdiction_id": "San Jose CA",
+            "jurisdiction_name": "San Jose CA",
+            "mode": "domain_package",
+            "orchestrator": "windmill",
+            "scope_index": 0,
+            "scope_key": "San Jose CA|meeting_minutes|0",
+            "source_family": "meeting_minutes",
+            "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:2",
+            "windmill_run_id": "wm-local-bd9qjof6",
+            "windmill_step_id": "freshness_gate",
+            "windmill_workspace": "affordabot"
+          },
+          "invoked_command": "freshness_gate",
+          "refs": {
+            "search_snapshot_id": "snapshot_58d18f23ed3a62a1",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:2",
+            "windmill_run_id": "wm-local-bd9qjof6"
+          },
+          "retry_class": "none",
+          "status": "succeeded"
+        },
+        "index": {
+          "alerts": [],
+          "command": "index",
+          "contract_version": "2026-04-13.windmill-domain.v1",
+          "counts": {
+            "chunks": 4
+          },
+          "created_at": "2026-04-13T07:35:38.845529+00:00",
+          "decision_reason": "chunks_indexed",
+          "details": {
+            "idempotent_reuse": true
+          },
+          "envelope": {
+            "architecture_path": "affordabot_domain_boundary",
+            "contract_version": "2026-04-13.windmill-domain.v1",
+            "idempotency_key": "run:bd-9qjof.6:san-jose:index",
+            "jurisdiction_id": "San Jose CA",
+            "jurisdiction_name": "San Jose CA",
+            "mode": "domain_package",
+            "orchestrator": "windmill",
+            "scope_index": 0,
+            "scope_key": "San Jose CA|meeting_minutes|0",
+            "source_family": "meeting_minutes",
+            "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:4",
+            "windmill_run_id": "wm-local-bd9qjof6",
+            "windmill_step_id": "index",
+            "windmill_workspace": "affordabot"
+          },
+          "invoked_command": "index",
+          "refs": {
+            "raw_scrape_ids": [
+              "raw_cd7d532efe76b4b7"
+            ],
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:4",
+            "windmill_run_id": "wm-local-bd9qjof6"
+          },
+          "retry_class": "none",
+          "status": "succeeded"
+        },
+        "read_fetch": {
+          "alerts": [],
+          "command": "read_fetch",
+          "contract_version": "2026-04-13.windmill-domain.v1",
+          "counts": {
+            "artifacts": 1,
+            "raw_scrapes": 1
+          },
+          "created_at": "2026-04-13T07:35:38.845492+00:00",
+          "decision_reason": "raw_scrapes_materialized",
+          "details": {
+            "idempotent_reuse": true
+          },
+          "envelope": {
+            "architecture_path": "affordabot_domain_boundary",
+            "contract_version": "2026-04-13.windmill-domain.v1",
+            "idempotency_key": "run:bd-9qjof.6:san-jose:read_fetch",
+            "jurisdiction_id": "San Jose CA",
+            "jurisdiction_name": "San Jose CA",
+            "mode": "domain_package",
+            "orchestrator": "windmill",
+            "scope_index": 0,
+            "scope_key": "San Jose CA|meeting_minutes|0",
+            "source_family": "meeting_minutes",
+            "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:3",
+            "windmill_run_id": "wm-local-bd9qjof6",
+            "windmill_step_id": "read_fetch",
+            "windmill_workspace": "affordabot"
+          },
+          "invoked_command": "read_fetch",
+          "refs": {
+            "artifact_refs": [
+              "artifacts/2026-04-13.windmill-domain.v1/San Jose CA/meeting_minutes/reader_output/2ac6d83f3e9b6730204a78fa7b6211a69f0912e09f1756c4d1aee408132c66ff.md"
+            ],
+            "raw_scrape_ids": [
+              "raw_cd7d532efe76b4b7"
+            ],
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:3",
+            "windmill_run_id": "wm-local-bd9qjof6"
+          },
+          "retry_class": "none",
+          "status": "succeeded"
+        },
+        "search_materialize": {
+          "alerts": [],
+          "command": "search_materialize",
+          "contract_version": "2026-04-13.windmill-domain.v1",
+          "counts": {
+            "search_results": 1
+          },
+          "created_at": "2026-04-13T07:35:38.845304+00:00",
+          "decision_reason": "fresh_snapshot_materialized",
+          "details": {
+            "idempotent_reuse": true,
+            "query": "San Jose city council meeting minutes housing"
+          },
+          "envelope": {
+            "architecture_path": "affordabot_domain_boundary",
+            "contract_version": "2026-04-13.windmill-domain.v1",
+            "idempotency_key": "run:bd-9qjof.6:san-jose:search_materialize",
+            "jurisdiction_id": "San Jose CA",
+            "jurisdiction_name": "San Jose CA",
+            "mode": "domain_package",
+            "orchestrator": "windmill",
+            "scope_index": 0,
+            "scope_key": "San Jose CA|meeting_minutes|0",
+            "source_family": "meeting_minutes",
+            "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:1",
+            "windmill_run_id": "wm-local-bd9qjof6",
+            "windmill_step_id": "search_materialize",
+            "windmill_workspace": "affordabot"
+          },
+          "invoked_command": "search_materialize",
+          "refs": {
+            "search_snapshot_id": "snapshot_58d18f23ed3a62a1",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:1",
+            "windmill_run_id": "wm-local-bd9qjof6"
+          },
+          "retry_class": "none",
+          "status": "succeeded"
+        },
+        "summarize_run": {
+          "alerts": [],
+          "command": "summarize_run",
+          "contract_version": "2026-04-13.windmill-domain.v1",
+          "counts": {
+            "analyses": 1,
+            "artifacts": 1,
+            "chunks": 4,
+            "evidence_chunks": 4,
+            "raw_scrapes": 1,
+            "search_results": 2
+          },
+          "created_at": "2026-04-13T07:35:38.845591+00:00",
+          "decision_reason": "run_summary_materialized",
+          "details": {
+            "idempotent_reuse": true,
+            "step_statuses": {
+              "analyze": "succeeded",
+              "freshness_gate": "succeeded",
+              "index": "succeeded",
+              "read_fetch": "succeeded",
+              "search_materialize": "succeeded"
+            }
+          },
+          "envelope": {
+            "architecture_path": "affordabot_domain_boundary",
+            "contract_version": "2026-04-13.windmill-domain.v1",
+            "idempotency_key": "run:bd-9qjof.6:san-jose:summarize_run",
+            "jurisdiction_id": "San Jose CA",
+            "jurisdiction_name": "San Jose CA",
+            "mode": "domain_package",
+            "orchestrator": "windmill",
+            "scope_index": 0,
+            "scope_key": "San Jose CA|meeting_minutes|0",
+            "source_family": "meeting_minutes",
+            "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:6",
+            "windmill_run_id": "wm-local-bd9qjof6",
+            "windmill_step_id": "summarize_run",
+            "windmill_workspace": "affordabot"
+          },
+          "invoked_command": "summarize_run",
+          "refs": {
+            "analyze_reason": "analysis_completed",
+            "analyze_retry_class": "none",
+            "freshness_gate_reason": "fresh",
+            "freshness_gate_retry_class": "none",
+            "index_reason": "chunks_indexed",
+            "index_retry_class": "none",
+            "read_fetch_reason": "raw_scrapes_materialized",
+            "read_fetch_retry_class": "none",
+            "run_id": "run_wm-local-bd9qjof6",
+            "search_materialize_reason": "fresh_snapshot_materialized",
+            "search_materialize_retry_class": "none",
+            "windmill_job_id": "wm-local-job-bd9qjof6:0:6",
+            "windmill_run_id": "wm-local-bd9qjof6"
+          },
+          "retry_class": "none",
+          "status": "succeeded"
+        }
+      }
+    },
+    "stale_blocked": {
+      "alert": "freshness_gate:stale_blocked",
+      "scope_index": 1,
+      "scope_item": {
+        "jurisdiction": "San Jose CA",
+        "source_family": "meeting_minutes"
+      },
+      "status": "blocked",
+      "steps": {
+        "freshness_gate": {
+          "alerts": [
+            "stale_search_results_fail_closed"
+          ],
+          "command": "freshness_gate",
+          "contract_version": "2026-04-13.windmill-domain.v1",
+          "counts": {
+            "search_results": 1
+          },
+          "created_at": "2026-04-13T07:35:38.845943+00:00",
+          "decision_reason": "stale_blocked",
+          "details": {
+            "fail_closed_ceiling_hours": 168,
+            "fallback_age_hours": 0,
+            "fresh_hours": 24,
+            "freshness_status": "stale_blocked",
+            "snapshot_age_hours": 120,
+            "stale_usable_ceiling_hours": 72
+          },
+          "envelope": {
+            "architecture_path": "affordabot_domain_boundary",
+            "contract_version": "2026-04-13.windmill-domain.v1",
+            "idempotency_key": "run:bd-9qjof.6:san-jose:blocked:freshness_gate",
+            "jurisdiction_id": "San Jose CA",
+            "jurisdiction_name": "San Jose CA",
+            "mode": "domain_package",
+            "orchestrator": "windmill",
+            "scope_index": 1,
+            "scope_key": "San Jose CA|meeting_minutes|1",
+            "source_family": "meeting_minutes",
+            "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+            "windmill_job_id": "wm-local-job-bd9qjof6:1:2",
+            "windmill_run_id": "wm-local-bd9qjof6",
+            "windmill_step_id": "freshness_gate",
+            "windmill_workspace": "affordabot"
+          },
+          "invoked_command": "freshness_gate",
+          "refs": {
+            "search_snapshot_id": "snapshot_58d18f23ed3a62a1",
+            "windmill_job_id": "wm-local-job-bd9qjof6:1:2",
+            "windmill_run_id": "wm-local-bd9qjof6"
+          },
+          "retry_class": "operator_required",
+          "status": "blocked"
+        },
+        "search_materialize": {
+          "alerts": [],
+          "command": "search_materialize",
+          "contract_version": "2026-04-13.windmill-domain.v1",
+          "counts": {
+            "search_results": 1
+          },
+          "created_at": "2026-04-13T07:35:38.845917+00:00",
+          "decision_reason": "fresh_snapshot_materialized",
+          "details": {
+            "query": "San Jose city council meeting minutes housing"
+          },
+          "envelope": {
+            "architecture_path": "affordabot_domain_boundary",
+            "contract_version": "2026-04-13.windmill-domain.v1",
+            "idempotency_key": "run:bd-9qjof.6:san-jose:blocked:search_materialize",
+            "jurisdiction_id": "San Jose CA",
+            "jurisdiction_name": "San Jose CA",
+            "mode": "domain_package",
+            "orchestrator": "windmill",
+            "scope_index": 1,
+            "scope_key": "San Jose CA|meeting_minutes|1",
+            "source_family": "meeting_minutes",
+            "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+            "windmill_job_id": "wm-local-job-bd9qjof6:1:1",
+            "windmill_run_id": "wm-local-bd9qjof6",
+            "windmill_step_id": "search_materialize",
+            "windmill_workspace": "affordabot"
+          },
+          "invoked_command": "search_materialize",
+          "refs": {
+            "search_snapshot_id": "snapshot_58d18f23ed3a62a1",
+            "windmill_job_id": "wm-local-job-bd9qjof6:1:1",
+            "windmill_run_id": "wm-local-bd9qjof6"
+          },
+          "retry_class": "none",
+          "status": "succeeded"
+        },
+        "summarize_run": {
+          "alerts": [
+            "stale_search_results_fail_closed"
+          ],
+          "command": "summarize_run",
+          "contract_version": "2026-04-13.windmill-domain.v1",
+          "counts": {
+            "search_results": 2
+          },
+          "created_at": "2026-04-13T07:35:38.845966+00:00",
+          "decision_reason": "run_summary_materialized",
+          "details": {
+            "step_statuses": {
+              "freshness_gate": "blocked",
+              "search_materialize": "succeeded"
+            }
+          },
+          "envelope": {
+            "architecture_path": "affordabot_domain_boundary",
+            "contract_version": "2026-04-13.windmill-domain.v1",
+            "idempotency_key": "run:bd-9qjof.6:san-jose:blocked:summarize_run",
+            "jurisdiction_id": "San Jose CA",
+            "jurisdiction_name": "San Jose CA",
+            "mode": "domain_package",
+            "orchestrator": "windmill",
+            "scope_index": 1,
+            "scope_key": "San Jose CA|meeting_minutes|1",
+            "source_family": "meeting_minutes",
+            "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+            "windmill_job_id": "wm-local-job-bd9qjof6:1:6",
+            "windmill_run_id": "wm-local-bd9qjof6",
+            "windmill_step_id": "summarize_run",
+            "windmill_workspace": "affordabot"
+          },
+          "invoked_command": "summarize_run",
+          "refs": {
+            "freshness_gate_reason": "stale_blocked",
+            "freshness_gate_retry_class": "operator_required",
+            "run_id": "run_wm-local-bd9qjof6",
+            "search_materialize_reason": "fresh_snapshot_materialized",
+            "search_materialize_retry_class": "none",
+            "windmill_job_id": "wm-local-job-bd9qjof6:1:6",
+            "windmill_run_id": "wm-local-bd9qjof6"
+          },
+          "retry_class": "operator_required",
+          "status": "blocked"
+        }
+      }
+    }
+  },
+  "scope_item": {
+    "jurisdiction": "San Jose CA",
+    "source_family": "meeting_minutes"
+  },
+  "status": "succeeded"
+}

--- a/docs/poc/windmill-domain-boundary-integration/artifacts/local_integration_report.json
+++ b/docs/poc/windmill-domain-boundary-integration/artifacts/local_integration_report.json
@@ -26,7 +26,7 @@
             "analyses": 1,
             "evidence_chunks": 4
           },
-          "created_at": "2026-04-13T07:35:38.845565+00:00",
+          "created_at": "2026-04-13T00:00:00+00:00",
           "decision_reason": "analysis_completed",
           "details": {
             "sufficiency_state": "qualitative_only"
@@ -64,7 +64,7 @@
           "counts": {
             "search_results": 1
           },
-          "created_at": "2026-04-13T07:35:38.845356+00:00",
+          "created_at": "2026-04-13T00:00:00+00:00",
           "decision_reason": "fresh",
           "details": {
             "fail_closed_ceiling_hours": 168,
@@ -107,7 +107,7 @@
           "counts": {
             "chunks": 4
           },
-          "created_at": "2026-04-13T07:35:38.845529+00:00",
+          "created_at": "2026-04-13T00:00:00+00:00",
           "decision_reason": "chunks_indexed",
           "details": {},
           "envelope": {
@@ -146,7 +146,7 @@
             "artifacts": 1,
             "raw_scrapes": 1
           },
-          "created_at": "2026-04-13T07:35:38.845492+00:00",
+          "created_at": "2026-04-13T00:00:00+00:00",
           "decision_reason": "raw_scrapes_materialized",
           "details": {},
           "envelope": {
@@ -187,7 +187,7 @@
           "counts": {
             "search_results": 1
           },
-          "created_at": "2026-04-13T07:35:38.845304+00:00",
+          "created_at": "2026-04-13T00:00:00+00:00",
           "decision_reason": "fresh_snapshot_materialized",
           "details": {
             "query": "San Jose city council meeting minutes housing"
@@ -230,7 +230,7 @@
             "raw_scrapes": 1,
             "search_results": 2
           },
-          "created_at": "2026-04-13T07:35:38.845591+00:00",
+          "created_at": "2026-04-13T00:00:00+00:00",
           "decision_reason": "run_summary_materialized",
           "details": {
             "step_statuses": {
@@ -296,7 +296,7 @@
             "analyses": 1,
             "evidence_chunks": 4
           },
-          "created_at": "2026-04-13T07:35:38.845565+00:00",
+          "created_at": "2026-04-13T00:00:00+00:00",
           "decision_reason": "analysis_completed",
           "details": {
             "idempotent_reuse": true,
@@ -335,7 +335,7 @@
           "counts": {
             "search_results": 1
           },
-          "created_at": "2026-04-13T07:35:38.845356+00:00",
+          "created_at": "2026-04-13T00:00:00+00:00",
           "decision_reason": "fresh",
           "details": {
             "fail_closed_ceiling_hours": 168,
@@ -379,7 +379,7 @@
           "counts": {
             "chunks": 4
           },
-          "created_at": "2026-04-13T07:35:38.845529+00:00",
+          "created_at": "2026-04-13T00:00:00+00:00",
           "decision_reason": "chunks_indexed",
           "details": {
             "idempotent_reuse": true
@@ -420,7 +420,7 @@
             "artifacts": 1,
             "raw_scrapes": 1
           },
-          "created_at": "2026-04-13T07:35:38.845492+00:00",
+          "created_at": "2026-04-13T00:00:00+00:00",
           "decision_reason": "raw_scrapes_materialized",
           "details": {
             "idempotent_reuse": true
@@ -463,7 +463,7 @@
           "counts": {
             "search_results": 1
           },
-          "created_at": "2026-04-13T07:35:38.845304+00:00",
+          "created_at": "2026-04-13T00:00:00+00:00",
           "decision_reason": "fresh_snapshot_materialized",
           "details": {
             "idempotent_reuse": true,
@@ -507,7 +507,7 @@
             "raw_scrapes": 1,
             "search_results": 2
           },
-          "created_at": "2026-04-13T07:35:38.845591+00:00",
+          "created_at": "2026-04-13T00:00:00+00:00",
           "decision_reason": "run_summary_materialized",
           "details": {
             "idempotent_reuse": true,
@@ -575,7 +575,7 @@
           "counts": {
             "search_results": 1
           },
-          "created_at": "2026-04-13T07:35:38.845943+00:00",
+          "created_at": "2026-04-13T00:00:00+00:00",
           "decision_reason": "stale_blocked",
           "details": {
             "fail_closed_ceiling_hours": 168,
@@ -618,7 +618,7 @@
           "counts": {
             "search_results": 1
           },
-          "created_at": "2026-04-13T07:35:38.845917+00:00",
+          "created_at": "2026-04-13T00:00:00+00:00",
           "decision_reason": "fresh_snapshot_materialized",
           "details": {
             "query": "San Jose city council meeting minutes housing"
@@ -658,7 +658,7 @@
           "counts": {
             "search_results": 2
           },
-          "created_at": "2026-04-13T07:35:38.845966+00:00",
+          "created_at": "2026-04-13T00:00:00+00:00",
           "decision_reason": "run_summary_materialized",
           "details": {
             "step_statuses": {

--- a/docs/poc/windmill-domain-boundary-integration/artifacts/local_integration_report.md
+++ b/docs/poc/windmill-domain-boundary-integration/artifacts/local_integration_report.md
@@ -1,0 +1,22 @@
+# Windmill Domain Boundary Local Integration Evidence
+
+## Run Verdict
+- status: `succeeded`
+
+## Evidence Checks
+- happy_status: `succeeded`
+- rerun_status: `succeeded`
+- stale_blocked_status: `blocked`
+- rerun_index_idempotent_reuse: `True`
+- rerun_chunk_count_stable: `True`
+- stale_blocked_short_circuit: `True`
+- windmill_refs_propagated: `True`
+
+## Scenario Summaries
+- happy_first steps: `search_materialize, freshness_gate, read_fetch, index, analyze, summarize_run`
+- happy_rerun steps: `search_materialize, freshness_gate, read_fetch, index, analyze, summarize_run`
+- stale_blocked steps: `search_materialize, freshness_gate, summarize_run`
+
+## Notes
+- Windmill path uses coarse commands only.
+- No external network/database/object/vector service calls were made.

--- a/docs/poc/windmill-domain-boundary-integration/live-windmill-preflight.md
+++ b/docs/poc/windmill-domain-boundary-integration/live-windmill-preflight.md
@@ -1,0 +1,99 @@
+# Live Windmill Preflight (Domain-Boundary POC)
+
+Date: 2026-04-13  
+Epic/Subtask: `bd-9qjof` / `bd-9qjof.6`  
+PR branch: `feature/offline-20260412-windmill-bakeoff`  
+Target PR head at start: `44d0bbe9bfc546cd937b20273991895117e2d7f9`
+
+## Verdict
+
+`blocked_by_auth`
+
+Live remote preflight cannot proceed in this session because no Windmill workspace/profile is configured locally, and no non-interactive remote context is available without introducing secret/auth mutation risk.
+
+## Scope Checked
+
+Reviewed domain-boundary design and flow assets:
+
+- `docs/architecture/2026-04-12-windmill-affordabot-boundary-adr.md`
+- `docs/specs/2026-04-13-windmill-domain-brownfield-spec-lock.md`
+- `ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.py`
+- `ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary__flow/flow.yaml`
+
+## Commands Run (Non-Mutating)
+
+```bash
+git -C /tmp/agents/offline-20260412-windmill-bakeoff/affordabot fetch origin feature/offline-20260412-windmill-bakeoff
+git -C /tmp/agents/offline-20260412-windmill-bakeoff/affordabot rev-parse HEAD
+git -C /tmp/agents/offline-20260412-windmill-bakeoff/affordabot rev-parse origin/feature/offline-20260412-windmill-bakeoff
+
+command -v wmill
+npx --yes windmill-cli --version
+npx --yes windmill-cli --help
+npx --yes windmill-cli profile list
+npx --yes windmill-cli workspace list-remote
+
+env | rg '^WINDMILL_' | sed 's/=.*//'
+sed -n '1,220p' ops/windmill/wmill.yaml
+```
+
+## Evidence Summary
+
+Proven:
+
+- PR branch is pinned to expected head SHA (`44d0bbe...`) before investigation.
+- Local native `wmill` binary is not installed on PATH.
+- Windmill CLI is available via `npx windmill-cli` (version `1.682.0`).
+- Local Windmill profile state shows no active workspace.
+- Remote workspace enumeration fails with: no workspace given and no default set.
+- Repository has committed Windmill sync config (`ops/windmill/wmill.yaml`) for paths and sync behavior.
+
+Not proven:
+
+- Authenticated access to the development Windmill workspace.
+- Presence of required remote workspace paths/resources for domain-boundary dry-run.
+- Safe isolated run namespace in live workspace.
+- Backend endpoint + internal auth token wiring for live command execution.
+- End-to-end non-scheduled flow run in live Windmill.
+
+## Risk Assessment
+
+Live execution is **not safe to proceed autonomously** from this session because:
+
+1. Remote workspace context is absent (no active profile/workspace).
+2. Attempting to establish auth/workspace here would require secret/bootstrap steps that are outside this no-mutation preflight lane.
+3. Shared workspace isolation is not yet proven (dev-only folder/flow path plus no-schedule policy).
+
+## Required Next Step
+
+Run a controlled auth/bootstrap preflight in a dedicated dev context (cache/service-account path only, no interactive 1Password prompts), then repeat read-only remote checks before any flow run.
+
+If remote preflight passes, run only a **manual non-scheduled dry-run** of:
+
+- `f/affordabot/pipeline_daily_refresh_domain_boundary__flow`
+
+with:
+
+- dev-only idempotency key
+- single scope (`san-jose-ca` + `meeting_minutes`)
+- explicit proof that no schedule/workspace globals are mutated
+
+## Orchestrator Dry-Run Checklist (Non-Mutating First)
+
+1. Confirm workspace/profile exists and is dev-scoped.
+2. Confirm flow/script path exists remotely under affordabot dev workspace.
+3. Confirm required backend base URL is dev/staging, not production.
+4. Confirm cron/internal auth strategy is available without raw secret reads in shell logs.
+5. Confirm run invocation is manual-only (no schedule edits, no enable/disable operations).
+6. Confirm evidence capture target:
+   - Windmill run ID / URL
+   - command envelopes (contract version + jurisdiction/source family)
+   - domain command statuses and alerts
+7. Confirm rollback procedure is "stop after run"; no persistent schedule mutation.
+
+## POC Search/Reader/LLM Policy (Locked)
+
+- Z.ai direct web search is deprecated for this POC and is not the primary discovery path.
+- OSS/SearXNG search is primary for discovery.
+- Z.ai direct reader remains canonical for reader extraction.
+- Z.ai LLM analysis remains canonical for analysis generation.

--- a/docs/poc/windmill-storage-bakeoff/ARCHITECTURE_RECOMMENDATION.md
+++ b/docs/poc/windmill-storage-bakeoff/ARCHITECTURE_RECOMMENDATION.md
@@ -11,6 +11,8 @@ Adopt a hybrid architecture:
 - Affordabot owns product data invariants through a small domain-command layer or shared package: canonical document identity, idempotency, freshness semantics, artifact references, chunk provenance, sufficiency gates, and analysis output shape.
 - Storage remains boring infrastructure: Postgres/pgvector/MinIO are the durable state systems. Windmill may write operational run reports, but product records should be written through affordabot domain commands.
 
+The final locked boundary, including frontend, Postgres, pgvector, and MinIO ownership, is documented in `docs/architecture/2026-04-12-windmill-affordabot-boundary-adr.md`.
+
 This is not a recommendation to preserve the current monolithic backend cron pattern. The current pattern should still be replaced by Windmill-native DAGs.
 
 ## Evidence Produced
@@ -157,4 +159,3 @@ Should the next implementation build Path B as:
 2. a shared affordabot domain package imported by Windmill worker scripts?
 
 The POC evidence favors the domain boundary either way. The remaining choice is transport/deployment ergonomics, not whether product invariants should live in Windmill.
-

--- a/docs/poc/windmill-storage-bakeoff/ARCHITECTURE_RECOMMENDATION.md
+++ b/docs/poc/windmill-storage-bakeoff/ARCHITECTURE_RECOMMENDATION.md
@@ -1,0 +1,160 @@
+# Architecture Recommendation: Windmill Storage Boundary Bakeoff
+
+Date: 2026-04-12
+Tracking: `bd-jxclm.15` used as temporary reconciliation key while Beads mutations are broken.
+
+## Recommendation
+
+Adopt a hybrid architecture:
+
+- Windmill owns orchestration: schedule/manual trigger, DAG shape, retries, branches, per-jurisdiction fanout, failure handlers, run history, and operator controls.
+- Affordabot owns product data invariants through a small domain-command layer or shared package: canonical document identity, idempotency, freshness semantics, artifact references, chunk provenance, sufficiency gates, and analysis output shape.
+- Storage remains boring infrastructure: Postgres/pgvector/MinIO are the durable state systems. Windmill may write operational run reports, but product records should be written through affordabot domain commands.
+
+This is not a recommendation to preserve the current monolithic backend cron pattern. The current pattern should still be replaced by Windmill-native DAGs.
+
+## Evidence Produced
+
+Two comparable San Jose meeting-minutes POCs were implemented:
+
+- Path A, Windmill-heavy direct storage: `backend/scripts/verification/windmill_bakeoff_direct_storage.py`
+- Path B, Windmill plus affordabot domain boundary: `backend/scripts/verification/windmill_bakeoff_domain_boundary.py`
+
+Both paths exercised:
+
+- SearXNG-shaped search input
+- Z.ai reader-shaped content extraction
+- MinIO-shaped artifact references
+- pgvector-shaped chunk indexing
+- final analysis with evidence references
+- first run
+- rerun/idempotency
+- source failure
+- reader failure
+- storage failure
+- stale-but-usable
+- stale-blocked
+
+Live Windmill/SearXNG/Z.ai/Postgres/MinIO execution was intentionally not used in this pass because agent secret access was restricted after the 1Password popup incident. The local substitutes preserve contract shape but do not prove live service connectivity.
+
+## Path A Findings: Windmill-Heavy Direct Storage
+
+Path A proved that a Windmill/direct-storage implementation can be made to pass the thin slice:
+
+- first run succeeds
+- rerun avoids duplicate documents, chunks, and analysis rows
+- stale-but-usable emits an alert and proceeds
+- stale-blocked fails closed
+- failure states are explicit
+- a Windmill export is present
+
+But the implementation had to recreate domain logic inside the direct-storage runner:
+
+- canonical document key generation
+- content hashing
+- object key construction
+- search snapshot identity
+- document upsert semantics
+- chunk identity and upsert behavior
+- evidence references
+- freshness gates
+- analysis idempotency
+
+The final Path A implementation is also larger:
+
+- direct-storage runner: about 1,000 lines
+- path docs plus flow export: about 1,200 additional lines
+
+The most important architectural signal is that Path A works only by making the Windmill script act like an application backend. A truly Windmill-maximal version would need many granular scripts and explicit state handoff between steps, which moves even more product semantics into Windmill.
+
+## Path B Findings: Windmill Plus Domain Boundary
+
+Path B also passed the same thin slice:
+
+- first run succeeds
+- rerun avoids duplicate search snapshots, documents, artifacts, chunks, and analysis
+- stale-but-usable emits `freshness_gate:stale_but_usable` and proceeds
+- stale-blocked fails closed before read/index/analyze
+- source, reader, and storage failures stop at the correct boundary
+- analysis fails closed when evidence chunks are absent
+- a Windmill flow/script export is present
+- unit tests cover idempotency, stale-blocked behavior, and no-analysis-without-evidence
+
+The Path B domain commands are coarse enough to justify the backend/domain layer:
+
+- `search_materialize`: query-scope snapshot identity
+- `freshness_gate`: freshness policy and zero-result semantics
+- `read_fetch`: canonical document identity and artifact dedupe
+- `index`: chunk provenance and upsert idempotency
+- `analyze`: sufficiency/evidence gate
+- `summarize_run`: links Windmill run IDs to product state counts
+
+The important architectural signal is that Path B keeps Windmill as the orchestration runtime without turning Windmill scripts into the hidden product backend.
+
+## Decision Matrix
+
+| Criterion | Path A: Windmill Direct Storage | Path B: Domain Boundary |
+| --- | --- | --- |
+| Windmill orchestration usage | Medium; flow export exists, but main logic remains one large runner | High; flow can call coarse commands while preserving step graph |
+| Product invariant locality | Weak; invariants live in Windmill/direct-storage code | Strong; invariants are named domain commands |
+| Idempotency | Proven, but hand-implemented in storage runner | Proven and tied to domain commands |
+| Provenance | Proven for thin slice, but assembled inside runner | Proven as domain invariant |
+| Failure behavior | Proven, but warm/cold state must be carefully documented | Proven with clearer step-scoped fail-closed behavior |
+| Testability | Possible, but scripts trend toward a second backend | Better; domain commands can move into normal backend/package tests |
+| Frontend/read-side fit | Needs a read model/API anyway | Natural fit; backend/domain layer owns product views |
+| Risk of reinventing backend in Windmill | High | Lower |
+
+## Architecture To Lock For Next Implementation
+
+Use Windmill as the pipeline application shell, not as the product data owner:
+
+1. Windmill flow: `pipeline_daily_refresh`
+2. Windmill steps:
+   - `search_materialize`
+   - `freshness_gate`
+   - branch on freshness status
+   - `read_fetch`
+   - `index`
+   - `analyze`
+   - `summarize_run`
+3. Windmill native features:
+   - per-step retries/backoff
+   - branch-one/fail-closed behavior
+   - per-jurisdiction loop
+   - schedule and manual trigger
+   - failure handler
+   - run history
+4. Affordabot domain commands:
+   - implemented as a small tested Python package or coarse HTTP endpoints
+   - no low-level `insert_row` / `upload_object` endpoint sprawl
+   - own all Postgres/pgvector/MinIO product writes
+5. Direct Windmill writes:
+   - allowed only for operational reports/log mirrors
+   - not allowed for canonical documents, chunks, analysis outputs, or provenance rows
+
+## What Still Needs Live Validation
+
+This POC is enough for architecture discussion, but not final deployment readiness.
+
+Live validation still needs:
+
+- private/dev SearXNG endpoint call from Windmill
+- Z.ai direct reader call from the same runtime path
+- Z.ai LLM analysis call from the same runtime path
+- Postgres + pgvector write/read using real schema or migration prototype
+- MinIO artifact write/read with real bucket config
+- Windmill run URL evidence from the shared `affordabot` workspace
+- failure handler notification evidence
+- no raw 1Password GUI prompts during the live run
+
+## Strategic HITL Question
+
+The architecture decision to discuss is:
+
+Should the next implementation build Path B as:
+
+1. coarse backend HTTP endpoints called by Windmill, or
+2. a shared affordabot domain package imported by Windmill worker scripts?
+
+The POC evidence favors the domain boundary either way. The remaining choice is transport/deployment ergonomics, not whether product invariants should live in Windmill.
+

--- a/docs/poc/windmill-storage-bakeoff/ARCHITECTURE_RECOMMENDATION.md
+++ b/docs/poc/windmill-storage-bakeoff/ARCHITECTURE_RECOMMENDATION.md
@@ -13,6 +13,8 @@ Adopt a hybrid architecture:
 
 The final locked boundary, including frontend, Postgres, pgvector, and MinIO ownership, is documented in `docs/architecture/2026-04-12-windmill-affordabot-boundary-adr.md`.
 
+The brownfield implementation contract, including exact existing-stack mapping, command contracts, identity, atomicity, concurrency, frontend read models, and two-agent execution waves, is documented in `docs/specs/2026-04-13-windmill-domain-brownfield-spec-lock.md`.
+
 This is not a recommendation to preserve the current monolithic backend cron pattern. The current pattern should still be replaced by Windmill-native DAGs.
 
 ## Evidence Produced

--- a/docs/poc/windmill-storage-bakeoff/OFFLINE_WORKLOG.md
+++ b/docs/poc/windmill-storage-bakeoff/OFFLINE_WORKLOG.md
@@ -1,0 +1,28 @@
+# Offline Worklog: Windmill Storage Boundary Bakeoff
+
+Tracking key: `offline-20260412-windmill-storage-bakeoff`
+Started: 2026-04-12
+Repo: affordabot
+Beads: local Beads mutations are broken; reconcile after infra repair.
+
+## Goal
+
+Gather enough implementation evidence to recommend a final Windmill/affordabot/storage boundary for the San Jose meeting-minutes pipeline.
+
+## Current Hypotheses
+
+- Windmill should own orchestration: DAG, schedules, retries, branch decisions, run logs, operator controls.
+- Affordabot may shrink substantially, but some domain boundary may still be needed for canonical document identity, idempotency, provenance, and analysis sufficiency.
+- Direct Windmill storage writes are viable only if they do not turn Windmill scripts into the hidden product backend.
+
+## Agent Assignments
+
+- Path A: Windmill-heavy direct storage POC.
+- Path B: Windmill orchestration plus affordabot domain-boundary POC.
+
+## Reconcile Later
+
+- Create or update the real Beads issue once infra restores reliable Beads mutations.
+- Link the final PR URL(s), merge commit(s), and architecture recommendation.
+- Close the tracker item if merged.
+

--- a/docs/poc/windmill-storage-bakeoff/README.md
+++ b/docs/poc/windmill-storage-bakeoff/README.md
@@ -1,0 +1,118 @@
+# Windmill Storage Boundary Bakeoff POC
+
+Status: in progress
+Tracking: offline-20260412-windmill-storage-bakeoff
+Beads status: offline because local Beads mutations are broken; reconcile after infra repair.
+
+## Decision Question
+
+Can affordabot pre-MVP be primarily a Windmill DAG application with direct storage writes, or does it still need an affordabot-owned domain boundary for product data writes?
+
+This POC compares two implementation paths against the same San Jose meeting-minutes slice.
+
+## Fixed Slice
+
+- Jurisdiction: `San Jose CA`
+- Source family: `meeting_minutes`
+- Discovery: SearXNG-compatible search endpoint
+- Reader: Z.ai direct web reader when live secrets are available; deterministic local reader stub when secrets are unavailable
+- Analysis: Z.ai LLM when live secrets are available; deterministic local analysis stub when secrets are unavailable
+- Storage target: Postgres/pgvector/MinIO interfaces when live infra is available; deterministic local storage adapter when live infra is unavailable
+
+The POC must separate live-infra blockers from architectural evidence. A local deterministic substitute is acceptable only when it preserves the same contract shape and records the live blocker.
+
+## Path A: Windmill-Heavy Direct Storage
+
+Windmill owns the DAG and calls storage/search/reader/LLM helpers directly.
+
+Expected ownership:
+
+- Windmill flow shape
+- per-step retries/backoff
+- branch on freshness status
+- per-jurisdiction loop shape
+- operational run summary
+- direct writes through storage adapters for search snapshots, artifacts, chunks, and analysis rows
+
+Affordabot should be minimally involved in Path A. If domain logic is needed, document exactly where it starts becoming more than storage glue.
+
+## Path B: Windmill Plus Affordabot Domain Boundary
+
+Windmill owns the DAG, but each step calls a coarse affordabot domain command.
+
+Expected ownership:
+
+- Windmill flow shape
+- per-step retries/backoff
+- branch on freshness status
+- per-jurisdiction loop shape
+- operational run summary
+- affordabot commands for canonical document identity, idempotency, artifact persistence, chunk indexing, analysis sufficiency, and provenance
+
+Affordabot commands must not be thin SQL wrappers. Each command must protect at least one domain invariant.
+
+## Shared Run Envelope
+
+Every step input/output should carry this envelope:
+
+```json
+{
+  "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+  "architecture_path": "windmill_direct_storage | affordabot_domain_boundary",
+  "orchestrator": "windmill",
+  "windmill_workspace": "affordabot",
+  "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_bakeoff",
+  "windmill_run_id": "local-or-live-run-id",
+  "windmill_job_id": "local-or-live-job-id",
+  "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+  "jurisdiction": "San Jose CA",
+  "source_family": "meeting_minutes"
+}
+```
+
+## Required Status Vocabulary
+
+- `fresh`: current result is fresh enough to use.
+- `stale_but_usable`: current result is stale but within fallback ceiling; analysis may continue and must emit an alert.
+- `stale_blocked`: current result exceeds fallback ceiling; analysis must fail closed.
+- `empty_result`: search completed but returned zero candidates; this is not a transport failure.
+- `source_error`: search/source retrieval failed.
+- `reader_error`: reader failed after URL selection.
+- `storage_error`: Postgres/pgvector/MinIO persistence failed.
+- `analysis_error`: LLM analysis failed.
+
+## Required Evidence
+
+Each path must produce:
+
+- first-run result
+- rerun/idempotency result
+- SearXNG failure drill
+- reader failure drill
+- storage failure drill or documented blocker
+- final analysis result
+- provenance chain from final claim to chunk/document/artifact/search snapshot
+- Windmill flow export or executable local Windmill-shaped flow surrogate
+- storage snapshots before and after rerun
+- implementation complexity notes
+
+## Pass/Fail Criteria
+
+Architecture evidence is sufficient only if both paths can be compared on:
+
+- whether the code stayed understandable
+- whether reruns avoided duplicate product records
+- whether Windmill-native retries/branches/logs were enough
+- whether storage writes were safe without spreading product invariants
+- whether frontend/read-side consumption would be straightforward
+- whether live infra blockers are operational rather than architectural
+
+## Guardrails
+
+- Do not run raw `op read`, `op item get`, `op item list`, or `op whoami`.
+- Do not mutate Beads while local Beads is broken.
+- Do not write secrets into repo files, logs, Windmill exports, or artifacts.
+- Do not make irreversible live infrastructure changes.
+- Prefer committed Windmill flow/script exports over live-only edits.
+- Keep Path A and Path B write scopes separate.
+

--- a/docs/poc/windmill-storage-bakeoff/path-a-direct-storage/README.md
+++ b/docs/poc/windmill-storage-bakeoff/path-a-direct-storage/README.md
@@ -1,0 +1,46 @@
+# Path A Direct Storage (Windmill-Heavy)
+
+This implementation captures the Path A bakeoff for the San Jose meeting-minutes slice with a Windmill-shaped DAG that performs direct storage interactions without affordabot backend domain endpoints.
+
+## Scope
+
+- Orchestration model: Windmill-owned step graph (`search_materialize`, `freshness_gate`, `read_fetch`, `index_chunks`, `analyze`) plus failure drills.
+- Storage model: direct writes through local deterministic adapters that mirror:
+  - MinIO object refs (`minio://...`)
+  - pgvector-like chunk storage/query
+  - Postgres-like relational rows for snapshots/documents/analysis/runs
+- Search/reader/analysis:
+  - SearXNG-compatible payload shape
+  - Z.ai reader and LLM contract shapes
+  - deterministic local fallbacks when live infra/secrets are unavailable
+
+## Files
+
+- Runner: `backend/scripts/verification/windmill_bakeoff_direct_storage.py`
+- Windmill script export: `ops/windmill/f/affordabot/pipeline_daily_refresh_direct_storage.py`
+- Windmill script schema: `ops/windmill/f/affordabot/pipeline_daily_refresh_direct_storage.script.yaml`
+- Windmill flow export: `ops/windmill/f/affordabot/pipeline_daily_refresh_direct_storage__flow/flow.yaml`
+- Evidence:
+  - `run-evidence.md`
+  - `storage-snapshots.md`
+  - `failure-drills.md`
+  - `suite-results.json`
+
+## Architectural Finding (Path A)
+
+Path A is viable for a thin pre-MVP slice, but direct-storage logic quickly starts re-creating product invariants in the flow layer:
+
+- canonical document identity (`canonical_document_key`)
+- idempotent artifact keys (content-hash/idempotency scoped refs)
+- chunk deduplication and upsert semantics
+- analysis upsert semantics by idempotency key
+- status vocabulary enforcement for failure/freshness outcomes
+
+In short: Windmill can own orchestration well, but pure direct storage writes force orchestration code to absorb domain responsibilities unless those invariants are moved into reusable domain commands/libraries.
+
+## Live Infra Blockers in This Run
+
+- `SEARX_ENDPOINT` not configured in this environment, so deterministic SearX fixture used.
+- `ZAI_API_KEY` not available for this run, so reader/analysis used deterministic contract-shape substitutes.
+
+Both blockers are operational. The flow and storage-boundary behavior were still exercised with stable deterministic fixtures.

--- a/docs/poc/windmill-storage-bakeoff/path-a-direct-storage/README.md
+++ b/docs/poc/windmill-storage-bakeoff/path-a-direct-storage/README.md
@@ -12,7 +12,11 @@ This implementation captures the Path A bakeoff for the San Jose meeting-minutes
 - Search/reader/analysis:
   - SearXNG-compatible payload shape
   - Z.ai reader and LLM contract shapes
-  - deterministic local fallbacks when live infra/secrets are unavailable
+- deterministic local fallbacks when live infra/secrets are unavailable
+
+Interpretation note:
+- The current Windmill export demonstrates flow shape and retry wiring, but most execution remains concentrated in one script entrypoint.
+- This is useful for Path A boundary evidence, not proof of full Windmill-native step decomposition.
 
 ## Files
 
@@ -37,6 +41,15 @@ Path A is viable for a thin pre-MVP slice, but direct-storage logic quickly star
 - status vocabulary enforcement for failure/freshness outcomes
 
 In short: Windmill can own orchestration well, but pure direct storage writes force orchestration code to absorb domain responsibilities unless those invariants are moved into reusable domain commands/libraries.
+
+Additional limitation:
+- To be maximally Windmill-native, this path would need explicit per-step state passing with smaller scripts (or a shared execution context contract between scripts). Without that, one Windmill script becomes a de facto backend pipeline implementation.
+
+## Failure Drill Interpretation
+
+- Warm-state drills (executed after successful baseline run) show fallback behavior with previously materialized state present.
+- Cold-state drills (isolated state dir per drill) show failure behavior without prior state.
+- Both views are included in `failure-drills.md` and `suite-results.json`.
 
 ## Live Infra Blockers in This Run
 

--- a/docs/poc/windmill-storage-bakeoff/path-a-direct-storage/failure-drills.md
+++ b/docs/poc/windmill-storage-bakeoff/path-a-direct-storage/failure-drills.md
@@ -1,0 +1,10 @@
+# Path A Failure Drills
+
+- `searx_failure` => status `source_error` reason `simulated_searx_failure`
+- `reader_failure` => status `reader_error` reason `simulated_reader_failure`
+- `storage_failure` => status `storage_error` reason `simulated_storage_error`
+
+Expected terminal statuses:
+- SearXNG failure => `source_error`
+- Reader failure => `reader_error`
+- Storage failure => `storage_error`

--- a/docs/poc/windmill-storage-bakeoff/path-a-direct-storage/failure-drills.md
+++ b/docs/poc/windmill-storage-bakeoff/path-a-direct-storage/failure-drills.md
@@ -1,8 +1,16 @@
 # Path A Failure Drills
 
-- `searx_failure` => status `source_error` reason `simulated_searx_failure`
-- `reader_failure` => status `reader_error` reason `simulated_reader_failure`
-- `storage_failure` => status `storage_error` reason `simulated_storage_error`
+## Warm-State Failures (after successful baseline run)
+
+- `searx_failure` => status `source_error` reason `simulated_searx_failure` objects `3`
+- `reader_failure` => status `reader_error` reason `simulated_reader_failure` objects `3`
+- `storage_failure` => status `storage_error` reason `simulated_storage_error` objects `3`
+
+## Cold-State Failures (isolated fresh state per drill)
+
+- `searx_failure` => status `source_error` reason `simulated_searx_failure` objects `0` state_dir `docs/poc/windmill-storage-bakeoff/path-a-direct-storage/runtime_state__cold_searx_failure`
+- `reader_failure` => status `reader_error` reason `simulated_reader_failure` objects `1` state_dir `docs/poc/windmill-storage-bakeoff/path-a-direct-storage/runtime_state__cold_reader_failure`
+- `storage_failure` => status `storage_error` reason `simulated_storage_error` objects `0` state_dir `docs/poc/windmill-storage-bakeoff/path-a-direct-storage/runtime_state__cold_storage_failure`
 
 Expected terminal statuses:
 - SearXNG failure => `source_error`

--- a/docs/poc/windmill-storage-bakeoff/path-a-direct-storage/run-evidence.md
+++ b/docs/poc/windmill-storage-bakeoff/path-a-direct-storage/run-evidence.md
@@ -32,3 +32,20 @@ Computed checks:
 - chunks stable: `True`
 - analyses stable: `True`
 - overall idempotent: `True`
+
+## Freshness Gate Drills
+
+- stale usable status: `succeeded`
+- stale usable alert count: `1`
+- stale usable freshness step: `stale_but_usable`
+- stale blocked status: `stale_blocked`
+- stale blocked reason: `age_hours=96.00`
+- stale blocked terminal freshness step: `stale_blocked`
+
+## Windmill Mapping Limitation
+
+The committed flow export is Windmill-shaped, but Path A execution still concentrates
+most domain-like behavior in one script implementation. This proves direct-storage viability,
+not full Windmill-native step decomposition. A truly maximal Windmill implementation would
+require step-level storage context handoff or more granular scripts, which shifts more domain
+invariants into Windmill code.

--- a/docs/poc/windmill-storage-bakeoff/path-a-direct-storage/run-evidence.md
+++ b/docs/poc/windmill-storage-bakeoff/path-a-direct-storage/run-evidence.md
@@ -1,0 +1,34 @@
+# Path A Run Evidence
+
+Contract version: `2026-04-12.windmill-storage-bakeoff.v1`
+Architecture path: `windmill_direct_storage`
+
+## First Run
+
+- status: `succeeded`
+- reason: `completed`
+- search results: `3`
+- objects total: `3`
+- chunks total: `1`
+- documents total: `1`
+- analyses total: `1`
+
+## Rerun (Idempotency)
+
+- status: `succeeded`
+- reason: `completed`
+- objects total: `3`
+- chunks total: `1`
+- documents total: `1`
+- analyses total: `1`
+
+Idempotency assertion:
+- canonical documents should remain stable across rerun with same idempotency key
+- vector chunks should be reused rather than duplicated
+- analysis row should be upserted by idempotency key
+
+Computed checks:
+- documents stable: `True`
+- chunks stable: `True`
+- analyses stable: `True`
+- overall idempotent: `True`

--- a/docs/poc/windmill-storage-bakeoff/path-a-direct-storage/storage-snapshots.md
+++ b/docs/poc/windmill-storage-bakeoff/path-a-direct-storage/storage-snapshots.md
@@ -1,0 +1,53 @@
+# Path A Storage Snapshots
+
+## First Run Snapshot
+
+```json
+{
+  "object_store": {
+    "keys": [
+      "documents/sanjoseca-gov-your-government-departments-offices-city-clerk-city-council-meetings/reader/52e6d8a43914d77c.md",
+      "idempotency/san-jose-ca:meeting_minutes:2026-04-12/analysis/69e1e31c34f41ea6.json",
+      "idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json"
+    ],
+    "object_count": 3
+  },
+  "relational_store": {
+    "analysis_count": 1,
+    "document_count": 1,
+    "search_snapshot_count": 1
+  },
+  "vector_store": {
+    "chunk_count": 1,
+    "chunk_ids": [
+      "sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meetings::chunk-0::712bf03ddc3f"
+    ]
+  }
+}
+```
+
+## Rerun Snapshot
+
+```json
+{
+  "object_store": {
+    "keys": [
+      "documents/sanjoseca-gov-your-government-departments-offices-city-clerk-city-council-meetings/reader/52e6d8a43914d77c.md",
+      "idempotency/san-jose-ca:meeting_minutes:2026-04-12/analysis/69e1e31c34f41ea6.json",
+      "idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json"
+    ],
+    "object_count": 3
+  },
+  "relational_store": {
+    "analysis_count": 1,
+    "document_count": 1,
+    "search_snapshot_count": 1
+  },
+  "vector_store": {
+    "chunk_count": 1,
+    "chunk_ids": [
+      "sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meetings::chunk-0::712bf03ddc3f"
+    ]
+  }
+}
+```

--- a/docs/poc/windmill-storage-bakeoff/path-a-direct-storage/suite-results.json
+++ b/docs/poc/windmill-storage-bakeoff/path-a-direct-storage/suite-results.json
@@ -1,0 +1,372 @@
+{
+  "checks": {
+    "analyses_stable": true,
+    "chunks_stable": true,
+    "documents_stable": true,
+    "idempotent": true
+  },
+  "failures": {
+    "reader_failure": {
+      "alerts": [],
+      "analysis_preview": null,
+      "counts": {
+        "analyses_total": 1,
+        "chunks_total": 1,
+        "documents_total": 1,
+        "objects_total": 3,
+        "search_results": 3
+      },
+      "created_at": "2026-04-12T17:19:09.349195+00:00",
+      "envelope": {
+        "architecture_path": "windmill_direct_storage",
+        "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+        "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+        "jurisdiction": "San Jose CA",
+        "orchestrator": "windmill",
+        "source_family": "meeting_minutes",
+        "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_direct_storage",
+        "windmill_job_id": "job-local-6a37a66a-d465-4074-837a-c2a9c85962a7",
+        "windmill_run_id": "local-6a37a66a-d465-4074-837a-c2a9c85962a7",
+        "windmill_workspace": "affordabot"
+      },
+      "reason": "simulated_reader_failure",
+      "scenario": "reader_failure",
+      "status": "reader_error",
+      "steps": [
+        {
+          "artifact_ref": "minio://affordabot-artifacts/idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json#b0f216d429a0dc71d70720b8304c1816c248eab1c58f28d1b31b639101efaf62",
+          "result_count": 3,
+          "snapshot_created": false,
+          "snapshot_id": "san-jose-ca:meeting_minutes:2026-04-12::535a80471cc2cdd4",
+          "status": "succeeded",
+          "step": "search_materialize"
+        },
+        {
+          "reason": "age_hours=0.00",
+          "status": "fresh",
+          "step": "freshness_gate"
+        },
+        {
+          "error": "simulated_reader_failure",
+          "status": "reader_error",
+          "step": "read_fetch"
+        }
+      ],
+      "storage_snapshot": {
+        "object_store": {
+          "keys": [
+            "documents/sanjoseca-gov-your-government-departments-offices-city-clerk-city-council-meetings/reader/52e6d8a43914d77c.md",
+            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/analysis/69e1e31c34f41ea6.json",
+            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json"
+          ],
+          "object_count": 3
+        },
+        "relational_store": {
+          "analysis_count": 1,
+          "document_count": 1,
+          "search_snapshot_count": 1
+        },
+        "vector_store": {
+          "chunk_count": 1,
+          "chunk_ids": [
+            "sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meetings::chunk-0::712bf03ddc3f"
+          ]
+        }
+      }
+    },
+    "searx_failure": {
+      "alerts": [],
+      "analysis_preview": null,
+      "counts": {
+        "analyses_total": 1,
+        "chunks_total": 1,
+        "documents_total": 1,
+        "objects_total": 3,
+        "search_results": 0
+      },
+      "created_at": "2026-04-12T17:19:09.349006+00:00",
+      "envelope": {
+        "architecture_path": "windmill_direct_storage",
+        "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+        "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+        "jurisdiction": "San Jose CA",
+        "orchestrator": "windmill",
+        "source_family": "meeting_minutes",
+        "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_direct_storage",
+        "windmill_job_id": "job-local-320275f7-7e7d-402b-b22d-209fc974419a",
+        "windmill_run_id": "local-320275f7-7e7d-402b-b22d-209fc974419a",
+        "windmill_workspace": "affordabot"
+      },
+      "reason": "simulated_searx_failure",
+      "scenario": "searx_failure",
+      "status": "source_error",
+      "steps": [
+        {
+          "error": "simulated_searx_failure",
+          "status": "source_error",
+          "step": "search_materialize"
+        }
+      ],
+      "storage_snapshot": {
+        "object_store": {
+          "keys": [
+            "documents/sanjoseca-gov-your-government-departments-offices-city-clerk-city-council-meetings/reader/52e6d8a43914d77c.md",
+            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/analysis/69e1e31c34f41ea6.json",
+            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json"
+          ],
+          "object_count": 3
+        },
+        "relational_store": {
+          "analysis_count": 1,
+          "document_count": 1,
+          "search_snapshot_count": 1
+        },
+        "vector_store": {
+          "chunk_count": 1,
+          "chunk_ids": [
+            "sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meetings::chunk-0::712bf03ddc3f"
+          ]
+        }
+      }
+    },
+    "storage_failure": {
+      "alerts": [],
+      "analysis_preview": null,
+      "counts": {
+        "analyses_total": 1,
+        "chunks_total": 1,
+        "documents_total": 1,
+        "objects_total": 3,
+        "search_results": 3
+      },
+      "created_at": "2026-04-12T17:19:09.349651+00:00",
+      "envelope": {
+        "architecture_path": "windmill_direct_storage",
+        "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+        "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+        "jurisdiction": "San Jose CA",
+        "orchestrator": "windmill",
+        "source_family": "meeting_minutes",
+        "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_direct_storage",
+        "windmill_job_id": "job-local-5bd21465-cfd1-4f43-a250-cf904fe6c358",
+        "windmill_run_id": "local-5bd21465-cfd1-4f43-a250-cf904fe6c358",
+        "windmill_workspace": "affordabot"
+      },
+      "reason": "simulated_storage_error",
+      "scenario": "storage_failure",
+      "status": "storage_error",
+      "steps": [
+        {
+          "error": "simulated_storage_error",
+          "status": "storage_error",
+          "step": "search_materialize"
+        }
+      ],
+      "storage_snapshot": {
+        "object_store": {
+          "keys": [
+            "documents/sanjoseca-gov-your-government-departments-offices-city-clerk-city-council-meetings/reader/52e6d8a43914d77c.md",
+            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/analysis/69e1e31c34f41ea6.json",
+            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json"
+          ],
+          "object_count": 3
+        },
+        "relational_store": {
+          "analysis_count": 1,
+          "document_count": 1,
+          "search_snapshot_count": 1
+        },
+        "vector_store": {
+          "chunk_count": 1,
+          "chunk_ids": [
+            "sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meetings::chunk-0::712bf03ddc3f"
+          ]
+        }
+      }
+    }
+  },
+  "generated_at": "2026-04-12T17:19:09.349837+00:00",
+  "live_blockers": [
+    "SEARX_ENDPOINT not configured; used deterministic SearX fixture.",
+    "Z.ai reader/analysis live call unavailable; used deterministic contract-shape substitutes."
+  ],
+  "live_flags": {
+    "allow_live_zai": false,
+    "searx_endpoint_configured": false,
+    "zai_api_key_present": false
+  },
+  "run_date": "2026-04-12",
+  "runs": {
+    "first": {
+      "alerts": [],
+      "analysis_preview": "San Jose meeting minutes indicate transit funding decisions and housing permit acceleration updates were discussed in recent sessions.",
+      "counts": {
+        "analyses_total": 1,
+        "chunks_total": 1,
+        "documents_total": 1,
+        "objects_total": 3,
+        "search_results": 3
+      },
+      "created_at": "2026-04-12T17:19:09.346009+00:00",
+      "envelope": {
+        "architecture_path": "windmill_direct_storage",
+        "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+        "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+        "jurisdiction": "San Jose CA",
+        "orchestrator": "windmill",
+        "source_family": "meeting_minutes",
+        "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_direct_storage",
+        "windmill_job_id": "job-local-f2b23d63-0eaf-4c06-98bc-5b488d562ace",
+        "windmill_run_id": "local-f2b23d63-0eaf-4c06-98bc-5b488d562ace",
+        "windmill_workspace": "affordabot"
+      },
+      "reason": "completed",
+      "scenario": "normal",
+      "status": "succeeded",
+      "steps": [
+        {
+          "artifact_ref": "minio://affordabot-artifacts/idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json#b0f216d429a0dc71d70720b8304c1816c248eab1c58f28d1b31b639101efaf62",
+          "result_count": 3,
+          "snapshot_created": true,
+          "snapshot_id": "san-jose-ca:meeting_minutes:2026-04-12::535a80471cc2cdd4",
+          "status": "succeeded",
+          "step": "search_materialize"
+        },
+        {
+          "reason": "age_hours=0.00",
+          "status": "fresh",
+          "step": "freshness_gate"
+        },
+        {
+          "artifact_ref": "minio://affordabot-artifacts/documents/sanjoseca-gov-your-government-departments-offices-city-clerk-city-council-meetings/reader/52e6d8a43914d77c.md#52e6d8a43914d77c7e131fc1420160385cedd325b800eb313d7c8f3c51e60502",
+          "canonical_document_key": "sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meetings",
+          "document_created": true,
+          "reader_mode": "deterministic",
+          "status": "succeeded",
+          "step": "read_fetch"
+        },
+        {
+          "chunks_created": 1,
+          "chunks_reused": 0,
+          "chunks_total_for_document": 1,
+          "status": "succeeded",
+          "step": "index_chunks"
+        },
+        {
+          "analysis_artifact_ref": "minio://affordabot-artifacts/idempotency/san-jose-ca:meeting_minutes:2026-04-12/analysis/69e1e31c34f41ea6.json#6ef14f3decf189c7f1fa6e1c2537c6ee70ceee7ae1c9128154a42edcc510f35d",
+          "analysis_created": true,
+          "analysis_mode": "deterministic",
+          "status": "succeeded",
+          "step": "analyze"
+        }
+      ],
+      "storage_snapshot": {
+        "object_store": {
+          "keys": [
+            "documents/sanjoseca-gov-your-government-departments-offices-city-clerk-city-council-meetings/reader/52e6d8a43914d77c.md",
+            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/analysis/69e1e31c34f41ea6.json",
+            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json"
+          ],
+          "object_count": 3
+        },
+        "relational_store": {
+          "analysis_count": 1,
+          "document_count": 1,
+          "search_snapshot_count": 1
+        },
+        "vector_store": {
+          "chunk_count": 1,
+          "chunk_ids": [
+            "sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meetings::chunk-0::712bf03ddc3f"
+          ]
+        }
+      }
+    },
+    "rerun": {
+      "alerts": [],
+      "analysis_preview": "San Jose meeting minutes indicate transit funding decisions and housing permit acceleration updates were discussed in recent sessions.",
+      "counts": {
+        "analyses_total": 1,
+        "chunks_total": 1,
+        "documents_total": 1,
+        "objects_total": 3,
+        "search_results": 3
+      },
+      "created_at": "2026-04-12T17:19:09.347826+00:00",
+      "envelope": {
+        "architecture_path": "windmill_direct_storage",
+        "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+        "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+        "jurisdiction": "San Jose CA",
+        "orchestrator": "windmill",
+        "source_family": "meeting_minutes",
+        "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_direct_storage",
+        "windmill_job_id": "job-local-17377228-ab0b-4657-94b4-52d6ded0c1c2",
+        "windmill_run_id": "local-17377228-ab0b-4657-94b4-52d6ded0c1c2",
+        "windmill_workspace": "affordabot"
+      },
+      "reason": "completed",
+      "scenario": "normal",
+      "status": "succeeded",
+      "steps": [
+        {
+          "artifact_ref": "minio://affordabot-artifacts/idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json#b0f216d429a0dc71d70720b8304c1816c248eab1c58f28d1b31b639101efaf62",
+          "result_count": 3,
+          "snapshot_created": false,
+          "snapshot_id": "san-jose-ca:meeting_minutes:2026-04-12::535a80471cc2cdd4",
+          "status": "succeeded",
+          "step": "search_materialize"
+        },
+        {
+          "reason": "age_hours=0.00",
+          "status": "fresh",
+          "step": "freshness_gate"
+        },
+        {
+          "artifact_ref": "minio://affordabot-artifacts/documents/sanjoseca-gov-your-government-departments-offices-city-clerk-city-council-meetings/reader/52e6d8a43914d77c.md#52e6d8a43914d77c7e131fc1420160385cedd325b800eb313d7c8f3c51e60502",
+          "canonical_document_key": "sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meetings",
+          "document_created": false,
+          "reader_mode": "deterministic",
+          "status": "succeeded",
+          "step": "read_fetch"
+        },
+        {
+          "chunks_created": 0,
+          "chunks_reused": 1,
+          "chunks_total_for_document": 1,
+          "status": "succeeded",
+          "step": "index_chunks"
+        },
+        {
+          "analysis_artifact_ref": "minio://affordabot-artifacts/idempotency/san-jose-ca:meeting_minutes:2026-04-12/analysis/69e1e31c34f41ea6.json#6ef14f3decf189c7f1fa6e1c2537c6ee70ceee7ae1c9128154a42edcc510f35d",
+          "analysis_created": false,
+          "analysis_mode": "deterministic",
+          "status": "succeeded",
+          "step": "analyze"
+        }
+      ],
+      "storage_snapshot": {
+        "object_store": {
+          "keys": [
+            "documents/sanjoseca-gov-your-government-departments-offices-city-clerk-city-council-meetings/reader/52e6d8a43914d77c.md",
+            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/analysis/69e1e31c34f41ea6.json",
+            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json"
+          ],
+          "object_count": 3
+        },
+        "relational_store": {
+          "analysis_count": 1,
+          "document_count": 1,
+          "search_snapshot_count": 1
+        },
+        "vector_store": {
+          "chunk_count": 1,
+          "chunk_ids": [
+            "sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meetings::chunk-0::712bf03ddc3f"
+          ]
+        }
+      }
+    }
+  },
+  "state_dir": "docs/poc/windmill-storage-bakeoff/path-a-direct-storage/runtime_state"
+}

--- a/docs/poc/windmill-storage-bakeoff/path-a-direct-storage/suite-results.json
+++ b/docs/poc/windmill-storage-bakeoff/path-a-direct-storage/suite-results.json
@@ -3,189 +3,367 @@
     "analyses_stable": true,
     "chunks_stable": true,
     "documents_stable": true,
-    "idempotent": true
+    "idempotent": true,
+    "stale_blocked_status": true,
+    "stale_usable_alerted": true,
+    "stale_usable_status": true
   },
   "failures": {
-    "reader_failure": {
-      "alerts": [],
-      "analysis_preview": null,
-      "counts": {
-        "analyses_total": 1,
-        "chunks_total": 1,
-        "documents_total": 1,
-        "objects_total": 3,
-        "search_results": 3
-      },
-      "created_at": "2026-04-12T17:19:09.349195+00:00",
-      "envelope": {
-        "architecture_path": "windmill_direct_storage",
-        "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
-        "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
-        "jurisdiction": "San Jose CA",
-        "orchestrator": "windmill",
-        "source_family": "meeting_minutes",
-        "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_direct_storage",
-        "windmill_job_id": "job-local-6a37a66a-d465-4074-837a-c2a9c85962a7",
-        "windmill_run_id": "local-6a37a66a-d465-4074-837a-c2a9c85962a7",
-        "windmill_workspace": "affordabot"
-      },
-      "reason": "simulated_reader_failure",
-      "scenario": "reader_failure",
-      "status": "reader_error",
-      "steps": [
-        {
-          "artifact_ref": "minio://affordabot-artifacts/idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json#b0f216d429a0dc71d70720b8304c1816c248eab1c58f28d1b31b639101efaf62",
-          "result_count": 3,
-          "snapshot_created": false,
-          "snapshot_id": "san-jose-ca:meeting_minutes:2026-04-12::535a80471cc2cdd4",
-          "status": "succeeded",
-          "step": "search_materialize"
-        },
-        {
-          "reason": "age_hours=0.00",
-          "status": "fresh",
-          "step": "freshness_gate"
-        },
-        {
-          "error": "simulated_reader_failure",
+    "cold_state": {
+      "reader_failure": {
+        "result": {
+          "alerts": [],
+          "analysis_preview": null,
+          "counts": {
+            "analyses_total": 0,
+            "chunks_total": 0,
+            "documents_total": 0,
+            "objects_total": 1,
+            "search_results": 3
+          },
+          "created_at": "2026-04-12T17:25:01.107428+00:00",
+          "envelope": {
+            "architecture_path": "windmill_direct_storage",
+            "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+            "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+            "jurisdiction": "San Jose CA",
+            "orchestrator": "windmill",
+            "source_family": "meeting_minutes",
+            "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_direct_storage",
+            "windmill_job_id": "job-local-06c5f79b-6eef-485e-8247-a8fdf6ca0c30",
+            "windmill_run_id": "local-06c5f79b-6eef-485e-8247-a8fdf6ca0c30",
+            "windmill_workspace": "affordabot"
+          },
+          "reason": "simulated_reader_failure",
+          "scenario": "reader_failure",
           "status": "reader_error",
-          "step": "read_fetch"
-        }
-      ],
-      "storage_snapshot": {
-        "object_store": {
-          "keys": [
-            "documents/sanjoseca-gov-your-government-departments-offices-city-clerk-city-council-meetings/reader/52e6d8a43914d77c.md",
-            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/analysis/69e1e31c34f41ea6.json",
-            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json"
+          "steps": [
+            {
+              "artifact_ref": "minio://affordabot-artifacts/idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json#b0f216d429a0dc71d70720b8304c1816c248eab1c58f28d1b31b639101efaf62",
+              "result_count": 3,
+              "snapshot_created": true,
+              "snapshot_id": "san-jose-ca:meeting_minutes:2026-04-12::535a80471cc2cdd4",
+              "status": "succeeded",
+              "step": "search_materialize"
+            },
+            {
+              "reason": "age_hours=0.00",
+              "status": "fresh",
+              "step": "freshness_gate"
+            },
+            {
+              "error": "simulated_reader_failure",
+              "status": "reader_error",
+              "step": "read_fetch"
+            }
           ],
-          "object_count": 3
+          "storage_snapshot": {
+            "object_store": {
+              "keys": [
+                "idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json"
+              ],
+              "object_count": 1
+            },
+            "relational_store": {
+              "analysis_count": 0,
+              "document_count": 0,
+              "search_snapshot_count": 1
+            },
+            "vector_store": {
+              "chunk_count": 0,
+              "chunk_ids": []
+            }
+          }
         },
-        "relational_store": {
-          "analysis_count": 1,
-          "document_count": 1,
-          "search_snapshot_count": 1
-        },
-        "vector_store": {
-          "chunk_count": 1,
-          "chunk_ids": [
-            "sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meetings::chunk-0::712bf03ddc3f"
-          ]
-        }
-      }
-    },
-    "searx_failure": {
-      "alerts": [],
-      "analysis_preview": null,
-      "counts": {
-        "analyses_total": 1,
-        "chunks_total": 1,
-        "documents_total": 1,
-        "objects_total": 3,
-        "search_results": 0
+        "state_dir": "docs/poc/windmill-storage-bakeoff/path-a-direct-storage/runtime_state__cold_reader_failure"
       },
-      "created_at": "2026-04-12T17:19:09.349006+00:00",
-      "envelope": {
-        "architecture_path": "windmill_direct_storage",
-        "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
-        "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
-        "jurisdiction": "San Jose CA",
-        "orchestrator": "windmill",
-        "source_family": "meeting_minutes",
-        "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_direct_storage",
-        "windmill_job_id": "job-local-320275f7-7e7d-402b-b22d-209fc974419a",
-        "windmill_run_id": "local-320275f7-7e7d-402b-b22d-209fc974419a",
-        "windmill_workspace": "affordabot"
-      },
-      "reason": "simulated_searx_failure",
-      "scenario": "searx_failure",
-      "status": "source_error",
-      "steps": [
-        {
-          "error": "simulated_searx_failure",
+      "searx_failure": {
+        "result": {
+          "alerts": [],
+          "analysis_preview": null,
+          "counts": {
+            "analyses_total": 0,
+            "chunks_total": 0,
+            "documents_total": 0,
+            "objects_total": 0,
+            "search_results": 0
+          },
+          "created_at": "2026-04-12T17:25:01.107145+00:00",
+          "envelope": {
+            "architecture_path": "windmill_direct_storage",
+            "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+            "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+            "jurisdiction": "San Jose CA",
+            "orchestrator": "windmill",
+            "source_family": "meeting_minutes",
+            "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_direct_storage",
+            "windmill_job_id": "job-local-c1ec90f8-3df0-4049-9cfd-99a922977c63",
+            "windmill_run_id": "local-c1ec90f8-3df0-4049-9cfd-99a922977c63",
+            "windmill_workspace": "affordabot"
+          },
+          "reason": "simulated_searx_failure",
+          "scenario": "searx_failure",
           "status": "source_error",
-          "step": "search_materialize"
-        }
-      ],
-      "storage_snapshot": {
-        "object_store": {
-          "keys": [
-            "documents/sanjoseca-gov-your-government-departments-offices-city-clerk-city-council-meetings/reader/52e6d8a43914d77c.md",
-            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/analysis/69e1e31c34f41ea6.json",
-            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json"
+          "steps": [
+            {
+              "error": "simulated_searx_failure",
+              "status": "source_error",
+              "step": "search_materialize"
+            }
           ],
-          "object_count": 3
+          "storage_snapshot": {
+            "object_store": {
+              "keys": [],
+              "object_count": 0
+            },
+            "relational_store": {
+              "analysis_count": 0,
+              "document_count": 0,
+              "search_snapshot_count": 0
+            },
+            "vector_store": {
+              "chunk_count": 0,
+              "chunk_ids": []
+            }
+          }
         },
-        "relational_store": {
-          "analysis_count": 1,
-          "document_count": 1,
-          "search_snapshot_count": 1
+        "state_dir": "docs/poc/windmill-storage-bakeoff/path-a-direct-storage/runtime_state__cold_searx_failure"
+      },
+      "storage_failure": {
+        "result": {
+          "alerts": [],
+          "analysis_preview": null,
+          "counts": {
+            "analyses_total": 0,
+            "chunks_total": 0,
+            "documents_total": 0,
+            "objects_total": 0,
+            "search_results": 3
+          },
+          "created_at": "2026-04-12T17:25:01.108081+00:00",
+          "envelope": {
+            "architecture_path": "windmill_direct_storage",
+            "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+            "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+            "jurisdiction": "San Jose CA",
+            "orchestrator": "windmill",
+            "source_family": "meeting_minutes",
+            "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_direct_storage",
+            "windmill_job_id": "job-local-a28a0e70-ee18-448e-95ac-9dfe04d9a321",
+            "windmill_run_id": "local-a28a0e70-ee18-448e-95ac-9dfe04d9a321",
+            "windmill_workspace": "affordabot"
+          },
+          "reason": "simulated_storage_error",
+          "scenario": "storage_failure",
+          "status": "storage_error",
+          "steps": [
+            {
+              "error": "simulated_storage_error",
+              "status": "storage_error",
+              "step": "search_materialize"
+            }
+          ],
+          "storage_snapshot": {
+            "object_store": {
+              "keys": [],
+              "object_count": 0
+            },
+            "relational_store": {
+              "analysis_count": 0,
+              "document_count": 0,
+              "search_snapshot_count": 0
+            },
+            "vector_store": {
+              "chunk_count": 0,
+              "chunk_ids": []
+            }
+          }
         },
-        "vector_store": {
-          "chunk_count": 1,
-          "chunk_ids": [
-            "sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meetings::chunk-0::712bf03ddc3f"
-          ]
-        }
+        "state_dir": "docs/poc/windmill-storage-bakeoff/path-a-direct-storage/runtime_state__cold_storage_failure"
       }
     },
-    "storage_failure": {
-      "alerts": [],
-      "analysis_preview": null,
-      "counts": {
-        "analyses_total": 1,
-        "chunks_total": 1,
-        "documents_total": 1,
-        "objects_total": 3,
-        "search_results": 3
-      },
-      "created_at": "2026-04-12T17:19:09.349651+00:00",
-      "envelope": {
-        "architecture_path": "windmill_direct_storage",
-        "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
-        "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
-        "jurisdiction": "San Jose CA",
-        "orchestrator": "windmill",
-        "source_family": "meeting_minutes",
-        "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_direct_storage",
-        "windmill_job_id": "job-local-5bd21465-cfd1-4f43-a250-cf904fe6c358",
-        "windmill_run_id": "local-5bd21465-cfd1-4f43-a250-cf904fe6c358",
-        "windmill_workspace": "affordabot"
-      },
-      "reason": "simulated_storage_error",
-      "scenario": "storage_failure",
-      "status": "storage_error",
-      "steps": [
-        {
-          "error": "simulated_storage_error",
-          "status": "storage_error",
-          "step": "search_materialize"
+    "warm_state": {
+      "reader_failure": {
+        "alerts": [],
+        "analysis_preview": null,
+        "counts": {
+          "analyses_total": 1,
+          "chunks_total": 1,
+          "documents_total": 1,
+          "objects_total": 3,
+          "search_results": 3
+        },
+        "created_at": "2026-04-12T17:25:01.106195+00:00",
+        "envelope": {
+          "architecture_path": "windmill_direct_storage",
+          "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+          "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+          "jurisdiction": "San Jose CA",
+          "orchestrator": "windmill",
+          "source_family": "meeting_minutes",
+          "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_direct_storage",
+          "windmill_job_id": "job-local-9729f647-51b4-4a3b-886e-87e210413b2b",
+          "windmill_run_id": "local-9729f647-51b4-4a3b-886e-87e210413b2b",
+          "windmill_workspace": "affordabot"
+        },
+        "reason": "simulated_reader_failure",
+        "scenario": "reader_failure",
+        "status": "reader_error",
+        "steps": [
+          {
+            "artifact_ref": "minio://affordabot-artifacts/idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json#b0f216d429a0dc71d70720b8304c1816c248eab1c58f28d1b31b639101efaf62",
+            "result_count": 3,
+            "snapshot_created": false,
+            "snapshot_id": "san-jose-ca:meeting_minutes:2026-04-12::535a80471cc2cdd4",
+            "status": "succeeded",
+            "step": "search_materialize"
+          },
+          {
+            "reason": "age_hours=0.00",
+            "status": "fresh",
+            "step": "freshness_gate"
+          },
+          {
+            "error": "simulated_reader_failure",
+            "status": "reader_error",
+            "step": "read_fetch"
+          }
+        ],
+        "storage_snapshot": {
+          "object_store": {
+            "keys": [
+              "documents/sanjoseca-gov-your-government-departments-offices-city-clerk-city-council-meetings/reader/52e6d8a43914d77c.md",
+              "idempotency/san-jose-ca:meeting_minutes:2026-04-12/analysis/69e1e31c34f41ea6.json",
+              "idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json"
+            ],
+            "object_count": 3
+          },
+          "relational_store": {
+            "analysis_count": 1,
+            "document_count": 1,
+            "search_snapshot_count": 1
+          },
+          "vector_store": {
+            "chunk_count": 1,
+            "chunk_ids": [
+              "sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meetings::chunk-0::712bf03ddc3f"
+            ]
+          }
         }
-      ],
-      "storage_snapshot": {
-        "object_store": {
-          "keys": [
-            "documents/sanjoseca-gov-your-government-departments-offices-city-clerk-city-council-meetings/reader/52e6d8a43914d77c.md",
-            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/analysis/69e1e31c34f41ea6.json",
-            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json"
-          ],
-          "object_count": 3
+      },
+      "searx_failure": {
+        "alerts": [],
+        "analysis_preview": null,
+        "counts": {
+          "analyses_total": 1,
+          "chunks_total": 1,
+          "documents_total": 1,
+          "objects_total": 3,
+          "search_results": 0
         },
-        "relational_store": {
-          "analysis_count": 1,
-          "document_count": 1,
-          "search_snapshot_count": 1
+        "created_at": "2026-04-12T17:25:01.105996+00:00",
+        "envelope": {
+          "architecture_path": "windmill_direct_storage",
+          "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+          "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+          "jurisdiction": "San Jose CA",
+          "orchestrator": "windmill",
+          "source_family": "meeting_minutes",
+          "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_direct_storage",
+          "windmill_job_id": "job-local-6feb357c-ce6c-4ba6-b27e-d648df72eee6",
+          "windmill_run_id": "local-6feb357c-ce6c-4ba6-b27e-d648df72eee6",
+          "windmill_workspace": "affordabot"
         },
-        "vector_store": {
-          "chunk_count": 1,
-          "chunk_ids": [
-            "sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meetings::chunk-0::712bf03ddc3f"
-          ]
+        "reason": "simulated_searx_failure",
+        "scenario": "searx_failure",
+        "status": "source_error",
+        "steps": [
+          {
+            "error": "simulated_searx_failure",
+            "status": "source_error",
+            "step": "search_materialize"
+          }
+        ],
+        "storage_snapshot": {
+          "object_store": {
+            "keys": [
+              "documents/sanjoseca-gov-your-government-departments-offices-city-clerk-city-council-meetings/reader/52e6d8a43914d77c.md",
+              "idempotency/san-jose-ca:meeting_minutes:2026-04-12/analysis/69e1e31c34f41ea6.json",
+              "idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json"
+            ],
+            "object_count": 3
+          },
+          "relational_store": {
+            "analysis_count": 1,
+            "document_count": 1,
+            "search_snapshot_count": 1
+          },
+          "vector_store": {
+            "chunk_count": 1,
+            "chunk_ids": [
+              "sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meetings::chunk-0::712bf03ddc3f"
+            ]
+          }
+        }
+      },
+      "storage_failure": {
+        "alerts": [],
+        "analysis_preview": null,
+        "counts": {
+          "analyses_total": 1,
+          "chunks_total": 1,
+          "documents_total": 1,
+          "objects_total": 3,
+          "search_results": 3
+        },
+        "created_at": "2026-04-12T17:25:01.106720+00:00",
+        "envelope": {
+          "architecture_path": "windmill_direct_storage",
+          "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+          "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+          "jurisdiction": "San Jose CA",
+          "orchestrator": "windmill",
+          "source_family": "meeting_minutes",
+          "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_direct_storage",
+          "windmill_job_id": "job-local-fc1b6338-845a-4211-9b28-699a760b5a08",
+          "windmill_run_id": "local-fc1b6338-845a-4211-9b28-699a760b5a08",
+          "windmill_workspace": "affordabot"
+        },
+        "reason": "simulated_storage_error",
+        "scenario": "storage_failure",
+        "status": "storage_error",
+        "steps": [
+          {
+            "error": "simulated_storage_error",
+            "status": "storage_error",
+            "step": "search_materialize"
+          }
+        ],
+        "storage_snapshot": {
+          "object_store": {
+            "keys": [
+              "documents/sanjoseca-gov-your-government-departments-offices-city-clerk-city-council-meetings/reader/52e6d8a43914d77c.md",
+              "idempotency/san-jose-ca:meeting_minutes:2026-04-12/analysis/69e1e31c34f41ea6.json",
+              "idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json"
+            ],
+            "object_count": 3
+          },
+          "relational_store": {
+            "analysis_count": 1,
+            "document_count": 1,
+            "search_snapshot_count": 1
+          },
+          "vector_store": {
+            "chunk_count": 1,
+            "chunk_ids": [
+              "sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meetings::chunk-0::712bf03ddc3f"
+            ]
+          }
         }
       }
     }
   },
-  "generated_at": "2026-04-12T17:19:09.349837+00:00",
+  "generated_at": "2026-04-12T17:25:01.106948+00:00",
   "live_blockers": [
     "SEARX_ENDPOINT not configured; used deterministic SearX fixture.",
     "Z.ai reader/analysis live call unavailable; used deterministic contract-shape substitutes."
@@ -207,7 +385,7 @@
         "objects_total": 3,
         "search_results": 3
       },
-      "created_at": "2026-04-12T17:19:09.346009+00:00",
+      "created_at": "2026-04-12T17:25:01.098625+00:00",
       "envelope": {
         "architecture_path": "windmill_direct_storage",
         "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
@@ -216,8 +394,8 @@
         "orchestrator": "windmill",
         "source_family": "meeting_minutes",
         "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_direct_storage",
-        "windmill_job_id": "job-local-f2b23d63-0eaf-4c06-98bc-5b488d562ace",
-        "windmill_run_id": "local-f2b23d63-0eaf-4c06-98bc-5b488d562ace",
+        "windmill_job_id": "job-local-9b5d3bbe-4db9-4062-8c3a-df37e868b739",
+        "windmill_run_id": "local-9b5d3bbe-4db9-4062-8c3a-df37e868b739",
         "windmill_workspace": "affordabot"
       },
       "reason": "completed",
@@ -292,7 +470,7 @@
         "objects_total": 3,
         "search_results": 3
       },
-      "created_at": "2026-04-12T17:19:09.347826+00:00",
+      "created_at": "2026-04-12T17:25:01.101590+00:00",
       "envelope": {
         "architecture_path": "windmill_direct_storage",
         "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
@@ -301,8 +479,8 @@
         "orchestrator": "windmill",
         "source_family": "meeting_minutes",
         "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_direct_storage",
-        "windmill_job_id": "job-local-17377228-ab0b-4657-94b4-52d6ded0c1c2",
-        "windmill_run_id": "local-17377228-ab0b-4657-94b4-52d6ded0c1c2",
+        "windmill_job_id": "job-local-1c2f8b23-5cf1-4e71-a593-0911422eff64",
+        "windmill_run_id": "local-1c2f8b23-5cf1-4e71-a593-0911422eff64",
         "windmill_workspace": "affordabot"
       },
       "reason": "completed",
@@ -320,6 +498,158 @@
         {
           "reason": "age_hours=0.00",
           "status": "fresh",
+          "step": "freshness_gate"
+        },
+        {
+          "artifact_ref": "minio://affordabot-artifacts/documents/sanjoseca-gov-your-government-departments-offices-city-clerk-city-council-meetings/reader/52e6d8a43914d77c.md#52e6d8a43914d77c7e131fc1420160385cedd325b800eb313d7c8f3c51e60502",
+          "canonical_document_key": "sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meetings",
+          "document_created": false,
+          "reader_mode": "deterministic",
+          "status": "succeeded",
+          "step": "read_fetch"
+        },
+        {
+          "chunks_created": 0,
+          "chunks_reused": 1,
+          "chunks_total_for_document": 1,
+          "status": "succeeded",
+          "step": "index_chunks"
+        },
+        {
+          "analysis_artifact_ref": "minio://affordabot-artifacts/idempotency/san-jose-ca:meeting_minutes:2026-04-12/analysis/69e1e31c34f41ea6.json#6ef14f3decf189c7f1fa6e1c2537c6ee70ceee7ae1c9128154a42edcc510f35d",
+          "analysis_created": false,
+          "analysis_mode": "deterministic",
+          "status": "succeeded",
+          "step": "analyze"
+        }
+      ],
+      "storage_snapshot": {
+        "object_store": {
+          "keys": [
+            "documents/sanjoseca-gov-your-government-departments-offices-city-clerk-city-council-meetings/reader/52e6d8a43914d77c.md",
+            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/analysis/69e1e31c34f41ea6.json",
+            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json"
+          ],
+          "object_count": 3
+        },
+        "relational_store": {
+          "analysis_count": 1,
+          "document_count": 1,
+          "search_snapshot_count": 1
+        },
+        "vector_store": {
+          "chunk_count": 1,
+          "chunk_ids": [
+            "sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meetings::chunk-0::712bf03ddc3f"
+          ]
+        }
+      }
+    }
+  },
+  "stale_gate": {
+    "stale_blocked": {
+      "alerts": [],
+      "analysis_preview": null,
+      "counts": {
+        "analyses_total": 1,
+        "chunks_total": 1,
+        "documents_total": 1,
+        "objects_total": 3,
+        "search_results": 3
+      },
+      "created_at": "2026-04-12T17:25:01.105478+00:00",
+      "envelope": {
+        "architecture_path": "windmill_direct_storage",
+        "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+        "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+        "jurisdiction": "San Jose CA",
+        "orchestrator": "windmill",
+        "source_family": "meeting_minutes",
+        "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_direct_storage",
+        "windmill_job_id": "job-local-6d837993-c132-416b-a45c-54c09e615a3f",
+        "windmill_run_id": "local-6d837993-c132-416b-a45c-54c09e615a3f",
+        "windmill_workspace": "affordabot"
+      },
+      "reason": "age_hours=96.00",
+      "scenario": "normal",
+      "status": "stale_blocked",
+      "steps": [
+        {
+          "artifact_ref": "minio://affordabot-artifacts/idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json#b0f216d429a0dc71d70720b8304c1816c248eab1c58f28d1b31b639101efaf62",
+          "result_count": 3,
+          "snapshot_created": false,
+          "snapshot_id": "san-jose-ca:meeting_minutes:2026-04-12::535a80471cc2cdd4",
+          "status": "succeeded",
+          "step": "search_materialize"
+        },
+        {
+          "reason": "age_hours=96.00",
+          "status": "stale_blocked",
+          "step": "freshness_gate"
+        }
+      ],
+      "storage_snapshot": {
+        "object_store": {
+          "keys": [
+            "documents/sanjoseca-gov-your-government-departments-offices-city-clerk-city-council-meetings/reader/52e6d8a43914d77c.md",
+            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/analysis/69e1e31c34f41ea6.json",
+            "idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json"
+          ],
+          "object_count": 3
+        },
+        "relational_store": {
+          "analysis_count": 1,
+          "document_count": 1,
+          "search_snapshot_count": 1
+        },
+        "vector_store": {
+          "chunk_count": 1,
+          "chunk_ids": [
+            "sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meetings::chunk-0::712bf03ddc3f"
+          ]
+        }
+      }
+    },
+    "stale_usable": {
+      "alerts": [
+        "stale_backed=true"
+      ],
+      "analysis_preview": "San Jose meeting minutes indicate transit funding decisions and housing permit acceleration updates were discussed in recent sessions.",
+      "counts": {
+        "analyses_total": 1,
+        "chunks_total": 1,
+        "documents_total": 1,
+        "objects_total": 3,
+        "search_results": 3
+      },
+      "created_at": "2026-04-12T17:25:01.103583+00:00",
+      "envelope": {
+        "architecture_path": "windmill_direct_storage",
+        "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+        "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+        "jurisdiction": "San Jose CA",
+        "orchestrator": "windmill",
+        "source_family": "meeting_minutes",
+        "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_direct_storage",
+        "windmill_job_id": "job-local-34a83526-6d97-4984-b5b7-e524bc58d61e",
+        "windmill_run_id": "local-34a83526-6d97-4984-b5b7-e524bc58d61e",
+        "windmill_workspace": "affordabot"
+      },
+      "reason": "completed",
+      "scenario": "normal",
+      "status": "succeeded",
+      "steps": [
+        {
+          "artifact_ref": "minio://affordabot-artifacts/idempotency/san-jose-ca:meeting_minutes:2026-04-12/search/ad52464ef535c48b.json#b0f216d429a0dc71d70720b8304c1816c248eab1c58f28d1b31b639101efaf62",
+          "result_count": 3,
+          "snapshot_created": false,
+          "snapshot_id": "san-jose-ca:meeting_minutes:2026-04-12::535a80471cc2cdd4",
+          "status": "succeeded",
+          "step": "search_materialize"
+        },
+        {
+          "reason": "age_hours=36.00",
+          "status": "stale_but_usable",
           "step": "freshness_gate"
         },
         {

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/README.md
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/README.md
@@ -6,6 +6,11 @@ storage writes are performed only by coarse affordabot domain commands.
 Implementation entrypoint:
 - `backend/scripts/verification/windmill_bakeoff_domain_boundary.py`
 
+Committed Windmill export (reviewable orchestration shape):
+- `ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.py`
+- `ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.script.yaml`
+- `ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary__flow/flow.yaml`
+
 Runner flow steps (Windmill-shaped):
 1. `search_materialize`
 2. `freshness_gate`
@@ -43,6 +48,8 @@ Live infra was intentionally not used because secret access is currently restric
 - `artifacts/source_failure.json`
 - `artifacts/reader_failure.json`
 - `artifacts/storage_failure.json`
+- `artifacts/stale_usable.json`
+- `artifacts/stale_blocked.json`
 
 ## Architectural Finding (Path B)
 

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/README.md
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/README.md
@@ -1,0 +1,51 @@
+# Path B: Windmill + Affordabot Domain Boundary
+
+This POC implements a Windmill-shaped flow where orchestration is step-based, but product
+storage writes are performed only by coarse affordabot domain commands.
+
+Implementation entrypoint:
+- `backend/scripts/verification/windmill_bakeoff_domain_boundary.py`
+
+Runner flow steps (Windmill-shaped):
+1. `search_materialize`
+2. `freshness_gate`
+3. `read_fetch`
+4. `index`
+5. `analyze`
+6. `summarize_run`
+
+## Domain Boundary Contract
+
+Each domain command owns explicit invariants and is intentionally not a thin SQL wrapper:
+
+- `search_materialize`: idempotent search snapshot persistence for the scope `(jurisdiction, source_family, query, normalized_results)`.
+- `freshness_gate`: explicit freshness state (`fresh`, `empty_result`, `stale_blocked`) with zero-result treated as non-transport state.
+- `read_fetch`: canonical document identity (`canonical_document_key`) and deduplicated artifact reference.
+- `index`: chunk upsert idempotency and provenance links (`chunk -> canonical_document_key + artifact_ref`).
+- `analyze`: fail closed when evidence is missing (`analysis_error` if no chunks).
+- `summarize_run`: ties orchestration IDs to domain state counts and per-step statuses.
+
+## Local Adapters Used
+
+This run uses deterministic local substitutes with production-compatible contract shape:
+
+- Search: SearXNG-compatible JSON response model.
+- Reader: Z.ai reader contract shape (`reader_result` envelope).
+- Artifacts: MinIO-style refs (`minio://affordabot-artifacts/...`).
+- Vector index: pgvector-compatible embedding adapter.
+- Analysis: deterministic analysis adapter that emits explicit evidence refs.
+
+Live infra was intentionally not used because secret access is currently restricted in this task.
+
+## Artifacts
+
+- `artifacts/happy_rerun.json`
+- `artifacts/source_failure.json`
+- `artifacts/reader_failure.json`
+- `artifacts/storage_failure.json`
+
+## Architectural Finding (Path B)
+
+Path B is viable. The backend boundary clearly pays for itself at canonical identity,
+idempotency, provenance, and sufficiency gating. It starts to look like middleware only if
+commands are decomposed into low-level storage primitives instead of domain commands.

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/happy_rerun.json
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/happy_rerun.json
@@ -1,7 +1,7 @@
 {
   "first_run": {
     "alerts": [],
-    "created_at": "2026-04-12T17:16:12.187682+00:00",
+    "created_at": "2026-04-12T17:26:44.109197+00:00",
     "envelope": {
       "architecture_path": "affordabot_domain_boundary",
       "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
@@ -54,7 +54,7 @@
   },
   "rerun": {
     "alerts": [],
-    "created_at": "2026-04-12T17:16:12.187725+00:00",
+    "created_at": "2026-04-12T17:26:44.109258+00:00",
     "envelope": {
       "architecture_path": "affordabot_domain_boundary",
       "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/happy_rerun.json
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/happy_rerun.json
@@ -1,0 +1,108 @@
+{
+  "first_run": {
+    "alerts": [],
+    "created_at": "2026-04-12T17:16:12.187682+00:00",
+    "envelope": {
+      "architecture_path": "affordabot_domain_boundary",
+      "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+      "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+      "jurisdiction": "San Jose CA",
+      "orchestrator": "windmill",
+      "source_family": "meeting_minutes",
+      "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+      "windmill_job_id": "job-main",
+      "windmill_run_id": "run-first",
+      "windmill_workspace": "affordabot"
+    },
+    "status": "succeeded",
+    "step_results": {
+      "analyze": {
+        "analysis_id": "analysis-ebbbe7e0f3aeac41",
+        "reused": false,
+        "status": "fresh"
+      },
+      "freshness_gate": {
+        "age_seconds": 0,
+        "status": "fresh"
+      },
+      "index": {
+        "chunks_created": 5,
+        "chunks_total": 5,
+        "status": "fresh"
+      },
+      "read_fetch": {
+        "artifact_ref": "minio://affordabot-artifacts/San_Jose_CA/ecf092f9a92f34b1.md",
+        "canonical_document_key": "san-jose-ca::a653e7debe31e650",
+        "source_url": "https://www.sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meeting-minutes",
+        "status": "fresh"
+      },
+      "search_materialize": {
+        "result_count": 2,
+        "snapshot_id": "snapshot-579c45d51063aaef",
+        "status": "fresh"
+      }
+    },
+    "storage_counts": {
+      "analyses": 1,
+      "artifacts": 1,
+      "chunks": 5,
+      "documents": 1,
+      "run_summaries": 0,
+      "search_snapshots": 1
+    },
+    "summary_id": "summary-run-first"
+  },
+  "rerun": {
+    "alerts": [],
+    "created_at": "2026-04-12T17:16:12.187725+00:00",
+    "envelope": {
+      "architecture_path": "affordabot_domain_boundary",
+      "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+      "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+      "jurisdiction": "San Jose CA",
+      "orchestrator": "windmill",
+      "source_family": "meeting_minutes",
+      "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+      "windmill_job_id": "job-main",
+      "windmill_run_id": "run-second",
+      "windmill_workspace": "affordabot"
+    },
+    "status": "succeeded",
+    "step_results": {
+      "analyze": {
+        "analysis_id": "analysis-ebbbe7e0f3aeac41",
+        "reused": true,
+        "status": "fresh"
+      },
+      "freshness_gate": {
+        "age_seconds": 0,
+        "status": "fresh"
+      },
+      "index": {
+        "chunks_created": 0,
+        "chunks_total": 5,
+        "status": "fresh"
+      },
+      "read_fetch": {
+        "artifact_ref": "minio://affordabot-artifacts/San_Jose_CA/ecf092f9a92f34b1.md",
+        "canonical_document_key": "san-jose-ca::a653e7debe31e650",
+        "source_url": "https://www.sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meeting-minutes",
+        "status": "fresh"
+      },
+      "search_materialize": {
+        "result_count": 2,
+        "snapshot_id": "snapshot-579c45d51063aaef",
+        "status": "fresh"
+      }
+    },
+    "storage_counts": {
+      "analyses": 1,
+      "artifacts": 1,
+      "chunks": 5,
+      "documents": 1,
+      "run_summaries": 1,
+      "search_snapshots": 1
+    },
+    "summary_id": "summary-run-second"
+  }
+}

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/reader_failure.json
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/reader_failure.json
@@ -1,0 +1,45 @@
+{
+  "alerts": [
+    "read_fetch:reader_error",
+    "index:unknown",
+    "analyze:unknown"
+  ],
+  "created_at": "2026-04-12T17:16:12.297070+00:00",
+  "envelope": {
+    "architecture_path": "affordabot_domain_boundary",
+    "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+    "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+    "jurisdiction": "San Jose CA",
+    "orchestrator": "windmill",
+    "source_family": "meeting_minutes",
+    "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+    "windmill_job_id": "job-reader",
+    "windmill_run_id": "run-reader-failure",
+    "windmill_workspace": "affordabot"
+  },
+  "status": "failed",
+  "step_results": {
+    "freshness_gate": {
+      "age_seconds": 0,
+      "status": "fresh"
+    },
+    "read_fetch": {
+      "error": "simulated_reader_error",
+      "status": "reader_error"
+    },
+    "search_materialize": {
+      "result_count": 2,
+      "snapshot_id": "snapshot-579c45d51063aaef",
+      "status": "fresh"
+    }
+  },
+  "storage_counts": {
+    "analyses": 0,
+    "artifacts": 0,
+    "chunks": 0,
+    "documents": 0,
+    "run_summaries": 0,
+    "search_snapshots": 1
+  },
+  "summary_id": "summary-run-reader-failure"
+}

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/reader_failure.json
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/reader_failure.json
@@ -1,10 +1,8 @@
 {
   "alerts": [
-    "read_fetch:reader_error",
-    "index:unknown",
-    "analyze:unknown"
+    "read_fetch:reader_error"
   ],
-  "created_at": "2026-04-12T17:16:12.297070+00:00",
+  "created_at": "2026-04-12T17:26:44.236762+00:00",
   "envelope": {
     "architecture_path": "affordabot_domain_boundary",
     "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/source_failure.json
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/source_failure.json
@@ -1,0 +1,38 @@
+{
+  "alerts": [
+    "search_materialize:source_error",
+    "freshness_gate:unknown",
+    "read_fetch:unknown",
+    "index:unknown",
+    "analyze:unknown"
+  ],
+  "created_at": "2026-04-12T17:16:12.240926+00:00",
+  "envelope": {
+    "architecture_path": "affordabot_domain_boundary",
+    "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+    "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+    "jurisdiction": "San Jose CA",
+    "orchestrator": "windmill",
+    "source_family": "meeting_minutes",
+    "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+    "windmill_job_id": "job-search",
+    "windmill_run_id": "run-source-failure",
+    "windmill_workspace": "affordabot"
+  },
+  "status": "failed",
+  "step_results": {
+    "search_materialize": {
+      "error": "simulated_source_error",
+      "status": "source_error"
+    }
+  },
+  "storage_counts": {
+    "analyses": 0,
+    "artifacts": 0,
+    "chunks": 0,
+    "documents": 0,
+    "run_summaries": 0,
+    "search_snapshots": 0
+  },
+  "summary_id": "summary-run-source-failure"
+}

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/source_failure.json
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/source_failure.json
@@ -1,12 +1,8 @@
 {
   "alerts": [
-    "search_materialize:source_error",
-    "freshness_gate:unknown",
-    "read_fetch:unknown",
-    "index:unknown",
-    "analyze:unknown"
+    "search_materialize:source_error"
   ],
-  "created_at": "2026-04-12T17:16:12.240926+00:00",
+  "created_at": "2026-04-12T17:26:44.164225+00:00",
   "envelope": {
     "architecture_path": "affordabot_domain_boundary",
     "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/stale_blocked.json
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/stale_blocked.json
@@ -1,8 +1,8 @@
 {
   "alerts": [
-    "index:storage_error"
+    "freshness_gate:stale_blocked"
   ],
-  "created_at": "2026-04-12T17:26:44.297324+00:00",
+  "created_at": "2026-04-12T17:26:44.404673+00:00",
   "envelope": {
     "architecture_path": "affordabot_domain_boundary",
     "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
@@ -11,26 +11,15 @@
     "orchestrator": "windmill",
     "source_family": "meeting_minutes",
     "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
-    "windmill_job_id": "job-index",
-    "windmill_run_id": "run-storage-failure",
+    "windmill_job_id": "job-freshness",
+    "windmill_run_id": "run-stale-blocked",
     "windmill_workspace": "affordabot"
   },
   "status": "failed",
   "step_results": {
     "freshness_gate": {
-      "age_seconds": 0,
-      "status": "fresh"
-    },
-    "index": {
-      "error": "simulated_storage_error:index",
-      "status": "storage_error",
-      "step": "index"
-    },
-    "read_fetch": {
-      "artifact_ref": "minio://affordabot-artifacts/San_Jose_CA/ecf092f9a92f34b1.md",
-      "canonical_document_key": "san-jose-ca::a653e7debe31e650",
-      "source_url": "https://www.sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meeting-minutes",
-      "status": "fresh"
+      "age_seconds": 288000,
+      "status": "stale_blocked"
     },
     "search_materialize": {
       "result_count": 2,
@@ -40,11 +29,11 @@
   },
   "storage_counts": {
     "analyses": 0,
-    "artifacts": 1,
+    "artifacts": 0,
     "chunks": 0,
-    "documents": 1,
+    "documents": 0,
     "run_summaries": 0,
     "search_snapshots": 1
   },
-  "summary_id": "summary-run-storage-failure"
+  "summary_id": "summary-run-stale-blocked"
 }

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/stale_usable.json
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/stale_usable.json
@@ -1,8 +1,8 @@
 {
   "alerts": [
-    "index:storage_error"
+    "freshness_gate:stale_but_usable"
   ],
-  "created_at": "2026-04-12T17:26:44.297324+00:00",
+  "created_at": "2026-04-12T17:26:44.350265+00:00",
   "envelope": {
     "architecture_path": "affordabot_domain_boundary",
     "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
@@ -11,20 +11,25 @@
     "orchestrator": "windmill",
     "source_family": "meeting_minutes",
     "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
-    "windmill_job_id": "job-index",
-    "windmill_run_id": "run-storage-failure",
+    "windmill_job_id": "job-freshness",
+    "windmill_run_id": "run-stale-usable",
     "windmill_workspace": "affordabot"
   },
-  "status": "failed",
+  "status": "succeeded",
   "step_results": {
-    "freshness_gate": {
-      "age_seconds": 0,
+    "analyze": {
+      "analysis_id": "analysis-ebbbe7e0f3aeac41",
+      "reused": false,
       "status": "fresh"
     },
+    "freshness_gate": {
+      "age_seconds": 108000,
+      "status": "stale_but_usable"
+    },
     "index": {
-      "error": "simulated_storage_error:index",
-      "status": "storage_error",
-      "step": "index"
+      "chunks_created": 5,
+      "chunks_total": 5,
+      "status": "fresh"
     },
     "read_fetch": {
       "artifact_ref": "minio://affordabot-artifacts/San_Jose_CA/ecf092f9a92f34b1.md",
@@ -39,12 +44,12 @@
     }
   },
   "storage_counts": {
-    "analyses": 0,
+    "analyses": 1,
     "artifacts": 1,
-    "chunks": 0,
+    "chunks": 5,
     "documents": 1,
     "run_summaries": 0,
     "search_snapshots": 1
   },
-  "summary_id": "summary-run-storage-failure"
+  "summary_id": "summary-run-stale-usable"
 }

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/storage_failure.json
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/storage_failure.json
@@ -1,0 +1,51 @@
+{
+  "alerts": [
+    "index:storage_error",
+    "analyze:unknown"
+  ],
+  "created_at": "2026-04-12T17:16:12.351797+00:00",
+  "envelope": {
+    "architecture_path": "affordabot_domain_boundary",
+    "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+    "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+    "jurisdiction": "San Jose CA",
+    "orchestrator": "windmill",
+    "source_family": "meeting_minutes",
+    "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+    "windmill_job_id": "job-index",
+    "windmill_run_id": "run-storage-failure",
+    "windmill_workspace": "affordabot"
+  },
+  "status": "failed",
+  "step_results": {
+    "freshness_gate": {
+      "age_seconds": 0,
+      "status": "fresh"
+    },
+    "index": {
+      "error": "simulated_storage_error:index",
+      "status": "storage_error",
+      "step": "index"
+    },
+    "read_fetch": {
+      "artifact_ref": "minio://affordabot-artifacts/San_Jose_CA/ecf092f9a92f34b1.md",
+      "canonical_document_key": "san-jose-ca::a653e7debe31e650",
+      "source_url": "https://www.sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meeting-minutes",
+      "status": "fresh"
+    },
+    "search_materialize": {
+      "result_count": 2,
+      "snapshot_id": "snapshot-579c45d51063aaef",
+      "status": "fresh"
+    }
+  },
+  "storage_counts": {
+    "analyses": 0,
+    "artifacts": 1,
+    "chunks": 0,
+    "documents": 1,
+    "run_summaries": 0,
+    "search_snapshots": 1
+  },
+  "summary_id": "summary-run-storage-failure"
+}

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/failure-drills.md
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/failure-drills.md
@@ -60,6 +60,43 @@ Why this matters:
 - Domain boundary prevents analysis from running after storage/index failure.
 - Partial state remains inspectable but bounded.
 
+## 4) Stale Gate Drill (`stale_but_usable`)
+
+Command:
+
+```bash
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario stale_usable --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/stale_usable.json
+```
+
+Observed:
+
+- Run `status=succeeded`
+- `freshness_gate.status=stale_but_usable`
+- Alert emitted: `freshness_gate:stale_but_usable`
+- `read_fetch/index/analyze` continue
+
+Why this matters:
+- Staleness can degrade gracefully with explicit alerting.
+- Supports "use yesterday's data" behavior while retaining traceability.
+
+## 5) Stale Gate Drill (`stale_blocked`)
+
+Command:
+
+```bash
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario stale_blocked --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/stale_blocked.json
+```
+
+Observed:
+
+- Run `status=failed`
+- `freshness_gate.status=stale_blocked`
+- Pipeline stops before `read_fetch`
+
+Why this matters:
+- Fail-closed behavior is explicit at the freshness boundary.
+- Prevents stale evidence from flowing into analysis.
+
 ## Assessment
 
 Path B failure behavior is explicit and step-scoped. Windmill can orchestrate retries/branches,

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/failure-drills.md
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/failure-drills.md
@@ -1,0 +1,66 @@
+# Failure Drills
+
+Date: 2026-04-12  
+Runner: `backend/scripts/verification/windmill_bakeoff_domain_boundary.py`
+
+## 1) SearXNG Failure Drill
+
+Command:
+
+```bash
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario source_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/source_failure.json
+```
+
+Observed:
+
+- Run `status=failed`
+- `search_materialize.status=source_error`
+- downstream steps did not execute
+- storage counts remained zero
+
+Why this matters:
+- Transport failure is isolated at discovery step.
+- No partial product records are created.
+
+## 2) Reader Failure Drill
+
+Command:
+
+```bash
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario reader_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/reader_failure.json
+```
+
+Observed:
+
+- Run `status=failed`
+- `search_materialize` and `freshness_gate` succeeded
+- `read_fetch.status=reader_error`
+- `index` and `analyze` did not execute
+
+Why this matters:
+- Reader errors fail before index/analyze.
+- Prevents non-provenanced downstream outputs.
+
+## 3) Storage Failure Drill
+
+Command:
+
+```bash
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario storage_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/storage_failure.json
+```
+
+Observed:
+
+- Run `status=failed`
+- Failure at `index.status=storage_error`
+- `read_fetch` succeeded (document + artifact present)
+- `chunks=0`, `analyses=0`
+
+Why this matters:
+- Domain boundary prevents analysis from running after storage/index failure.
+- Partial state remains inspectable but bounded.
+
+## Assessment
+
+Path B failure behavior is explicit and step-scoped. Windmill can orchestrate retries/branches,
+while affordabot domain commands enforce product integrity before each transition.

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/run-evidence.md
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/run-evidence.md
@@ -12,6 +12,9 @@ Path: `B / affordabot_domain_boundary`
 /usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario source_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/source_failure.json
 /usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario reader_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/reader_failure.json
 /usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario storage_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/storage_failure.json
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario stale_usable --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/stale_usable.json
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario stale_blocked --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/stale_blocked.json
+/usr/bin/python3 -m unittest backend/tests/verification/test_windmill_bakeoff_domain_boundary.py
 ```
 
 ## Outcome Summary
@@ -22,6 +25,9 @@ Path: `B / affordabot_domain_boundary`
 - Source failure drill: `status=failed` with `search_materialize:source_error`
 - Reader failure drill: `status=failed` with `read_fetch:reader_error`
 - Storage failure drill: `status=failed` with `index:storage_error`
+- Stale usable drill: `status=succeeded` with `freshness_gate:stale_but_usable`
+- Stale blocked drill: `status=failed` with `freshness_gate:stale_blocked`
+- Narrow tests: pass (`Ran 3 tests ... OK`)
 
 ## Key Evidence
 
@@ -44,3 +50,11 @@ Interpretation: idempotency is preserved across document identity, artifacts, ch
 
 - None for deterministic contract validation.
 - Live Windmill/SearXNG/Z.ai credentials were intentionally not used under current safety constraints.
+
+## Windmill Export Evidence
+
+The Path B orchestration shape is committed as reviewable repo code:
+
+- `ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.py`
+- `ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.script.yaml`
+- `ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary__flow/flow.yaml`

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/run-evidence.md
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/run-evidence.md
@@ -1,0 +1,46 @@
+# Run Evidence
+
+Date: 2026-04-12  
+Feature key: `bd-jxclm.15` (Beads reconciliation pending infra repair)  
+Path: `B / affordabot_domain_boundary`
+
+## Commands
+
+```bash
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --help
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario happy_rerun --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/happy_rerun.json
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario source_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/source_failure.json
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario reader_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/reader_failure.json
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario storage_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/storage_failure.json
+```
+
+## Outcome Summary
+
+- `--help`: pass
+- Happy path first run: `status=succeeded`
+- Rerun/idempotency: `status=succeeded` with no duplicate writes
+- Source failure drill: `status=failed` with `search_materialize:source_error`
+- Reader failure drill: `status=failed` with `read_fetch:reader_error`
+- Storage failure drill: `status=failed` with `index:storage_error`
+
+## Key Evidence
+
+From `happy_rerun.json`:
+
+- First run:
+  - `canonical_document_key`: `san-jose-ca::a653e7debe31e650`
+  - `artifact_ref`: `minio://affordabot-artifacts/San_Jose_CA/ecf092f9a92f34b1.md`
+  - `chunks_created`: `5`
+  - `analysis_id`: `analysis-ebbbe7e0f3aeac41` (`reused=false`)
+- Rerun:
+  - same `canonical_document_key`
+  - same `artifact_ref`
+  - `chunks_created`: `0`
+  - same `analysis_id` with `reused=true`
+
+Interpretation: idempotency is preserved across document identity, artifacts, chunks, and analysis.
+
+## Live Infra Blockers
+
+- None for deterministic contract validation.
+- Live Windmill/SearXNG/Z.ai credentials were intentionally not used under current safety constraints.

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/storage-snapshots.md
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/storage-snapshots.md
@@ -1,6 +1,9 @@
 # Storage Snapshots
 
 This file captures storage-state evidence from `artifacts/happy_rerun.json`.
+Additional stale-gate evidence comes from:
+- `artifacts/stale_usable.json`
+- `artifacts/stale_blocked.json`
 
 ## After First Run (`run-first`)
 
@@ -45,3 +48,15 @@ Idempotency signals:
 
 Path B can keep Windmill-style orchestration while preserving product write invariants in affordabot:
 stable identity, deduplicated artifacts/chunks, and evidence-gated analysis.
+
+## Stale Gate Storage Effects
+
+From `stale_usable.json`:
+- `freshness_gate.status = stale_but_usable`
+- downstream `read_fetch`, `index`, and `analyze` still execute
+- run carries alert `freshness_gate:stale_but_usable`
+
+From `stale_blocked.json`:
+- `freshness_gate.status = stale_blocked`
+- pipeline fails closed before `read_fetch`
+- storage remains bounded at discovery snapshot only

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/storage-snapshots.md
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/storage-snapshots.md
@@ -1,0 +1,47 @@
+# Storage Snapshots
+
+This file captures storage-state evidence from `artifacts/happy_rerun.json`.
+
+## After First Run (`run-first`)
+
+Storage counts:
+
+- `search_snapshots`: 1
+- `documents`: 1
+- `artifacts`: 1
+- `chunks`: 5
+- `analyses`: 1
+
+Representative keys:
+
+- `snapshot_id`: `snapshot-579c45d51063aaef`
+- `canonical_document_key`: `san-jose-ca::a653e7debe31e650`
+- `artifact_ref`: `minio://affordabot-artifacts/San_Jose_CA/ecf092f9a92f34b1.md`
+- `analysis_id`: `analysis-ebbbe7e0f3aeac41`
+
+Provenance chain demonstrated:
+
+`claim -> evidence chunk ids -> canonical_document_key + artifact_ref -> search snapshot`
+
+## After Rerun (`run-second`)
+
+Storage counts:
+
+- `search_snapshots`: 1 (unchanged)
+- `documents`: 1 (unchanged)
+- `artifacts`: 1 (unchanged)
+- `chunks`: 5 (unchanged)
+- `analyses`: 1 (unchanged)
+
+Idempotency signals:
+
+- `search_materialize.snapshot_id` unchanged.
+- `read_fetch.canonical_document_key` unchanged.
+- `read_fetch.artifact_ref` unchanged.
+- `index.chunks_created = 0`.
+- `analyze.analysis_id` unchanged with `reused=true`.
+
+## Interpretation
+
+Path B can keep Windmill-style orchestration while preserving product write invariants in affordabot:
+stable identity, deduplicated artifacts/chunks, and evidence-gated analysis.

--- a/docs/specs/2026-04-13-windmill-domain-brownfield-spec-lock.md
+++ b/docs/specs/2026-04-13-windmill-domain-brownfield-spec-lock.md
@@ -1,0 +1,1005 @@
+# Windmill Domain Boundary Brownfield Spec Lock
+
+Date: 2026-04-13
+Status: Spec lock for implementation planning
+Epic: `bd-9qjof`
+First task: `bd-9qjof.1`
+Related ADR: `docs/architecture/2026-04-12-windmill-affordabot-boundary-adr.md`
+Related POC: `docs/poc/windmill-storage-bakeoff/ARCHITECTURE_RECOMMENDATION.md`
+
+## Summary
+
+Affordabot should replace the current monolithic cron-trigger pattern with a Windmill-native daily refresh flow, but Windmill must remain the orchestration layer. Product data logic stays in affordabot code.
+
+The implementation target is a brownfield refactor:
+
+- keep existing scraper, reader, ingestion, storage, retrieval, evidence, and admin surfaces where they already work
+- extract a tested domain-command package around those existing services
+- let Windmill call those coarse commands with native retries, branching, looping, schedules, failure handlers, and run history
+- expose frontend/operator state through affordabot backend read APIs
+
+This document locks the contracts needed before two implementation agents can safely work in parallel.
+
+## Problem
+
+Affordabot's discovery and scraping pipeline is not commodity ETL. It is part of the product moat:
+
+- canonical document identity
+- source family coverage
+- freshness and stale fallback behavior
+- reader output preservation
+- revision chains
+- MinIO artifact provenance
+- chunking and retrieval scope
+- evidence sufficiency before analysis
+- operator-visible trust and failure states
+
+Moving this logic directly into Windmill would create a second backend in workflow scripts. Keeping everything in the existing backend cron endpoints underuses Windmill's DAG, retry, branch, schedule, and operator controls.
+
+The correct implementation is a hybrid:
+
+```text
+Windmill flow
+  orchestrates and records work
+  calls coarse affordabot domain commands
+
+Affordabot domain package
+  enforces product invariants
+  writes canonical product state
+
+Affordabot backend API
+  serves frontend/operator read models
+  optionally triggers Windmill
+```
+
+## Goals
+
+- Replace the current four-step cron chain with a Windmill-native flow for the new persisted discovery pipeline.
+- Preserve affordabot-owned product invariants in normal backend/domain code.
+- Reuse the existing brownfield stack instead of rebuilding scraping, ingestion, pgvector, MinIO, evidence, or admin systems.
+- Make every domain command idempotent and safe under Windmill reruns.
+- Produce operator-visible run summaries that the frontend can display without direct Windmill, Postgres, pgvector, or MinIO coupling.
+- Validate the San Jose meeting-minutes slice end to end through live Windmill before production rollout.
+
+## Non-Goals
+
+- Do not migrate all existing cron jobs in one cutover.
+- Do not move canonical product writes into Windmill scripts.
+- Do not create low-level storage endpoints such as `insert_row`, `upload_object`, `embed_text`, or `write_chunk`.
+- Do not make the frontend call Windmill, Postgres, pgvector, or MinIO directly.
+- Do not make Z.ai web search primary. SearXNG-style OSS search is primary for search discovery.
+- Do not remove Z.ai direct reader or Z.ai LLM analysis. Those remain canonical for reader extraction and analysis.
+- Do not require coarse HTTP endpoints before the shared package path proves insufficient.
+
+## Existing Stack Inventory
+
+### Current Windmill Layer
+
+Keep short-term as the rollback lane:
+
+- `ops/windmill/README.md`
+- `ops/windmill/f/affordabot/trigger_cron_job.py`
+- `ops/windmill/f/affordabot/discovery_run__flow/flow.yaml`
+- `ops/windmill/f/affordabot/daily_scrape__flow/flow.yaml`
+- `ops/windmill/f/affordabot/rag_spiders__flow/flow.yaml`
+- `ops/windmill/f/affordabot/universal_harvester__flow/flow.yaml`
+- corresponding `*.schedule.yaml` files
+
+Current model: Windmill is the scheduler of record, but each Windmill job calls one authenticated backend cron endpoint. This is useful as a rollback path, but it is not the target flow shape.
+
+### Backend Cron Entrypoints
+
+Wrap first, then retire from the primary path after parity:
+
+- `backend/main.py` routes under `/cron/*`
+- `backend/scripts/cron/run_discovery.py`
+- `backend/scripts/cron/run_daily_scrape.py`
+- `backend/scripts/cron/run_rag_spiders.py`
+- `backend/scripts/cron/run_universal_harvester.py`
+
+These scripts are the current execution plane. The new domain package should reuse their service wiring where possible, but Windmill should call domain commands instead of calling one monolithic cron endpoint per phase.
+
+### Discovery And Search
+
+Reuse:
+
+- `backend/services/auto_discovery_service.py`
+- `backend/services/discovery/search_discovery.py`
+- `backend/services/discovery/service.py`
+- `backend/scripts/verification/poc_rag_pipeline_oss_swap.py`
+
+Target: OSS SearXNG-style search is the primary discovery source. Z.ai direct web search is deprecated from the primary path and may exist only as a scheduled bakeoff/manual health check.
+
+### Reader And Extraction
+
+Reuse:
+
+- `backend/clients/web_reader_client.py`
+- `backend/services/extractors/zai.py`
+
+Target: Z.ai direct reader remains canonical for web-reader extraction. Windmill should call an affordabot command that uses this reader; Windmill must not know the Z.ai response internals beyond command status.
+
+### Scraping And Substrate Capture
+
+Reuse:
+
+- `backend/services/scraper/*`
+- `backend/affordabot_scraper/*`
+- `backend/scripts/substrate/manual_capture.py`
+- `backend/scripts/substrate/manual_expansion_runner.py`
+- `backend/services/substrate_promotion.py`
+
+Target: keep source-specific capture logic in affordabot. Domain commands can call these services or factor shared helpers out of them.
+
+### Ingestion, MinIO, pgvector
+
+Reuse and tighten:
+
+- `backend/services/ingestion_service.py`
+- `backend/services/storage/s3_storage.py`
+- `backend/contracts/storage.py`
+- `backend/services/retrieval/local_pgvector.py`
+- `backend/services/vector_backend_factory.py`
+
+Current `IngestionService` already:
+
+- loads `raw_scrapes`
+- extracts text
+- uploads blob payloads when configured
+- chunks content
+- embeds chunks
+- upserts into `document_chunks`
+- records `ingestion_truth`
+- reuses an existing retrievable revision when `canonical_document_key` plus `content_hash` already exists
+
+The new `index` command should wrap this behavior but must add a clearer idempotency and partial-write recovery contract.
+
+### Identity And Revision Chain
+
+Reuse but modify:
+
+- `backend/services/revision_identity.py`
+- `backend/migrations/007_add_revision_identity_columns.sql`
+
+Current `build_canonical_document_key` is source-id-centric:
+
+```text
+v1|source=<source_id>|doctype=<document_type>|url=<canonical_url>
+```
+
+The new pipeline needs a jurisdiction/source-family scoped identity to avoid Path A versus Path B divergence and to support multi-jurisdiction document reuse intentionally.
+
+### Evidence And Analysis
+
+Reuse:
+
+- `backend/services/llm/orchestrator.py`
+- `backend/services/llm/evidence_adapter.py`
+- `backend/services/llm/evidence_gates.py`
+- `backend/schemas/analysis.py`
+
+Target: Z.ai LLM analysis remains canonical. The `analyze` command must fail closed when evidence is insufficient.
+
+### Admin And Frontend
+
+Reuse and extend:
+
+- `backend/routers/admin.py`
+- `backend/scripts/substrate/substrate_inspection_report.py`
+- `frontend/src/app/admin/page.tsx`
+- `frontend/src/components/admin/*`
+- `frontend/src/services/adminService.ts`
+
+Target: frontend displays pipeline status through backend read models. It should not parse Windmill payloads or infer product state from raw storage.
+
+## Active Contract
+
+### Command Envelope
+
+Every domain command accepts an envelope plus command-specific input:
+
+```json
+{
+  "contract_version": "2026-04-13.windmill-domain.v1",
+  "command": "search_materialize",
+  "orchestrator": "windmill",
+  "windmill_workspace": "affordabot",
+  "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+  "windmill_run_id": "wm-run-id",
+  "windmill_job_id": "wm-job-id",
+  "idempotency_key": "sha256(scope+command+logical-input)",
+  "jurisdiction_id": "san-jose-ca",
+  "jurisdiction_name": "San Jose CA",
+  "source_family": "meeting_minutes",
+  "requested_at": "2026-04-13T00:00:00Z"
+}
+```
+
+Every command returns:
+
+```json
+{
+  "contract_version": "2026-04-13.windmill-domain.v1",
+  "command": "search_materialize",
+  "status": "succeeded",
+  "decision_reason": "fresh_snapshot_materialized",
+  "retry_class": "none",
+  "alerts": [],
+  "counts": {},
+  "refs": {},
+  "windmill": {
+    "run_id": "wm-run-id",
+    "job_id": "wm-job-id"
+  }
+}
+```
+
+Allowed `status` values:
+
+- `succeeded`
+- `succeeded_with_alerts`
+- `skipped`
+- `blocked`
+- `failed_retryable`
+- `failed_terminal`
+
+Allowed `retry_class` values:
+
+- `none`
+- `transport`
+- `rate_limited`
+- `transient_storage`
+- `provider_unavailable`
+- `contract_violation`
+- `insufficient_evidence`
+- `operator_required`
+
+Windmill owns retry policy. Affordabot returns `retry_class`, `decision_reason`, and machine-readable `alerts`; it does not return `max_retries`, `retry_after_seconds`, or `next_recommended_step` as control instructions.
+
+### Domain Commands
+
+#### `search_materialize`
+
+Purpose: query OSS search and persist a normalized search snapshot.
+
+Wrap or reuse:
+
+- `backend/services/auto_discovery_service.py`
+- `backend/services/discovery/search_discovery.py`
+- `backend/services/discovery/service.py`
+- `backend/scripts/verification/poc_rag_pipeline_oss_swap.py`
+
+Inputs:
+
+- jurisdiction
+- source family
+- query template or explicit query
+- search backend configuration
+- max result count
+
+Writes:
+
+- search snapshot rows
+- raw normalized result payload artifact when large enough to justify MinIO
+- pipeline step summary
+
+Invariants:
+
+- zero search results are not a transport failure
+- every snapshot is scoped by jurisdiction and source family
+- snapshot identity is idempotent for equivalent normalized results
+- raw search payloads are retained or hash-addressed for auditability
+
+Acceptance tests:
+
+- same query and same results reuse the prior snapshot
+- same URL in a different jurisdiction does not collide unless the identity policy explicitly says so
+- empty results produce `succeeded_with_alerts` or `blocked` based on freshness state, not `failed_retryable`
+- SearXNG transport failure returns `failed_retryable` with `retry_class=transport`
+
+#### `freshness_gate`
+
+Purpose: decide whether the pipeline can proceed using fresh or stale results.
+
+Wrap or reuse:
+
+- POC freshness behavior in `backend/scripts/verification/windmill_bakeoff_domain_boundary.py`
+- existing admin/substrate run summary patterns
+
+Inputs:
+
+- latest search snapshot ref
+- latest successful run summary
+- source-family freshness policy
+
+Outputs:
+
+- `fresh`
+- `stale_but_usable`
+- `stale_blocked`
+- `empty_but_usable`
+- `empty_blocked`
+
+Invariants:
+
+- freshness policy is affordabot-owned business logic
+- stale fallback has a hard ceiling
+- stale fallback always emits an alert
+- zero-result handling is separate from provider failure
+- stale-blocked fails closed before reader/index/analyze
+
+Initial policy defaults:
+
+| Source Family | Fresh Hours | Stale Usable Ceiling | Fail-Closed Ceiling |
+| --- | ---: | ---: | ---: |
+| `meeting_minutes` | 24 | 72 | 168 |
+| `agendas` | 24 | 72 | 168 |
+| `legislation` | 24 | 48 | 120 |
+| `general_web_reference` | 48 | 168 | 336 |
+
+Acceptance tests:
+
+- fresh proceeds
+- stale-but-usable proceeds with alert
+- stale-blocked stops the flow before reads
+- repeated stale fallbacks hit the fail-closed ceiling
+
+#### `read_fetch`
+
+Purpose: fetch selected documents through the canonical reader path and create raw substrate records.
+
+Wrap or reuse:
+
+- `backend/clients/web_reader_client.py`
+- `backend/services/extractors/zai.py`
+- `backend/db/postgres_client.py:create_raw_scrape`
+- `backend/services/revision_identity.py`
+
+Inputs:
+
+- selected search result refs
+- reader backend selection
+- canonical identity policy
+
+Writes:
+
+- raw reader artifact in MinIO where configured
+- `raw_scrapes` row or updated revision chain
+- artifact metadata and content hash
+- pipeline step summary
+
+Invariants:
+
+- Z.ai direct reader remains canonical for reader extraction
+- Windmill does not parse reader payload internals
+- canonical document identity is generated by affordabot code
+- same content hash under the same canonical key reuses the existing retrievable revision
+- reader failures stop before index/analyze
+
+Acceptance tests:
+
+- reader success stores artifact ref and raw scrape ref
+- reader failure returns `failed_retryable` or `failed_terminal` based on provider error class
+- same content hash and same canonical key do not create duplicate chunks on rerun
+- MinIO artifact hash mismatch returns `failed_terminal`
+
+#### `index`
+
+Purpose: turn raw reader/substrate records into retrievable chunks.
+
+Wrap or reuse:
+
+- `backend/services/ingestion_service.py`
+- `backend/services/retrieval/local_pgvector.py`
+- `backend/services/vector_backend_factory.py`
+- `backend/services/storage/s3_storage.py`
+
+Inputs:
+
+- raw scrape refs
+- chunking/embedding configuration
+- retrieval scope
+
+Writes:
+
+- `raw_scrapes.ingestion_truth`
+- `raw_scrapes.document_id`
+- `document_chunks`
+- MinIO artifact refs when the raw payload was not already stored
+- pipeline step summary
+
+Invariants:
+
+- every chunk links to `raw_scrape_id`, `canonical_document_key`, `jurisdiction_id`, `source_family`, and artifact ref
+- pgvector is an index, not canonical truth
+- reruns reuse existing retrievable revisions where possible
+- vector writes are idempotent by deterministic chunk identity
+- no analysis is allowed if retrievable chunk count is zero
+
+Required refactor:
+
+Current `IngestionService` creates random document and chunk IDs for new processed rows. The new command must make chunk identity deterministic from:
+
+```text
+contract_version
+canonical_document_key
+content_hash
+chunk_index
+chunk_text_hash
+```
+
+Acceptance tests:
+
+- rerun does not duplicate chunks
+- partial MinIO success followed by Postgres failure recovers by hash/ref
+- partial Postgres success followed by vector failure recovers by deterministic chunk ids
+- `LocalPgVectorBackend.query` filters by jurisdiction/source family in metadata
+
+#### `analyze`
+
+Purpose: produce Z.ai LLM analysis only from sufficient evidence.
+
+Wrap or reuse:
+
+- `backend/services/llm/orchestrator.py`
+- `backend/services/llm/evidence_adapter.py`
+- `backend/services/llm/evidence_gates.py`
+- `backend/schemas/analysis.py`
+
+Inputs:
+
+- jurisdiction
+- source family
+- analysis question/template
+- evidence refs from indexed chunks
+
+Writes:
+
+- analysis record
+- evidence links
+- large LLM artifacts in MinIO if needed
+- pipeline step summary
+
+Invariants:
+
+- Z.ai LLM analysis remains canonical
+- no quantified/impact output without evidence sufficiency
+- every claim links to chunk/document/artifact provenance
+- analysis output includes contract version
+
+Acceptance tests:
+
+- no chunks produces `blocked` with `retry_class=insufficient_evidence`
+- insufficient evidence fails closed
+- successful analysis includes claim-to-evidence refs
+- contract version mismatch fails terminally
+
+#### `summarize_run`
+
+Purpose: produce product-visible pipeline state for operators and frontend.
+
+Wrap or reuse:
+
+- `backend/routers/admin.py`
+- `backend/scripts/substrate/substrate_inspection_report.py`
+- `backend/services/glass_box.py` where applicable
+
+Inputs:
+
+- Windmill run/job IDs
+- domain command outputs
+- product row refs
+
+Writes:
+
+- pipeline run summary rows
+- pipeline step summary rows
+- operator-visible alerts
+
+Invariants:
+
+- summary is backend-authored product state
+- Windmill run URL is an operator link, not product truth
+- frontend consumes this summary through backend API
+
+Acceptance tests:
+
+- happy run summary includes all step statuses and counts
+- stale fallback summary includes alert
+- blocked run summary exposes fail-closed reason
+- rerun summary links old/new attempt ids without duplicating product rows
+
+## Canonical Identity Spec
+
+### Target Format
+
+Use a new `v2` canonical document key for this pipeline:
+
+```text
+v2|jurisdiction=<jurisdiction_slug>|family=<source_family>|doctype=<document_type>|url=<normalized_url>
+```
+
+Fallback when no durable URL exists:
+
+```text
+v2|jurisdiction=<jurisdiction_slug>|family=<source_family>|doctype=<document_type>|title=<normalized_title>|date=<yyyy-mm-dd-or-unknown>
+```
+
+The jurisdiction slug is required even when the same URL appears in multiple jurisdictions. Cross-jurisdiction dedupe can be introduced later through a separate global content identity, not by weakening product-scoped canonical identity.
+
+### URL Normalization
+
+Start from `normalize_canonical_url` in `backend/services/revision_identity.py` and preserve:
+
+- lowercase scheme and host
+- default port removal
+- repeated slash normalization
+- trailing slash removal except root
+- tracking query removal for `utm_*`, `fbclid`, `gclid`, `mc_cid`, `mc_eid`, `ref`, `source`
+- sorted remaining query parameters
+- fragment removal
+
+Do not strip query parameters globally. Municipal agenda/minute systems sometimes encode document identity in query parameters.
+
+### Revision Behavior
+
+- `canonical_document_key` identifies a logical document within jurisdiction/source family.
+- `content_hash` identifies a concrete payload revision.
+- Same `canonical_document_key` plus same `content_hash` means the command should reuse the existing retrievable revision if one exists.
+- Same `canonical_document_key` plus different `content_hash` creates a new revision and points `previous_raw_scrape_id` at the latest prior revision.
+- `seen_count` increments when the same canonical/content identity is observed again.
+- `last_seen_at` updates on each observation.
+
+### Migration Position
+
+Do not rewrite all historical `v1` keys in the first implementation. Instead:
+
+- add `v2` key generation to the new domain package
+- keep old rows readable
+- write new rows with `v2` keys
+- add a later migration task only if historical chain continuity becomes necessary for launch
+
+## Storage Contract
+
+### Postgres
+
+Postgres is canonical relational product state.
+
+Existing tables to reuse:
+
+- `raw_scrapes`
+- `document_chunks`
+- `pipeline_runs`
+- `pipeline_steps`
+- admin/substrate read surfaces
+
+Additive tables or columns likely needed:
+
+- `search_result_snapshots`
+- `content_artifacts` or a similarly named artifact metadata table
+- `pipeline_runs` columns for `orchestrator`, `windmill_workspace`, `windmill_run_id`, `source_family`, `contract_version`, and `idempotency_key`
+- `pipeline_steps` columns for `command`, `retry_class`, `decision_reason`, `alerts`, `refs`, and Windmill job id
+
+Do not make Windmill write canonical product rows directly.
+
+### MinIO
+
+MinIO stores immutable large artifacts:
+
+- raw SearXNG JSON payloads when retained
+- Z.ai reader markdown/text output
+- raw HTML/PDF/source payloads
+- large LLM request/response artifacts if too large for Postgres
+
+Object keys are generated by affordabot domain code:
+
+```text
+artifacts/<contract_version>/<jurisdiction_slug>/<source_family>/<artifact_kind>/<sha256>.<ext>
+```
+
+Postgres stores:
+
+- object key/URI
+- content hash
+- media type
+- byte length where available
+- artifact kind
+- contract version
+- canonical document key where applicable
+- creating command and idempotency key
+
+### pgvector
+
+pgvector stores retrieval indexes derived from canonical chunks.
+
+Rules:
+
+- every vector row must include metadata for `jurisdiction_id`, `source_family`, `canonical_document_key`, `raw_scrape_id`, `artifact_ref`, and `contract_version`
+- every vector row points back to a canonical Postgres document/chunk context
+- similarity hits are candidates; evidence is the chunk plus provenance chain
+- rebuilding embeddings must not alter canonical document identity
+
+## Atomicity And Idempotency
+
+Windmill can rerun an entire flow. It does not provide resume-from-step semantics that should be trusted as the product recovery mechanism. Affordabot commands must make whole-flow reruns safe.
+
+### Idempotency Keys
+
+Each command computes an idempotency key from:
+
+```text
+contract_version
+command
+jurisdiction_id
+source_family
+logical input refs
+normalized provider payload hash where applicable
+```
+
+Database writes should use uniqueness constraints around command idempotency where possible.
+
+### Command Write Pattern
+
+Each command follows this pattern:
+
+1. validate contract version and input refs
+2. acquire a scoped advisory lock or insert an in-progress operation row
+3. detect prior completed command result by idempotency key
+4. write immutable artifacts first when the artifact hash is known
+5. write or upsert canonical Postgres rows in a transaction
+6. write pgvector rows using deterministic ids where applicable
+7. verify postconditions
+8. write pipeline step summary
+9. return refs and counts
+
+### Partial-Write Recovery
+
+Required behavior:
+
+| Failure Point | Rerun Behavior |
+| --- | --- |
+| provider failed before storage | retry provider or use freshness fallback |
+| MinIO object uploaded, Postgres row missing | find by content hash/object key and attach row |
+| Postgres raw row inserted, MinIO ref missing | retry artifact write or mark `storage_uri` absent with alert if non-blocking |
+| Postgres raw row inserted, vector write failed | rerun `index` reuses raw row and deterministic chunk ids |
+| vector rows written, raw row not marked processed | rerun verifies chunk count and marks retrievable |
+| analysis artifact written, analysis row missing | attach by content hash/idempotency key or rewrite deterministically |
+
+Storage upload failure should be blocking for reader artifacts in the new pipeline unless explicitly configured as non-blocking for a source family. The current ingestion path treats blob upload as non-blocking; the domain command must make that policy explicit.
+
+## Concurrency And Admission Control
+
+Windmill owns loops and concurrency settings. Affordabot owns product-level admission safety.
+
+Initial limits:
+
+- max Windmill fanout: 2 jurisdictions concurrently in dev
+- max source families per jurisdiction: 1 at a time
+- max SearXNG calls: 2 concurrent
+- max Z.ai reader calls: 1 concurrent in dev
+- max Z.ai LLM analysis calls: 1 concurrent in dev
+- max `index` commands touching the same jurisdiction/source family: 1
+
+Affordabot must enforce:
+
+- one active command per `jurisdiction_id + source_family + command + logical_input_hash`
+- one active full refresh per `jurisdiction_id + source_family`
+- deterministic rerun behavior if duplicate Windmill runs start
+
+Implementation options:
+
+- Postgres advisory locks for active command scopes
+- unique rows with `status in ('running')` guarded by transactions
+- provider-specific semaphores if commands run inside one worker process
+
+Duplicate Windmill run policy:
+
+- if an identical command is already completed, return the completed refs
+- if an identical command is running, return `skipped` or `blocked` with `retry_class=operator_required` depending on call context
+- if a conflicting command is running for the same jurisdiction/source family, fail closed before writes
+
+## Windmill Flow Contract
+
+Target flow:
+
+```text
+pipeline_daily_refresh
+  input: jurisdictions[], source_families[], mode
+  for each jurisdiction/source_family with concurrency limit
+    search_materialize
+    freshness_gate
+    branch:
+      stale_blocked | empty_blocked
+        summarize_run(blocked)
+        fail/alert
+      fresh | stale_but_usable | empty_but_usable
+        read_fetch
+        index
+        analyze
+        summarize_run
+```
+
+Windmill owns:
+
+- schedules
+- manual/webhook triggers
+- native step retries/backoff
+- branch conditions
+- per-jurisdiction/source-family loop
+- failure handler
+- run history and run URLs
+- operator approvals if needed later
+
+Windmill must not own:
+
+- canonical document key generation
+- SQL for canonical product records
+- MinIO object key policy
+- pgvector metadata policy
+- freshness semantics
+- analysis sufficiency gates
+- frontend read models
+
+Current cron flows remain enabled as rollback until the parity window passes.
+
+## Backend Read Model Contract
+
+Add backend read APIs under the admin router or a new pipeline admin router. Suggested paths:
+
+```text
+GET  /api/admin/pipeline/jurisdictions/{jurisdiction_id}/status
+GET  /api/admin/pipeline/runs/{run_id}
+GET  /api/admin/pipeline/runs/{run_id}/steps
+GET  /api/admin/pipeline/runs/{run_id}/evidence
+POST /api/admin/pipeline/jurisdictions/{jurisdiction_id}/refresh
+```
+
+The frontend-facing status payload should look like:
+
+```json
+{
+  "contract_version": "2026-04-13.windmill-domain.v1",
+  "jurisdiction_id": "san-jose-ca",
+  "jurisdiction_name": "San Jose CA",
+  "source_family": "meeting_minutes",
+  "pipeline_status": "stale_but_usable",
+  "last_success_at": "2026-04-13T00:00:00Z",
+  "freshness": {
+    "status": "stale_but_usable",
+    "fresh_hours": 24,
+    "stale_usable_ceiling_hours": 72,
+    "fail_closed_ceiling_hours": 168,
+    "alerts": ["source_search_failed_using_last_success"]
+  },
+  "counts": {
+    "search_results": 2,
+    "raw_scrapes": 1,
+    "artifacts": 1,
+    "chunks": 4,
+    "analyses": 1
+  },
+  "latest_analysis": {
+    "status": "ready",
+    "sufficiency_state": "qualitative_only",
+    "evidence_count": 4
+  },
+  "operator_links": {
+    "windmill_run_url": "https://windmill.example/runs/..."
+  }
+}
+```
+
+Frontend rules:
+
+- use `frontend/src/services/adminService.ts` as the API boundary
+- extend existing admin/substrate views before inventing a parallel admin app
+- display backend statuses and alerts directly
+- never infer freshness from raw timestamps in the browser
+- never construct MinIO keys in the browser
+- never call Windmill from the browser except through a backend-mediated operator action
+
+## Implementation Phases
+
+### Phase 0: Spec Lock
+
+Task: `bd-9qjof.1`
+
+Deliverables:
+
+- this spec
+- brownfield mapping in Beads
+- reviewer acceptance that identity, atomicity, concurrency, command envelope, and frontend read model are sufficiently locked
+
+Validation:
+
+- `git diff --check`
+- architecture review using `dx-review` or equivalent reviewer quorum
+
+### Phase 1: Domain Package Skeleton
+
+Task: `bd-9qjof.2`
+
+Deliverables:
+
+- package such as `backend/services/pipeline/domain/`
+- command request/response models
+- command envelope validator
+- deterministic in-memory adapters
+- tests ported from `backend/scripts/verification/windmill_bakeoff_domain_boundary.py`
+
+Validation:
+
+- happy run
+- rerun idempotency
+- source failure
+- reader failure
+- storage failure
+- stale-but-usable
+- stale-blocked
+- no-analysis-without-evidence
+
+### Phase 2: Windmill Flow Skeleton
+
+Task: `bd-9qjof.3`
+
+Deliverables:
+
+- Windmill flow export for `pipeline_daily_refresh_domain_boundary__flow`
+- thin Windmill scripts that invoke the domain package
+- native retries, branch predicates, failure handler, loop/fanout shape
+- no direct canonical storage writes in Windmill scripts
+
+Validation:
+
+- local flow-shaped test or script harness
+- static scan showing no direct SQL/MinIO/pgvector product writes in Windmill layer
+
+### Phase 3: Real Storage Adapters
+
+Task: `bd-9qjof.4`
+
+Deliverables:
+
+- Postgres schema/migration prototype
+- MinIO artifact adapter integration
+- pgvector deterministic chunk id integration
+- partial-write recovery tests
+
+Validation:
+
+- real or test Postgres-compatible integration test where available
+- MinIO/object-store contract test
+- crash-mid-step drills
+- rerun after partial failure
+
+### Phase 4: Backend Read Models And Frontend
+
+Task: `bd-9qjof.5`
+
+Deliverables:
+
+- backend admin pipeline status/read APIs
+- `adminService.ts` client methods and types
+- frontend admin status/evidence display
+- backend-mediated manual refresh action
+
+Validation:
+
+- backend API tests
+- frontend build/typecheck
+- browser or Playwright evidence for the admin route if UI files change
+
+### Phase 5: Live Windmill San Jose Gate
+
+Task: `bd-9qjof.6`
+
+Deliverables:
+
+- live Windmill run in shared `affordabot` workspace
+- private/dev SearXNG call evidence
+- Z.ai direct reader call evidence
+- Z.ai LLM analysis call evidence
+- Postgres + pgvector + MinIO write/read evidence
+- rerun idempotency evidence
+- stale/failure drill evidence
+- no 1Password GUI prompt evidence
+
+Validation:
+
+- run artifact committed under `docs/poc/` or `backend/artifacts/`
+- backend read model displays the run summary
+
+### Phase 6: Rollout And Final Review
+
+Task: `bd-9qjof.7`
+
+Deliverables:
+
+- parity window plan
+- rollback runbook
+- final architecture review package
+- decision record for promoting the new pipeline as primary
+
+Validation:
+
+- explicit parity duration and pass/fail metrics
+- rollback path proven or rehearsed
+- final review accepts the production path
+
+## Two-Agent Dispatch Plan
+
+After `bd-9qjof.1` is accepted:
+
+### Wave 1
+
+Worker A: `bd-9qjof.2`
+
+- owns domain package skeleton
+- owns envelope, command models, in-memory adapters, deterministic tests
+- must not edit Windmill flow assets except test fixtures
+
+Worker B: `bd-9qjof.3`
+
+- owns Windmill flow/script skeleton
+- owns flow-shaped harness and branch/retry/failure handler documentation
+- must not implement product storage logic inside Windmill scripts
+
+### Wave 2
+
+Worker A: `bd-9qjof.4`
+
+- owns Postgres/MinIO/pgvector adapters and partial-write recovery
+- owns deterministic chunk identity and storage tests
+
+Worker B: `bd-9qjof.5`
+
+- owns backend read APIs and frontend admin visualization
+- owns frontend evidence if UI changes
+
+### Wave 3
+
+Single integration owner: `bd-9qjof.6`
+
+- runs the live San Jose Windmill gate
+- gathers evidence
+- files defects discovered during live execution
+
+### Wave 4
+
+Single rollout owner: `bd-9qjof.7`
+
+- writes final review package
+- locks parity and rollback
+- prepares final architecture discussion
+
+## Validation Gates
+
+Minimum checks before implementation PRs can merge:
+
+- unit tests for command envelope and status vocabulary
+- unit tests for all six commands with deterministic adapters
+- idempotency tests for rerun and duplicate Windmill run admission
+- partial-write recovery tests for MinIO, Postgres, and pgvector
+- source failure, reader failure, storage failure, stale-but-usable, stale-blocked tests
+- backend API tests for pipeline read models
+- frontend build/typecheck and browser evidence if frontend changes
+- live Windmill San Jose run before production rollout lock
+
+## Risks And Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Windmill scripts become a second backend | Scripts may call only coarse domain commands; static review rejects direct canonical writes |
+| Identity divergence creates duplicate or orphaned data | Adopt `v2` jurisdiction/source-family scoped key; keep `v1` readable |
+| Whole-flow rerun duplicates rows | Idempotency keys, deterministic chunk ids, uniqueness constraints, and postcondition checks |
+| Partial writes across Postgres/MinIO/pgvector leave inconsistent state | Explicit recovery matrix and crash-mid-step tests |
+| Frontend couples to orchestration internals | Backend read model contract only; Windmill URLs are operator links |
+| Shared Windmill workspace affects Prime Radiant or other flows | Keep workspace path scoped to `f/affordabot/*`; do not mutate shared resources outside affordabot paths |
+| Z.ai search remains broken | Remove from primary path; schedule separate manual/weekly health check only |
+| Z.ai reader or LLM provider failure blocks launch | Commands classify provider failure and stale fallback behavior; reader/analysis remain canonical but fail closed where evidence is insufficient |
+
+## Recommended First Executable Task
+
+Start `bd-9qjof.2` and `bd-9qjof.3` in parallel only after reviewers accept this spec lock.
+
+The implementation should not start by editing storage schemas or frontend views. It should start by making the domain command contract executable with deterministic tests, while Windmill flow assets are shaped around that same contract.

--- a/frontend/src/components/admin/PipelineStatusPanel.tsx
+++ b/frontend/src/components/admin/PipelineStatusPanel.tsx
@@ -55,9 +55,7 @@ export function PipelineStatusPanel({ runId }: Props) {
             try {
                 const data = await adminService.getJurisdictions();
                 setJurisdictions(data);
-                if (data.length > 0 && !selectedJurisdiction) {
-                    setSelectedJurisdiction(data[0].id);
-                }
+                setSelectedJurisdiction((current) => current || data[0]?.id || '');
             } catch (err) {
                 console.error('Failed to load jurisdictions for pipeline panel:', err);
                 setError('Unable to load jurisdictions');

--- a/frontend/src/components/admin/PipelineStatusPanel.tsx
+++ b/frontend/src/components/admin/PipelineStatusPanel.tsx
@@ -1,0 +1,293 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, ExternalLink, Loader2, RefreshCcw } from 'lucide-react';
+import { adminService } from '@/services/adminService';
+import type {
+    Jurisdiction,
+    PipelineJurisdictionStatus,
+    PipelineRefreshResponse,
+    PipelineRunDetail,
+    PipelineRunEvidenceResponse,
+    PipelineRunStepsResponse,
+} from '@/services/adminService';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+
+const SOURCE_FAMILIES = [
+    'meeting_minutes',
+    'agendas',
+    'legislation',
+    'general_web_reference',
+];
+
+type Props = {
+    runId?: string | null;
+};
+
+function formatTime(value?: string | null): string {
+    if (!value) return 'n/a';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+    return date.toLocaleString();
+}
+
+export function PipelineStatusPanel({ runId }: Props) {
+    const [jurisdictions, setJurisdictions] = useState<Jurisdiction[]>([]);
+    const [selectedJurisdiction, setSelectedJurisdiction] = useState<string>('');
+    const [sourceFamily, setSourceFamily] = useState<string>('meeting_minutes');
+
+    const [status, setStatus] = useState<PipelineJurisdictionStatus | null>(null);
+    const [runDetail, setRunDetail] = useState<PipelineRunDetail | null>(null);
+    const [runSteps, setRunSteps] = useState<PipelineRunStepsResponse | null>(null);
+    const [runEvidence, setRunEvidence] = useState<PipelineRunEvidenceResponse | null>(null);
+    const [refreshAck, setRefreshAck] = useState<PipelineRefreshResponse | null>(null);
+
+    const [loading, setLoading] = useState(false);
+    const [refreshing, setRefreshing] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const loadJurisdictions = async () => {
+            try {
+                const data = await adminService.getJurisdictions();
+                setJurisdictions(data);
+                if (data.length > 0 && !selectedJurisdiction) {
+                    setSelectedJurisdiction(data[0].id);
+                }
+            } catch (err) {
+                console.error('Failed to load jurisdictions for pipeline panel:', err);
+                setError('Unable to load jurisdictions');
+            }
+        };
+        loadJurisdictions();
+    }, []);
+
+    const loadStatus = async (jurisdictionId: string, family: string) => {
+        setLoading(true);
+        setError(null);
+        try {
+            const statusData = await adminService.getPipelineJurisdictionStatus(
+                jurisdictionId,
+                family,
+            );
+            setStatus(statusData);
+        } catch (err) {
+            console.error('Failed to load pipeline jurisdiction status:', err);
+            setStatus(null);
+            setError('Failed to load pipeline status');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (!selectedJurisdiction) return;
+        loadStatus(selectedJurisdiction, sourceFamily);
+    }, [selectedJurisdiction, sourceFamily]);
+
+    useEffect(() => {
+        const loadRunData = async () => {
+            if (!runId) {
+                setRunDetail(null);
+                setRunSteps(null);
+                setRunEvidence(null);
+                return;
+            }
+            try {
+                const [detail, steps, evidence] = await Promise.all([
+                    adminService.getPipelineRun(runId),
+                    adminService.getPipelineRunSteps(runId),
+                    adminService.getPipelineRunEvidence(runId),
+                ]);
+                setRunDetail(detail);
+                setRunSteps(steps);
+                setRunEvidence(evidence);
+            } catch (err) {
+                console.error('Failed to load pipeline run detail bundle:', err);
+                setRunDetail(null);
+                setRunSteps(null);
+                setRunEvidence(null);
+            }
+        };
+        loadRunData();
+    }, [runId]);
+
+    const statusBadge = useMemo(() => {
+        const value = status?.pipeline_status || 'unknown';
+        if (value === 'fresh') return <Badge className="bg-emerald-600 text-white">fresh</Badge>;
+        if (value.includes('usable')) return <Badge className="bg-amber-500 text-black">{value}</Badge>;
+        if (value.includes('blocked')) return <Badge variant="destructive">{value}</Badge>;
+        return <Badge variant="outline">{value}</Badge>;
+    }, [status?.pipeline_status]);
+
+    const handleRefresh = async () => {
+        if (!selectedJurisdiction) return;
+        setRefreshing(true);
+        try {
+            const ack = await adminService.refreshPipelineJurisdiction(
+                selectedJurisdiction,
+                sourceFamily,
+            );
+            setRefreshAck(ack);
+            await loadStatus(selectedJurisdiction, sourceFamily);
+        } catch (err) {
+            console.error('Failed to request pipeline refresh:', err);
+            setError('Manual refresh request failed');
+        } finally {
+            setRefreshing(false);
+        }
+    };
+
+    return (
+        <Card data-testid="pipeline-status-panel">
+            <CardHeader>
+                <CardTitle>Pipeline Status</CardTitle>
+                <CardDescription>
+                    Backend-authored pipeline summary with freshness and evidence readiness.
+                </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+                    <div className="space-y-1">
+                        <Label htmlFor="pipeline-jurisdiction">Jurisdiction</Label>
+                        <select
+                            id="pipeline-jurisdiction"
+                            className="h-9 w-full rounded border border-slate-300 bg-white px-2 text-sm"
+                            value={selectedJurisdiction}
+                            onChange={(event) => setSelectedJurisdiction(event.target.value)}
+                        >
+                            {jurisdictions.map((jur) => (
+                                <option key={jur.id} value={jur.id}>
+                                    {jur.name}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                    <div className="space-y-1">
+                        <Label htmlFor="pipeline-source-family">Source family</Label>
+                        <select
+                            id="pipeline-source-family"
+                            className="h-9 w-full rounded border border-slate-300 bg-white px-2 text-sm"
+                            value={sourceFamily}
+                            onChange={(event) => setSourceFamily(event.target.value)}
+                        >
+                            {SOURCE_FAMILIES.map((family) => (
+                                <option key={family} value={family}>
+                                    {family}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                    <div className="flex items-end gap-2">
+                        <Button
+                            variant="outline"
+                            className="w-full"
+                            onClick={() => loadStatus(selectedJurisdiction, sourceFamily)}
+                            disabled={loading || !selectedJurisdiction}
+                        >
+                            {loading ? (
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            ) : (
+                                <RefreshCcw className="mr-2 h-4 w-4" />
+                            )}
+                            Reload Status
+                        </Button>
+                        <Button
+                            className="w-full"
+                            onClick={handleRefresh}
+                            disabled={refreshing || !selectedJurisdiction}
+                        >
+                            {refreshing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                            Queue Refresh
+                        </Button>
+                    </div>
+                </div>
+
+                {error ? (
+                    <Alert variant="destructive">
+                        <AlertTriangle className="h-4 w-4" />
+                        <AlertTitle>Pipeline status error</AlertTitle>
+                        <AlertDescription>{error}</AlertDescription>
+                    </Alert>
+                ) : null}
+
+                {status ? (
+                    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                        <div className="rounded border border-slate-200 p-3">
+                            <div className="mb-2 flex items-center justify-between">
+                                <p className="text-sm font-medium text-slate-900">
+                                    {status.jurisdiction_name} / {status.source_family}
+                                </p>
+                                {statusBadge}
+                            </div>
+                            <p className="text-xs text-slate-600">
+                                Last success: {formatTime(status.last_success_at)}
+                            </p>
+                            <p className="mt-2 text-xs text-slate-600">
+                                Freshness policy: {status.freshness.fresh_hours}h fresh,{' '}
+                                {status.freshness.stale_usable_ceiling_hours}h usable stale,{' '}
+                                {status.freshness.fail_closed_ceiling_hours}h fail-closed.
+                            </p>
+                            {status.operator_links.windmill_run_url ? (
+                                <a
+                                    href={status.operator_links.windmill_run_url}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="mt-3 inline-flex items-center text-xs text-blue-700 underline"
+                                >
+                                    Open Windmill run <ExternalLink className="ml-1 h-3 w-3" />
+                                </a>
+                            ) : null}
+                        </div>
+                        <div className="rounded border border-slate-200 p-3">
+                            <p className="text-sm font-medium text-slate-900">Counts</p>
+                            <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-slate-700">
+                                <span>Search: {status.counts.search_results}</span>
+                                <span>Raw scrapes: {status.counts.raw_scrapes}</span>
+                                <span>Artifacts: {status.counts.artifacts}</span>
+                                <span>Chunks: {status.counts.chunks}</span>
+                                <span>Analyses: {status.counts.analyses}</span>
+                                <span>Evidence: {status.latest_analysis.evidence_count}</span>
+                            </div>
+                            <p className="mt-3 text-xs text-slate-600">
+                                Analysis: {status.latest_analysis.status} / {status.latest_analysis.sufficiency_state}
+                            </p>
+                        </div>
+                    </div>
+                ) : null}
+
+                {status && (status.alerts.length > 0 || status.freshness.alerts.length > 0) ? (
+                    <div className="rounded border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900">
+                        {(status.freshness.alerts.length > 0
+                            ? status.freshness.alerts
+                            : status.alerts
+                        ).join(', ')}
+                    </div>
+                ) : null}
+
+                {refreshAck ? (
+                    <div className="rounded border border-slate-200 bg-slate-50 p-2 text-xs text-slate-600">
+                        {refreshAck.message}
+                    </div>
+                ) : null}
+
+                {runDetail ? (
+                    <div className="rounded border border-slate-200 p-3 text-xs text-slate-700">
+                        <p className="font-medium text-slate-900">Selected Run Context</p>
+                        <p className="mt-1">Run: {runDetail.run_id}</p>
+                        <p>Status: {runDetail.status}</p>
+                        <p>Source family: {runDetail.source_family}</p>
+                        <p>
+                            Steps: {runSteps?.steps.length ?? 0} / Evidence refs:{' '}
+                            {runEvidence?.evidence_count ?? 0}
+                        </p>
+                    </div>
+                ) : null}
+            </CardContent>
+        </Card>
+    );
+}

--- a/frontend/src/components/admin/SubstrateExplorer.tsx
+++ b/frontend/src/components/admin/SubstrateExplorer.tsx
@@ -19,6 +19,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { PipelineStatusPanel } from '@/components/admin/PipelineStatusPanel';
 
 const RUN_PAGE_SIZE = 30;
 const RAW_ROWS_PAGE_SIZE = 80;
@@ -226,6 +227,8 @@ export function SubstrateExplorer() {
 
     return (
         <div className="space-y-6" data-testid="substrate-explorer">
+            <PipelineStatusPanel runId={selectedRunId} />
+
             <div className="flex items-center justify-between">
                 <div>
                     <h2 className="text-2xl font-bold tracking-tight text-slate-900" data-testid="substrate-title">

--- a/frontend/src/services/adminService.ts
+++ b/frontend/src/services/adminService.ts
@@ -138,6 +138,111 @@ export interface SubstrateRunRawFilters {
     content_class?: string;
 }
 
+export interface PipelineFreshness {
+    status: string;
+    fresh_hours: number;
+    stale_usable_ceiling_hours: number;
+    fail_closed_ceiling_hours: number;
+    alerts: string[];
+}
+
+export interface PipelineCounts {
+    search_results: number;
+    raw_scrapes: number;
+    artifacts: number;
+    chunks: number;
+    analyses: number;
+}
+
+export interface PipelineLatestAnalysis {
+    status: 'ready' | 'not_ready' | 'blocked' | string;
+    sufficiency_state: string;
+    evidence_count: number;
+}
+
+export interface PipelineOperatorLinks {
+    windmill_run_url?: string | null;
+    windmill_workspace?: string | null;
+}
+
+export interface PipelineJurisdictionStatus {
+    contract_version: string;
+    jurisdiction_id: string;
+    jurisdiction_name: string;
+    source_family: string;
+    pipeline_status: string;
+    last_success_at: string | null;
+    freshness: PipelineFreshness;
+    counts: PipelineCounts;
+    latest_analysis: PipelineLatestAnalysis;
+    alerts: string[];
+    operator_links: PipelineOperatorLinks;
+}
+
+export interface PipelineRunDetail {
+    contract_version: string;
+    run_id: string;
+    status: string;
+    jurisdiction: string;
+    source_family: string;
+    bill_id: string | null;
+    started_at: string | null;
+    completed_at: string | null;
+    error: string | null;
+    trigger_source: string | null;
+    counts: PipelineCounts;
+    latest_analysis: PipelineLatestAnalysis;
+    alerts: string[];
+    operator_links: PipelineOperatorLinks;
+}
+
+export interface PipelineRunStep {
+    contract_version: string;
+    step_id: string;
+    run_id: string;
+    command: string;
+    status: string;
+    decision_reason: string | null;
+    retry_class: string;
+    alerts: string[];
+    counts: Record<string, number>;
+    refs: Record<string, unknown>;
+    duration_ms: number;
+    error: string | null;
+    timestamp: string | null;
+}
+
+export interface PipelineRunStepsResponse {
+    contract_version: string;
+    run_id: string;
+    steps: PipelineRunStep[];
+}
+
+export interface PipelineEvidenceItem {
+    id: string;
+    type: string;
+    label: string;
+    confidence: number | null;
+    source_ref: string | null;
+}
+
+export interface PipelineRunEvidenceResponse {
+    contract_version: string;
+    run_id: string;
+    evidence_count: number;
+    items: PipelineEvidenceItem[];
+}
+
+export interface PipelineRefreshResponse {
+    contract_version: string;
+    status: string;
+    decision_reason: string;
+    jurisdiction_id: string;
+    jurisdiction_name: string;
+    source_family: string;
+    message: string;
+}
+
 export const adminService = {
     // Sources
     async getSources(): Promise<Source[]> {
@@ -205,6 +310,45 @@ export const adminService = {
     async getJurisdictionDashboard(id: string): Promise<JurisdictionDashboardStats> {
         const res = await fetch(`${API_URL}/api/admin/jurisdiction/${id}/dashboard`);
         if (!res.ok) throw new Error('Failed to fetch dashboard stats');
+        return res.json();
+    },
+
+    // Pipeline read model
+    async getPipelineJurisdictionStatus(jurisdictionId: string, sourceFamily = 'meeting_minutes'): Promise<PipelineJurisdictionStatus> {
+        const params = new URLSearchParams({ source_family: sourceFamily });
+        const res = await fetch(
+            `${API_URL}/api/admin/pipeline/jurisdictions/${encodeURIComponent(jurisdictionId)}/status?${params.toString()}`,
+            NO_STORE_FETCH,
+        );
+        if (!res.ok) throw new Error('Failed to fetch pipeline jurisdiction status');
+        return res.json();
+    },
+
+    async getPipelineRun(runId: string): Promise<PipelineRunDetail> {
+        const res = await fetch(`${API_URL}/api/admin/pipeline/runs/${encodeURIComponent(runId)}`, NO_STORE_FETCH);
+        if (!res.ok) throw new Error('Failed to fetch pipeline run');
+        return res.json();
+    },
+
+    async getPipelineRunSteps(runId: string): Promise<PipelineRunStepsResponse> {
+        const res = await fetch(`${API_URL}/api/admin/pipeline/runs/${encodeURIComponent(runId)}/steps`, NO_STORE_FETCH);
+        if (!res.ok) throw new Error('Failed to fetch pipeline run steps');
+        return res.json();
+    },
+
+    async getPipelineRunEvidence(runId: string): Promise<PipelineRunEvidenceResponse> {
+        const res = await fetch(`${API_URL}/api/admin/pipeline/runs/${encodeURIComponent(runId)}/evidence`, NO_STORE_FETCH);
+        if (!res.ok) throw new Error('Failed to fetch pipeline run evidence');
+        return res.json();
+    },
+
+    async refreshPipelineJurisdiction(jurisdictionId: string, sourceFamily = 'meeting_minutes'): Promise<PipelineRefreshResponse> {
+        const params = new URLSearchParams({ source_family: sourceFamily });
+        const res = await fetch(
+            `${API_URL}/api/admin/pipeline/jurisdictions/${encodeURIComponent(jurisdictionId)}/refresh?${params.toString()}`,
+            { method: 'POST', cache: 'no-store' },
+        );
+        if (!res.ok) throw new Error('Failed to trigger pipeline refresh');
         return res.json();
     },
 

--- a/ops/windmill/README.md
+++ b/ops/windmill/README.md
@@ -42,6 +42,16 @@ Committed Windmill assets:
 - `ops/windmill/f/affordabot/*__flow/flow.yaml`
 - `ops/windmill/f/affordabot/*.schedule.yaml`
 
+Path B orchestration skeleton (unscheduled by default):
+- `ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.py`
+- `ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.script.yaml`
+- `ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary__flow/flow.yaml`
+
+Boundary note:
+- this flow shape calls coarse domain-command stubs only (`search_materialize`, `freshness_gate`,
+  `read_fetch`, `index`, `analyze`, `summarize_run`).
+- direct product writes (Postgres, pgvector, object storage) stay outside Windmill assets.
+
 Required workspace variables:
 
 - `f/affordabot/BACKEND_PUBLIC_URL`

--- a/ops/windmill/f/affordabot/pipeline_daily_refresh_direct_storage.py
+++ b/ops/windmill/f/affordabot/pipeline_daily_refresh_direct_storage.py
@@ -1,0 +1,61 @@
+"""
+Path A Windmill script export for storage-boundary bakeoff.
+
+This script intentionally models a Windmill step that shells into the deterministic
+runner committed in backend/scripts/verification/windmill_bakeoff_direct_storage.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from typing import Any
+
+
+def main(
+    run_date: str | None = None,
+    scenario: str = "normal",
+    state_dir: str = "docs/poc/windmill-storage-bakeoff/path-a-direct-storage/runtime_state",
+    evidence_dir: str = "docs/poc/windmill-storage-bakeoff/path-a-direct-storage",
+    emit_suite: bool = False,
+) -> dict[str, Any]:
+    mode = "suite" if emit_suite else "run"
+    command = [
+        "python3",
+        "backend/scripts/verification/windmill_bakeoff_direct_storage.py",
+        mode,
+        "--state-dir",
+        state_dir,
+    ]
+    if run_date:
+        command.extend(["--run-date", run_date])
+    if emit_suite:
+        command.extend(["--evidence-dir", evidence_dir])
+    else:
+        command.extend(["--scenario", scenario])
+
+    env = os.environ.copy()
+    proc = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    output: dict[str, Any]
+    try:
+        output = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        output = {"raw_stdout": proc.stdout}
+
+    return {
+        "status": "succeeded" if proc.returncode == 0 else "failed",
+        "mode": mode,
+        "command": command,
+        "returncode": proc.returncode,
+        "result": output,
+        "stderr": proc.stderr,
+    }

--- a/ops/windmill/f/affordabot/pipeline_daily_refresh_direct_storage.script.yaml
+++ b/ops/windmill/f/affordabot/pipeline_daily_refresh_direct_storage.script.yaml
@@ -1,0 +1,37 @@
+summary: Affordabot direct-storage bakeoff runner
+description: >
+  Path A bakeoff script. Windmill owns orchestration and invokes direct-storage
+  helper execution without calling affordabot backend domain endpoints.
+lock: ""
+kind: script
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  properties:
+    run_date:
+      type: string
+      description: Idempotency date for the San Jose meeting-minutes slice.
+      default: null
+      originalType: string
+    scenario:
+      type: string
+      enum:
+        - normal
+        - searx_failure
+        - reader_failure
+        - storage_failure
+      default: normal
+      originalType: string
+    state_dir:
+      type: string
+      default: docs/poc/windmill-storage-bakeoff/path-a-direct-storage/runtime_state
+      originalType: string
+    evidence_dir:
+      type: string
+      default: docs/poc/windmill-storage-bakeoff/path-a-direct-storage
+      originalType: string
+    emit_suite:
+      type: boolean
+      default: false
+      originalType: boolean
+  required: []

--- a/ops/windmill/f/affordabot/pipeline_daily_refresh_direct_storage__flow/flow.yaml
+++ b/ops/windmill/f/affordabot/pipeline_daily_refresh_direct_storage__flow/flow.yaml
@@ -1,0 +1,94 @@
+summary: Affordabot pipeline daily refresh (direct storage bakeoff)
+description: >
+  Path A Windmill-heavy direct-storage flow for San Jose meeting-minutes
+  evidence collection. This flow intentionally avoids backend domain endpoints.
+value:
+  modules:
+    - id: search_materialize
+      value:
+        type: script
+        path: f/affordabot/pipeline_daily_refresh_direct_storage
+        input_transforms:
+          run_date:
+            type: javascript
+            expr: flow_input.run_date
+          scenario:
+            type: static
+            value: normal
+          emit_suite:
+            type: static
+            value: false
+        retry:
+          attempts: 2
+          backoff:
+            initial_interval: 30
+            max_interval: 180
+            multiplier: 2
+    - id: rerun_idempotency
+      value:
+        type: script
+        path: f/affordabot/pipeline_daily_refresh_direct_storage
+        input_transforms:
+          run_date:
+            type: javascript
+            expr: flow_input.run_date
+          scenario:
+            type: static
+            value: normal
+          emit_suite:
+            type: static
+            value: false
+    - id: searx_failure_drill
+      value:
+        type: script
+        path: f/affordabot/pipeline_daily_refresh_direct_storage
+        input_transforms:
+          run_date:
+            type: javascript
+            expr: flow_input.run_date
+          scenario:
+            type: static
+            value: searx_failure
+          emit_suite:
+            type: static
+            value: false
+    - id: reader_failure_drill
+      value:
+        type: script
+        path: f/affordabot/pipeline_daily_refresh_direct_storage
+        input_transforms:
+          run_date:
+            type: javascript
+            expr: flow_input.run_date
+          scenario:
+            type: static
+            value: reader_failure
+          emit_suite:
+            type: static
+            value: false
+    - id: storage_failure_drill
+      value:
+        type: script
+        path: f/affordabot/pipeline_daily_refresh_direct_storage
+        input_transforms:
+          run_date:
+            type: javascript
+            expr: flow_input.run_date
+          scenario:
+            type: static
+            value: storage_failure
+          emit_suite:
+            type: static
+            value: false
+concurrency:
+  limit: 1
+  key: affordabot-bakeoff-direct-storage
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  properties:
+    run_date:
+      type: string
+      description: Idempotency date for the San Jose slice.
+  required: []
+ws_error_handler_muted: false

--- a/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.py
+++ b/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.py
@@ -1,91 +1,46 @@
-"""Windmill script surface for Path B orchestration review.
+"""Windmill script surface for Path B orchestration skeleton.
 
-This script models step-level orchestration payloads for the domain-boundary pipeline.
-It is committed for flow-shape review and contract comparison with Path A.
+This file intentionally models orchestration behavior only:
+- build scope matrix (jurisdiction x source family)
+- invoke coarse domain commands via stubs
+- branch on freshness status (blocked vs usable)
+- aggregate run summary + failure handler surface
+
+No direct product writes are performed here.
 """
 
-from typing import Any, Dict, Optional
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Dict, List, Optional
 
 
-def _step_result(
+USABLE_STATUSES = {"fresh", "stale_but_usable", "empty_but_usable"}
+BLOCKED_STATUSES = {"stale_blocked", "empty_blocked"}
+
+
+def _stable_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def _envelope(
+    *,
     step: str,
-    envelope: Dict[str, Any],
-    stale_status: str,
-    previous_step_output: Optional[Dict[str, Any]],
-    search_query: Optional[str],
-    analysis_question: Optional[str],
+    contract_version: str,
+    architecture_path: str,
+    windmill_workspace: str,
+    windmill_flow_path: str,
+    windmill_run_id: str,
+    windmill_job_id: str,
+    idempotency_key: str,
+    scope_item: Dict[str, str],
+    scope_index: int,
+    mode: str,
 ) -> Dict[str, Any]:
-    if step == "search_materialize":
-        return {
-            "status": "fresh",
-            "snapshot_id": "snapshot-579c45d51063aaef",
-            "result_count": 2,
-            "query": search_query,
-            "envelope": envelope,
-        }
-
-    if step == "freshness_gate":
-        if stale_status not in {"fresh", "stale_but_usable", "stale_blocked"}:
-            return {"status": "source_error", "error": "invalid_stale_status", "envelope": envelope}
-        return {"status": stale_status, "age_seconds": 3600, "envelope": envelope}
-
-    if step == "read_fetch":
-        if not previous_step_output:
-            return {"status": "reader_error", "error": "missing_freshness_gate_output", "envelope": envelope}
-        return {
-            "status": "fresh",
-            "canonical_document_key": "san-jose-ca::a653e7debe31e650",
-            "artifact_ref": "minio://affordabot-artifacts/San_Jose_CA/ecf092f9a92f34b1.md",
-            "envelope": envelope,
-        }
-
-    if step == "index":
-        if not previous_step_output:
-            return {"status": "storage_error", "error": "missing_read_fetch_output", "envelope": envelope}
-        return {
-            "status": "fresh",
-            "chunks_total": 5,
-            "chunks_created": 5,
-            "envelope": envelope,
-        }
-
-    if step == "analyze":
-        if not previous_step_output:
-            return {"status": "analysis_error", "error": "missing_index_output", "envelope": envelope}
-        return {
-            "status": "fresh",
-            "analysis_id": "analysis-ebbbe7e0f3aeac41",
-            "question": analysis_question,
-            "envelope": envelope,
-        }
-
-    if step == "summarize_run":
-        return {
-            "status": "succeeded",
-            "summary": "Path B flow-shape export. Domain writes belong to affordabot commands.",
-            "envelope": envelope,
-        }
-
-    return {"status": "source_error", "error": f"unsupported_step:{step}", "envelope": envelope}
-
-
-def main(
-    step: str,
-    contract_version: str = "2026-04-12.windmill-storage-bakeoff.v1",
-    architecture_path: str = "affordabot_domain_boundary",
-    windmill_workspace: str = "affordabot",
-    windmill_flow_path: str = "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
-    windmill_run_id: str = "windmill-run-id",
-    windmill_job_id: str = "windmill-job-id",
-    idempotency_key: str = "san-jose-ca:meeting_minutes:2026-04-12",
-    jurisdiction: str = "San Jose CA",
-    source_family: str = "meeting_minutes",
-    stale_status: str = "fresh",
-    search_query: Optional[str] = None,
-    analysis_question: Optional[str] = None,
-    previous_step_output: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
-    envelope = {
+    jurisdiction = scope_item.get("jurisdiction", "")
+    source_family = scope_item.get("source_family", "")
+    scope_key = f"{jurisdiction}|{source_family}|{scope_index}"
+    return {
         "contract_version": contract_version,
         "architecture_path": architecture_path,
         "orchestrator": "windmill",
@@ -93,16 +48,309 @@ def main(
         "windmill_flow_path": windmill_flow_path,
         "windmill_run_id": windmill_run_id,
         "windmill_job_id": windmill_job_id,
+        "windmill_step_id": step,
         "idempotency_key": idempotency_key,
         "jurisdiction": jurisdiction,
         "source_family": source_family,
+        "scope_index": scope_index,
+        "scope_key": scope_key,
+        "mode": mode,
     }
 
-    return _step_result(
-        step=step,
-        envelope=envelope,
-        stale_status=stale_status,
-        previous_step_output=previous_step_output,
-        search_query=search_query,
-        analysis_question=analysis_question,
-    )
+
+def _invoke_command_stub(
+    *,
+    command: str,
+    envelope: Dict[str, Any],
+    stale_status: str,
+    previous_step_output: Optional[Dict[str, Any]],
+    search_query: Optional[str],
+    analysis_question: Optional[str],
+) -> Dict[str, Any]:
+    if command == "search_materialize":
+        return {
+            "status": "fresh",
+            "snapshot_id": f"snapshot-{_stable_hash(envelope['scope_key'])}",
+            "result_count": 2,
+            "query": search_query,
+            "envelope": envelope,
+            "invoked_command": command,
+        }
+
+    if command == "freshness_gate":
+        if stale_status not in USABLE_STATUSES | BLOCKED_STATUSES:
+            return {
+                "status": "source_error",
+                "error": "invalid_stale_status",
+                "envelope": envelope,
+                "invoked_command": command,
+            }
+        return {
+            "status": stale_status,
+            "age_seconds": 3600,
+            "envelope": envelope,
+            "invoked_command": command,
+        }
+
+    if command == "read_fetch":
+        if not previous_step_output:
+            return {
+                "status": "reader_error",
+                "error": "missing_freshness_gate_output",
+                "envelope": envelope,
+                "invoked_command": command,
+            }
+        return {
+            "status": "fresh",
+            "canonical_document_key": f"doc-{_stable_hash(envelope['scope_key'])}",
+            "reader_record_id": f"reader-{_stable_hash(envelope['windmill_run_id'])}",
+            "envelope": envelope,
+            "invoked_command": command,
+        }
+
+    if command == "index":
+        if not previous_step_output:
+            return {
+                "status": "storage_error",
+                "error": "missing_read_fetch_output",
+                "envelope": envelope,
+                "invoked_command": command,
+            }
+        return {
+            "status": "fresh",
+            "chunks_total": 5,
+            "chunks_created": 5,
+            "envelope": envelope,
+            "invoked_command": command,
+        }
+
+    if command == "analyze":
+        if not previous_step_output:
+            return {
+                "status": "analysis_error",
+                "error": "missing_index_output",
+                "envelope": envelope,
+                "invoked_command": command,
+            }
+        return {
+            "status": "fresh",
+            "analysis_id": f"analysis-{_stable_hash(envelope['idempotency_key'])}",
+            "question": analysis_question,
+            "envelope": envelope,
+            "invoked_command": command,
+        }
+
+    if command == "summarize_run":
+        terminal_status = previous_step_output.get("status") if previous_step_output else "source_error"
+        flow_status = "blocked" if terminal_status in BLOCKED_STATUSES else "succeeded"
+        if terminal_status not in USABLE_STATUSES | BLOCKED_STATUSES | {"fresh", "succeeded"}:
+            flow_status = "failed"
+        return {
+            "status": flow_status,
+            "terminal_step_status": terminal_status,
+            "summary": "Path B orchestration skeleton. Product writes belong to affordabot commands.",
+            "envelope": envelope,
+            "invoked_command": command,
+        }
+
+    return {
+        "status": "source_error",
+        "error": f"unsupported_command:{command}",
+        "envelope": envelope,
+        "invoked_command": command,
+    }
+
+
+def _build_scope_matrix(jurisdictions: List[str], source_families: List[str]) -> Dict[str, Any]:
+    items: List[Dict[str, Any]] = []
+    for jurisdiction in jurisdictions:
+        for source_family in source_families:
+            items.append(
+                {
+                    "jurisdiction": jurisdiction,
+                    "source_family": source_family,
+                    "scope_key": f"{jurisdiction.lower()}::{source_family.lower()}",
+                }
+            )
+    return {
+        "status": "ready",
+        "scope_items": items,
+        "scope_count": len(items),
+    }
+
+
+def _run_scope_pipeline(
+    *,
+    contract_version: str,
+    architecture_path: str,
+    windmill_workspace: str,
+    windmill_flow_path: str,
+    windmill_run_id: str,
+    windmill_job_id: str,
+    idempotency_key: str,
+    mode: str,
+    scope_item: Dict[str, str],
+    scope_index: int,
+    stale_status: str,
+    search_query: Optional[str],
+    analysis_question: Optional[str],
+) -> Dict[str, Any]:
+    steps: Dict[str, Dict[str, Any]] = {}
+
+    def run_step(command: str, previous: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        env = _envelope(
+            step=command,
+            contract_version=contract_version,
+            architecture_path=architecture_path,
+            windmill_workspace=windmill_workspace,
+            windmill_flow_path=windmill_flow_path,
+            windmill_run_id=windmill_run_id,
+            windmill_job_id=f"{windmill_job_id}:{scope_index}:{command}",
+            idempotency_key=idempotency_key,
+            scope_item=scope_item,
+            scope_index=scope_index,
+            mode=mode,
+        )
+        return _invoke_command_stub(
+            command=command,
+            envelope=env,
+            stale_status=stale_status,
+            previous_step_output=previous,
+            search_query=search_query,
+            analysis_question=analysis_question,
+        )
+
+    steps["search_materialize"] = run_step("search_materialize")
+    steps["freshness_gate"] = run_step("freshness_gate", previous=steps["search_materialize"])
+    freshness_status = steps["freshness_gate"].get("status", "source_error")
+
+    if freshness_status in BLOCKED_STATUSES:
+        steps["summarize_run"] = run_step("summarize_run", previous=steps["freshness_gate"])
+        return {
+            "scope_item": scope_item,
+            "scope_index": scope_index,
+            "status": "blocked",
+            "steps": steps,
+            "alert": f"freshness_gate:{freshness_status}",
+        }
+
+    if freshness_status not in USABLE_STATUSES:
+        steps["summarize_run"] = run_step("summarize_run", previous=steps["freshness_gate"])
+        return {
+            "scope_item": scope_item,
+            "scope_index": scope_index,
+            "status": "failed",
+            "steps": steps,
+            "alert": f"freshness_gate:{freshness_status}",
+        }
+
+    steps["read_fetch"] = run_step("read_fetch", previous=steps["freshness_gate"])
+    if steps["read_fetch"].get("status") != "fresh":
+        steps["summarize_run"] = run_step("summarize_run", previous=steps["read_fetch"])
+        return {
+            "scope_item": scope_item,
+            "scope_index": scope_index,
+            "status": "failed",
+            "steps": steps,
+            "alert": f"read_fetch:{steps['read_fetch'].get('status')}",
+        }
+
+    steps["index"] = run_step("index", previous=steps["read_fetch"])
+    if steps["index"].get("status") != "fresh":
+        steps["summarize_run"] = run_step("summarize_run", previous=steps["index"])
+        return {
+            "scope_item": scope_item,
+            "scope_index": scope_index,
+            "status": "failed",
+            "steps": steps,
+            "alert": f"index:{steps['index'].get('status')}",
+        }
+
+    steps["analyze"] = run_step("analyze", previous=steps["index"])
+    steps["summarize_run"] = run_step("summarize_run", previous=steps["analyze"])
+    return {
+        "scope_item": scope_item,
+        "scope_index": scope_index,
+        "status": "succeeded" if steps["analyze"].get("status") == "fresh" else "failed",
+        "steps": steps,
+        "alert": "",
+    }
+
+
+def _aggregate_scope_results(scope_results: List[Dict[str, Any]]) -> Dict[str, Any]:
+    total = len(scope_results)
+    blocked = sum(1 for result in scope_results if result.get("status") == "blocked")
+    failed = sum(1 for result in scope_results if result.get("status") == "failed")
+    succeeded = sum(1 for result in scope_results if result.get("status") == "succeeded")
+    alerts = [result["alert"] for result in scope_results if result.get("alert")]
+    run_status = "failed" if failed > 0 or blocked > 0 else "succeeded"
+    return {
+        "status": run_status,
+        "scope_total": total,
+        "scope_succeeded": succeeded,
+        "scope_blocked": blocked,
+        "scope_failed": failed,
+        "alerts": alerts,
+        "scope_results": scope_results,
+    }
+
+
+def main(
+    step: str,
+    contract_version: str = "2026-04-13.windmill-domain-boundary.v1",
+    architecture_path: str = "affordabot_domain_boundary",
+    windmill_workspace: str = "affordabot",
+    windmill_flow_path: str = "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+    windmill_run_id: str = "windmill-run-id",
+    windmill_job_id: str = "windmill-job-id",
+    idempotency_key: str = "run:2026-04-13",
+    mode: str = "scheduled",
+    jurisdictions: Optional[List[str]] = None,
+    source_families: Optional[List[str]] = None,
+    scope_item: Optional[Dict[str, str]] = None,
+    scope_index: int = 0,
+    stale_status: str = "fresh",
+    search_query: Optional[str] = None,
+    analysis_question: Optional[str] = None,
+    previous_step_output: Optional[Dict[str, Any]] = None,
+    scope_results: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    jurisdictions = jurisdictions or ["San Jose CA"]
+    source_families = source_families or ["meeting_minutes"]
+
+    if step == "build_scope_matrix":
+        return _build_scope_matrix(jurisdictions, source_families)
+
+    if step == "run_scope_pipeline":
+        if not scope_item:
+            return {"status": "failed", "error": "missing_scope_item"}
+        return _run_scope_pipeline(
+            contract_version=contract_version,
+            architecture_path=architecture_path,
+            windmill_workspace=windmill_workspace,
+            windmill_flow_path=windmill_flow_path,
+            windmill_run_id=windmill_run_id,
+            windmill_job_id=windmill_job_id,
+            idempotency_key=idempotency_key,
+            mode=mode,
+            scope_item=scope_item,
+            scope_index=scope_index,
+            stale_status=stale_status,
+            search_query=search_query,
+            analysis_question=analysis_question,
+        )
+
+    if step == "aggregate_run_summary":
+        return _aggregate_scope_results(scope_results or [])
+
+    if step == "failure_handler":
+        return {
+            "status": "failed",
+            "summary": "Windmill failure handler for Path B orchestration skeleton.",
+            "last_step": previous_step_output,
+            "windmill_run_id": windmill_run_id,
+            "windmill_job_id": windmill_job_id,
+            "contract_version": contract_version,
+        }
+
+    return {"status": "source_error", "error": f"unsupported_step:{step}"}

--- a/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.py
+++ b/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.py
@@ -15,6 +15,7 @@ import hashlib
 from typing import Any, Dict, List, Optional
 
 
+CONTRACT_VERSION = "2026-04-13.windmill-domain.v1"
 USABLE_STATUSES = {"fresh", "stale_but_usable", "empty_but_usable"}
 BLOCKED_STATUSES = {"stale_blocked", "empty_blocked"}
 
@@ -50,7 +51,8 @@ def _envelope(
         "windmill_job_id": windmill_job_id,
         "windmill_step_id": step,
         "idempotency_key": idempotency_key,
-        "jurisdiction": jurisdiction,
+        "jurisdiction_id": jurisdiction,
+        "jurisdiction_name": jurisdiction,
         "source_family": source_family,
         "scope_index": scope_index,
         "scope_key": scope_key,
@@ -297,7 +299,7 @@ def _aggregate_scope_results(scope_results: List[Dict[str, Any]]) -> Dict[str, A
 
 def main(
     step: str,
-    contract_version: str = "2026-04-13.windmill-domain-boundary.v1",
+    contract_version: str = CONTRACT_VERSION,
     architecture_path: str = "affordabot_domain_boundary",
     windmill_workspace: str = "affordabot",
     windmill_flow_path: str = "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",

--- a/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.py
+++ b/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.py
@@ -1,0 +1,108 @@
+"""Windmill script surface for Path B orchestration review.
+
+This script models step-level orchestration payloads for the domain-boundary pipeline.
+It is committed for flow-shape review and contract comparison with Path A.
+"""
+
+from typing import Any, Dict, Optional
+
+
+def _step_result(
+    step: str,
+    envelope: Dict[str, Any],
+    stale_status: str,
+    previous_step_output: Optional[Dict[str, Any]],
+    search_query: Optional[str],
+    analysis_question: Optional[str],
+) -> Dict[str, Any]:
+    if step == "search_materialize":
+        return {
+            "status": "fresh",
+            "snapshot_id": "snapshot-579c45d51063aaef",
+            "result_count": 2,
+            "query": search_query,
+            "envelope": envelope,
+        }
+
+    if step == "freshness_gate":
+        if stale_status not in {"fresh", "stale_but_usable", "stale_blocked"}:
+            return {"status": "source_error", "error": "invalid_stale_status", "envelope": envelope}
+        return {"status": stale_status, "age_seconds": 3600, "envelope": envelope}
+
+    if step == "read_fetch":
+        if not previous_step_output:
+            return {"status": "reader_error", "error": "missing_freshness_gate_output", "envelope": envelope}
+        return {
+            "status": "fresh",
+            "canonical_document_key": "san-jose-ca::a653e7debe31e650",
+            "artifact_ref": "minio://affordabot-artifacts/San_Jose_CA/ecf092f9a92f34b1.md",
+            "envelope": envelope,
+        }
+
+    if step == "index":
+        if not previous_step_output:
+            return {"status": "storage_error", "error": "missing_read_fetch_output", "envelope": envelope}
+        return {
+            "status": "fresh",
+            "chunks_total": 5,
+            "chunks_created": 5,
+            "envelope": envelope,
+        }
+
+    if step == "analyze":
+        if not previous_step_output:
+            return {"status": "analysis_error", "error": "missing_index_output", "envelope": envelope}
+        return {
+            "status": "fresh",
+            "analysis_id": "analysis-ebbbe7e0f3aeac41",
+            "question": analysis_question,
+            "envelope": envelope,
+        }
+
+    if step == "summarize_run":
+        return {
+            "status": "succeeded",
+            "summary": "Path B flow-shape export. Domain writes belong to affordabot commands.",
+            "envelope": envelope,
+        }
+
+    return {"status": "source_error", "error": f"unsupported_step:{step}", "envelope": envelope}
+
+
+def main(
+    step: str,
+    contract_version: str = "2026-04-12.windmill-storage-bakeoff.v1",
+    architecture_path: str = "affordabot_domain_boundary",
+    windmill_workspace: str = "affordabot",
+    windmill_flow_path: str = "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+    windmill_run_id: str = "windmill-run-id",
+    windmill_job_id: str = "windmill-job-id",
+    idempotency_key: str = "san-jose-ca:meeting_minutes:2026-04-12",
+    jurisdiction: str = "San Jose CA",
+    source_family: str = "meeting_minutes",
+    stale_status: str = "fresh",
+    search_query: Optional[str] = None,
+    analysis_question: Optional[str] = None,
+    previous_step_output: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    envelope = {
+        "contract_version": contract_version,
+        "architecture_path": architecture_path,
+        "orchestrator": "windmill",
+        "windmill_workspace": windmill_workspace,
+        "windmill_flow_path": windmill_flow_path,
+        "windmill_run_id": windmill_run_id,
+        "windmill_job_id": windmill_job_id,
+        "idempotency_key": idempotency_key,
+        "jurisdiction": jurisdiction,
+        "source_family": source_family,
+    }
+
+    return _step_result(
+        step=step,
+        envelope=envelope,
+        stale_status=stale_status,
+        previous_step_output=previous_step_output,
+        search_query=search_query,
+        analysis_question=analysis_question,
+    )

--- a/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.py
+++ b/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.py
@@ -12,6 +12,9 @@ No direct product writes are performed here.
 from __future__ import annotations
 
 import hashlib
+import sys
+from datetime import timedelta
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 
@@ -279,6 +282,381 @@ def _run_scope_pipeline(
     }
 
 
+def _load_domain_package() -> Any:
+    repo_root = Path(__file__).resolve().parents[4]
+    backend_dir = repo_root / "backend"
+    backend_dir_text = str(backend_dir)
+    if backend_dir_text not in sys.path:
+        sys.path.insert(0, backend_dir_text)
+
+    from services.pipeline.domain import (  # noqa: PLC0415
+        CommandEnvelope,
+        FreshnessPolicy,
+        InMemoryAnalyzer,
+        InMemoryArtifactStore,
+        InMemoryDomainState,
+        InMemoryReaderProvider,
+        InMemorySearchProvider,
+        InMemoryVectorStore,
+        PipelineDomainCommands,
+        SearchResultItem,
+        WindmillMetadata,
+    )
+
+    return {
+        "CommandEnvelope": CommandEnvelope,
+        "FreshnessPolicy": FreshnessPolicy,
+        "InMemoryAnalyzer": InMemoryAnalyzer,
+        "InMemoryArtifactStore": InMemoryArtifactStore,
+        "InMemoryDomainState": InMemoryDomainState,
+        "InMemoryReaderProvider": InMemoryReaderProvider,
+        "InMemorySearchProvider": InMemorySearchProvider,
+        "InMemoryVectorStore": InMemoryVectorStore,
+        "PipelineDomainCommands": PipelineDomainCommands,
+        "SearchResultItem": SearchResultItem,
+        "WindmillMetadata": WindmillMetadata,
+    }
+
+
+def _build_domain_service(
+    *,
+    domain_state: Any | None,
+    scope_item: Dict[str, str],
+    search_query: str | None,
+) -> tuple[Any, Any]:
+    domain = _load_domain_package()
+    state = domain_state or domain["InMemoryDomainState"]()
+
+    default_url = (
+        "https://www.sanjoseca.gov/your-government/departments-offices/"
+        "city-clerk/city-council-meeting-minutes"
+    )
+    title = f"{scope_item.get('jurisdiction', 'Unknown')} Meeting Minutes"
+    snippet = search_query or "Local meeting minutes and agenda updates."
+    search_results = [
+        domain["SearchResultItem"](
+            url=default_url,
+            title=title,
+            snippet=snippet,
+        )
+    ]
+
+    service = domain["PipelineDomainCommands"](
+        state=state,
+        search_provider=domain["InMemorySearchProvider"](results=search_results),
+        reader_provider=domain["InMemoryReaderProvider"](),
+        artifact_store=domain["InMemoryArtifactStore"](state),
+        vector_store=domain["InMemoryVectorStore"](state),
+        analyzer=domain["InMemoryAnalyzer"](),
+    )
+    return state, service
+
+
+def _apply_staleness_override(
+    *,
+    stale_status: str,
+    state: Any,
+    snapshot_id: str,
+    scope_key: str,
+) -> Any | None:
+    now = state.now
+    latest_success = None
+    if stale_status == "stale_but_usable":
+        state.search_snapshots[snapshot_id]["captured_at"] = (now - timedelta(hours=36)).isoformat()
+        latest_success = now
+    elif stale_status == "stale_blocked":
+        state.search_snapshots[snapshot_id]["captured_at"] = (now - timedelta(hours=120)).isoformat()
+        latest_success = now
+    elif stale_status == "empty_but_usable":
+        state.search_snapshots[snapshot_id]["results"] = []
+        latest_success = now
+    elif stale_status == "empty_blocked":
+        state.search_snapshots[snapshot_id]["results"] = []
+        latest_success = None
+    if latest_success is not None:
+        state.previous_success_by_scope[scope_key] = latest_success
+    return latest_success
+
+
+def _run_scope_pipeline_domain_package(
+    *,
+    contract_version: str,
+    windmill_workspace: str,
+    windmill_flow_path: str,
+    windmill_run_id: str,
+    windmill_job_id: str,
+    idempotency_key: str,
+    scope_item: Dict[str, str],
+    scope_index: int,
+    stale_status: str,
+    search_query: str | None,
+    analysis_question: str | None,
+    domain_state: Any | None,
+) -> Dict[str, Any]:
+    state, service = _build_domain_service(
+        domain_state=domain_state,
+        scope_item=scope_item,
+        search_query=search_query,
+    )
+    domain = _load_domain_package()
+    policy = domain["FreshnessPolicy"](
+        fresh_hours=24,
+        stale_usable_ceiling_hours=72,
+        fail_closed_ceiling_hours=168,
+    )
+
+    scope_key = f"{scope_item.get('jurisdiction', '')}|{scope_item.get('source_family', '')}"
+    steps: Dict[str, Dict[str, Any]] = {}
+    envelopes: Dict[str, Dict[str, Any]] = {}
+
+    def make_envelope(command: str, step_idx: int) -> Any:
+        env = _envelope(
+            step=command,
+            contract_version=contract_version,
+            architecture_path="affordabot_domain_boundary",
+            windmill_workspace=windmill_workspace,
+            windmill_flow_path=windmill_flow_path,
+            windmill_run_id=windmill_run_id,
+            windmill_job_id=f"{windmill_job_id}:{scope_index}:{step_idx}",
+            idempotency_key=f"{idempotency_key}:{command}",
+            scope_item=scope_item,
+            scope_index=scope_index,
+            mode="domain_package",
+        )
+        envelopes[command] = env
+        return domain["CommandEnvelope"](
+            command=command,
+            jurisdiction_id=env["jurisdiction_id"],
+            source_family=env["source_family"],
+            idempotency_key=env["idempotency_key"],
+            contract_version=env["contract_version"],
+            windmill=domain["WindmillMetadata"](
+                run_id=env["windmill_run_id"],
+                job_id=env["windmill_job_id"],
+                workspace=env["windmill_workspace"],
+                flow_path=env["windmill_flow_path"],
+            ),
+        )
+
+    def store_step(command: str, response: Any) -> None:
+        payload = response.to_dict()
+        payload["envelope"] = envelopes[command]
+        payload["invoked_command"] = command
+        steps[command] = payload
+
+    search_env = make_envelope("search_materialize", 1)
+    search = service.search_materialize(
+        envelope=search_env,
+        query=search_query or "San Jose meeting minutes",
+    )
+    store_step("search_materialize", search)
+    snapshot_id = str(search.refs.get("search_snapshot_id", ""))
+    latest_success = _apply_staleness_override(
+        stale_status=stale_status,
+        state=state,
+        snapshot_id=snapshot_id,
+        scope_key=scope_key,
+    )
+
+    freshness_env = make_envelope("freshness_gate", 2)
+    freshness = service.freshness_gate(
+        envelope=freshness_env,
+        snapshot_id=snapshot_id,
+        policy=policy,
+        latest_success_at=latest_success,
+    )
+    store_step("freshness_gate", freshness)
+
+    if freshness.decision_reason in BLOCKED_STATUSES:
+        summarize_env = make_envelope("summarize_run", 6)
+        summary = service.summarize_run(
+            envelope=summarize_env,
+            command_responses=[search, freshness],
+        )
+        store_step("summarize_run", summary)
+        return {
+            "scope_item": scope_item,
+            "scope_index": scope_index,
+            "status": "blocked",
+            "steps": steps,
+            "alert": f"freshness_gate:{freshness.decision_reason}",
+            "domain_state": state,
+        }
+
+    if freshness.status.startswith("failed"):
+        summarize_env = make_envelope("summarize_run", 6)
+        summary = service.summarize_run(
+            envelope=summarize_env,
+            command_responses=[search, freshness],
+        )
+        store_step("summarize_run", summary)
+        return {
+            "scope_item": scope_item,
+            "scope_index": scope_index,
+            "status": "failed",
+            "steps": steps,
+            "alert": f"freshness_gate:{freshness.decision_reason}",
+            "domain_state": state,
+        }
+
+    read_env = make_envelope("read_fetch", 3)
+    read = service.read_fetch(
+        envelope=read_env,
+        snapshot_id=snapshot_id,
+    )
+    store_step("read_fetch", read)
+    if read.status != "succeeded":
+        summarize_env = make_envelope("summarize_run", 6)
+        summary = service.summarize_run(
+            envelope=summarize_env,
+            command_responses=[search, freshness, read],
+        )
+        store_step("summarize_run", summary)
+        return {
+            "scope_item": scope_item,
+            "scope_index": scope_index,
+            "status": "failed",
+            "steps": steps,
+            "alert": f"read_fetch:{read.decision_reason}",
+            "domain_state": state,
+        }
+
+    index_env = make_envelope("index", 4)
+    index = service.index(
+        envelope=index_env,
+        raw_scrape_ids=list(read.refs.get("raw_scrape_ids", [])),
+    )
+    store_step("index", index)
+    if index.status.startswith("failed") or index.status == "blocked":
+        summarize_env = make_envelope("summarize_run", 6)
+        summary = service.summarize_run(
+            envelope=summarize_env,
+            command_responses=[search, freshness, read, index],
+        )
+        store_step("summarize_run", summary)
+        return {
+            "scope_item": scope_item,
+            "scope_index": scope_index,
+            "status": "failed",
+            "steps": steps,
+            "alert": f"index:{index.decision_reason}",
+            "domain_state": state,
+        }
+
+    analyze_env = make_envelope("analyze", 5)
+    analyze = service.analyze(
+        envelope=analyze_env,
+        question=analysis_question or "Summarize meeting minutes",
+        jurisdiction_id=scope_item.get("jurisdiction", ""),
+        source_family=scope_item.get("source_family", ""),
+    )
+    store_step("analyze", analyze)
+
+    summarize_env = make_envelope("summarize_run", 6)
+    summary = service.summarize_run(
+        envelope=summarize_env,
+        command_responses=[search, freshness, read, index, analyze],
+    )
+    store_step("summarize_run", summary)
+
+    run_status = "succeeded"
+    if summary.status in {"failed_retryable", "failed_terminal"}:
+        run_status = "failed"
+    elif summary.status == "blocked":
+        run_status = "blocked"
+    return {
+        "scope_item": scope_item,
+        "scope_index": scope_index,
+        "status": run_status,
+        "steps": steps,
+        "alert": "" if run_status == "succeeded" else f"summarize_run:{summary.status}",
+        "domain_state": state,
+    }
+
+
+def _run_local_integration_harness(
+    *,
+    contract_version: str,
+    windmill_workspace: str,
+    windmill_flow_path: str,
+    windmill_run_id: str,
+    windmill_job_id: str,
+    idempotency_key: str,
+    scope_item: Dict[str, str],
+    search_query: str | None,
+    analysis_question: str | None,
+) -> Dict[str, Any]:
+    first = _run_scope_pipeline_domain_package(
+        contract_version=contract_version,
+        windmill_workspace=windmill_workspace,
+        windmill_flow_path=windmill_flow_path,
+        windmill_run_id=windmill_run_id,
+        windmill_job_id=windmill_job_id,
+        idempotency_key=idempotency_key,
+        scope_item=scope_item,
+        scope_index=0,
+        stale_status="fresh",
+        search_query=search_query,
+        analysis_question=analysis_question,
+        domain_state=None,
+    )
+    rerun = _run_scope_pipeline_domain_package(
+        contract_version=contract_version,
+        windmill_workspace=windmill_workspace,
+        windmill_flow_path=windmill_flow_path,
+        windmill_run_id=windmill_run_id,
+        windmill_job_id=windmill_job_id,
+        idempotency_key=idempotency_key,
+        scope_item=scope_item,
+        scope_index=0,
+        stale_status="fresh",
+        search_query=search_query,
+        analysis_question=analysis_question,
+        domain_state=first["domain_state"],
+    )
+    blocked = _run_scope_pipeline_domain_package(
+        contract_version=contract_version,
+        windmill_workspace=windmill_workspace,
+        windmill_flow_path=windmill_flow_path,
+        windmill_run_id=windmill_run_id,
+        windmill_job_id=windmill_job_id,
+        idempotency_key=f"{idempotency_key}:blocked",
+        scope_item=scope_item,
+        scope_index=1,
+        stale_status="stale_blocked",
+        search_query=search_query,
+        analysis_question=analysis_question,
+        domain_state=first["domain_state"],
+    )
+
+    first_index = first["steps"]["index"]
+    rerun_index = rerun["steps"]["index"]
+    evidence = {
+        "happy_status": first["status"],
+        "rerun_status": rerun["status"],
+        "stale_blocked_status": blocked["status"],
+        "rerun_index_idempotent_reuse": bool(rerun_index["details"].get("idempotent_reuse")),
+        "rerun_chunk_count_stable": first_index["counts"].get("chunks") == rerun_index["counts"].get("chunks"),
+        "stale_blocked_short_circuit": "read_fetch" not in blocked["steps"],
+        "windmill_refs_propagated": all(
+            step["refs"].get("windmill_run_id") == windmill_run_id
+            for step in first["steps"].values()
+        ),
+    }
+    for result in (first, rerun, blocked):
+        result.pop("domain_state", None)
+    return {
+        "status": "succeeded" if all(v for v in evidence.values()) else "failed",
+        "scope_item": scope_item,
+        "scenarios": {
+            "happy_first": first,
+            "happy_rerun": rerun,
+            "stale_blocked": blocked,
+        },
+        "evidence": evidence,
+    }
+
+
 def _aggregate_scope_results(scope_results: List[Dict[str, Any]]) -> Dict[str, Any]:
     total = len(scope_results)
     blocked = sum(1 for result in scope_results if result.get("status") == "blocked")
@@ -316,6 +694,8 @@ def main(
     analysis_question: Optional[str] = None,
     previous_step_output: Optional[Dict[str, Any]] = None,
     scope_results: Optional[List[Dict[str, Any]]] = None,
+    command_client: str = "stub",
+    domain_state: Any | None = None,
 ) -> Dict[str, Any]:
     jurisdictions = jurisdictions or ["San Jose CA"]
     source_families = source_families or ["meeting_minutes"]
@@ -326,6 +706,21 @@ def main(
     if step == "run_scope_pipeline":
         if not scope_item:
             return {"status": "failed", "error": "missing_scope_item"}
+        if command_client == "domain_package":
+            return _run_scope_pipeline_domain_package(
+                contract_version=contract_version,
+                windmill_workspace=windmill_workspace,
+                windmill_flow_path=windmill_flow_path,
+                windmill_run_id=windmill_run_id,
+                windmill_job_id=windmill_job_id,
+                idempotency_key=idempotency_key,
+                scope_item=scope_item,
+                scope_index=scope_index,
+                stale_status=stale_status,
+                search_query=search_query,
+                analysis_question=analysis_question,
+                domain_state=domain_state,
+            )
         return _run_scope_pipeline(
             contract_version=contract_version,
             architecture_path=architecture_path,
@@ -338,6 +733,21 @@ def main(
             scope_item=scope_item,
             scope_index=scope_index,
             stale_status=stale_status,
+            search_query=search_query,
+            analysis_question=analysis_question,
+        )
+
+    if step == "run_local_integration_harness":
+        if not scope_item:
+            scope_item = {"jurisdiction": jurisdictions[0], "source_family": source_families[0]}
+        return _run_local_integration_harness(
+            contract_version=contract_version,
+            windmill_workspace=windmill_workspace,
+            windmill_flow_path=windmill_flow_path,
+            windmill_run_id=windmill_run_id,
+            windmill_job_id=windmill_job_id,
+            idempotency_key=idempotency_key,
+            scope_item=scope_item,
             search_query=search_query,
             analysis_question=analysis_question,
         )

--- a/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.script.yaml
+++ b/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.script.yaml
@@ -1,0 +1,65 @@
+summary: Affordabot Path B domain-boundary bakeoff step
+description: >
+  Step-level script for the Path B windmill storage-boundary bakeoff.
+  This export is for orchestration-shape review and contract comparison.
+lock: ""
+kind: script
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  properties:
+    step:
+      type: string
+      description: Pipeline step name.
+      enum:
+        - search_materialize
+        - freshness_gate
+        - read_fetch
+        - index
+        - analyze
+        - summarize_run
+    contract_version:
+      type: string
+      default: 2026-04-12.windmill-storage-bakeoff.v1
+    architecture_path:
+      type: string
+      default: affordabot_domain_boundary
+    windmill_workspace:
+      type: string
+      default: affordabot
+    windmill_flow_path:
+      type: string
+      default: f/affordabot/pipeline_daily_refresh_domain_boundary__flow
+    windmill_run_id:
+      type: string
+      default: windmill-run-id
+    windmill_job_id:
+      type: string
+      default: windmill-job-id
+    idempotency_key:
+      type: string
+      default: san-jose-ca:meeting_minutes:2026-04-12
+    jurisdiction:
+      type: string
+      default: San Jose CA
+    source_family:
+      type: string
+      default: meeting_minutes
+    stale_status:
+      type: string
+      default: fresh
+      enum:
+        - fresh
+        - stale_but_usable
+        - stale_blocked
+    search_query:
+      type: string
+      default: San Jose CA city council meeting minutes housing
+    analysis_question:
+      type: string
+      default: Summarize housing-related signals from recent San Jose meeting minutes.
+    previous_step_output:
+      type: object
+      default: null
+  required:
+    - step

--- a/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.script.yaml
+++ b/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.script.yaml
@@ -18,7 +18,7 @@ schema:
         - failure_handler
     contract_version:
       type: string
-      default: 2026-04-13.windmill-domain-boundary.v1
+      default: 2026-04-13.windmill-domain.v1
     architecture_path:
       type: string
       default: affordabot_domain_boundary

--- a/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.script.yaml
+++ b/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.script.yaml
@@ -1,7 +1,7 @@
-summary: Affordabot Path B domain-boundary bakeoff step
+summary: Affordabot Path B domain-boundary orchestration skeleton step
 description: >
-  Step-level script for the Path B windmill storage-boundary bakeoff.
-  This export is for orchestration-shape review and contract comparison.
+  Step-level script for Path B Windmill orchestration.
+  It models scope fanout, freshness branching, and coarse domain command calls.
 lock: ""
 kind: script
 schema:
@@ -12,15 +12,13 @@ schema:
       type: string
       description: Pipeline step name.
       enum:
-        - search_materialize
-        - freshness_gate
-        - read_fetch
-        - index
-        - analyze
-        - summarize_run
+        - build_scope_matrix
+        - run_scope_pipeline
+        - aggregate_run_summary
+        - failure_handler
     contract_version:
       type: string
-      default: 2026-04-12.windmill-storage-bakeoff.v1
+      default: 2026-04-13.windmill-domain-boundary.v1
     architecture_path:
       type: string
       default: affordabot_domain_boundary
@@ -38,13 +36,39 @@ schema:
       default: windmill-job-id
     idempotency_key:
       type: string
-      default: san-jose-ca:meeting_minutes:2026-04-12
-    jurisdiction:
+      default: run:2026-04-13
+    mode:
       type: string
-      default: San Jose CA
-    source_family:
-      type: string
-      default: meeting_minutes
+      default: scheduled
+      enum:
+        - scheduled
+        - manual
+        - replay
+    jurisdictions:
+      type: array
+      items:
+        type: string
+      default:
+        - San Jose CA
+    source_families:
+      type: array
+      items:
+        type: string
+      default:
+        - meeting_minutes
+    scope_item:
+      type: object
+      default: null
+      properties:
+        jurisdiction:
+          type: string
+        source_family:
+          type: string
+        scope_key:
+          type: string
+    scope_index:
+      type: integer
+      default: 0
     stale_status:
       type: string
       default: fresh
@@ -52,6 +76,8 @@ schema:
         - fresh
         - stale_but_usable
         - stale_blocked
+        - empty_but_usable
+        - empty_blocked
     search_query:
       type: string
       default: San Jose CA city council meeting minutes housing
@@ -61,5 +87,10 @@ schema:
     previous_step_output:
       type: object
       default: null
+    scope_results:
+      type: array
+      default: []
+      items:
+        type: object
   required:
     - step

--- a/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary__flow/flow.yaml
+++ b/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary__flow/flow.yaml
@@ -1,220 +1,200 @@
-summary: Affordabot Path B domain-boundary daily refresh
+summary: Affordabot Path B domain-boundary daily refresh (orchestration skeleton)
 description: >
-  Windmill-shaped flow export for Path B. Orchestration is step-separate while
-  product writes are owned by affordabot domain commands.
+  Windmill-native orchestration skeleton for Path B.
+  Uses matrix fanout and freshness branching while keeping product writes inside
+  affordabot coarse domain commands.
 value:
+  failure_module:
+    id: failure_handler
+    value:
+      type: script
+      path: f/affordabot/pipeline_daily_refresh_domain_boundary
+      input_transforms:
+        step:
+          type: static
+          value: failure_handler
+        windmill_run_id:
+          type: static
+          value: $flow_job_id
+        windmill_job_id:
+          type: static
+          value: failure_handler
+        idempotency_key:
+          type: javascript
+          expr: flow_input.idempotency_key
+        previous_step_output:
+          type: javascript
+          expr: error
   modules:
-  - id: search_materialize
-    value:
-      type: script
-      path: f/affordabot/pipeline_daily_refresh_domain_boundary
-      retry:
-        attempts: 3
-        backoff:
-          initial_interval: 30
-          max_interval: 300
-          multiplier: 2
-      input_transforms:
-        step:
-          type: static
-          value: search_materialize
-        windmill_run_id:
-          type: static
-          value: $flow_job_id
-        windmill_job_id:
-          type: static
-          value: search_materialize
-        idempotency_key:
-          type: javascript
-          expr: flow_input.idempotency_key
-        jurisdiction:
-          type: javascript
-          expr: flow_input.jurisdiction
-        source_family:
-          type: javascript
-          expr: flow_input.source_family
-        search_query:
-          type: javascript
-          expr: flow_input.search_query
-  - id: freshness_gate
-    value:
-      type: script
-      path: f/affordabot/pipeline_daily_refresh_domain_boundary
-      retry:
-        attempts: 2
-        backoff:
-          initial_interval: 30
-          max_interval: 120
-          multiplier: 2
-      input_transforms:
-        step:
-          type: static
-          value: freshness_gate
-        windmill_run_id:
-          type: static
-          value: $flow_job_id
-        windmill_job_id:
-          type: static
-          value: freshness_gate
-        idempotency_key:
-          type: javascript
-          expr: flow_input.idempotency_key
-        jurisdiction:
-          type: javascript
-          expr: flow_input.jurisdiction
-        source_family:
-          type: javascript
-          expr: flow_input.source_family
-        stale_status:
-          type: javascript
-          expr: flow_input.stale_status
-        previous_step_output:
-          type: javascript
-          expr: results.search_materialize
-  - id: read_fetch
-    value:
-      type: script
-      path: f/affordabot/pipeline_daily_refresh_domain_boundary
-      retry:
-        attempts: 2
-        backoff:
-          initial_interval: 60
-          max_interval: 300
-          multiplier: 2
-      input_transforms:
-        step:
-          type: static
-          value: read_fetch
-        windmill_run_id:
-          type: static
-          value: $flow_job_id
-        windmill_job_id:
-          type: static
-          value: read_fetch
-        idempotency_key:
-          type: javascript
-          expr: flow_input.idempotency_key
-        jurisdiction:
-          type: javascript
-          expr: flow_input.jurisdiction
-        source_family:
-          type: javascript
-          expr: flow_input.source_family
-        previous_step_output:
-          type: javascript
-          expr: results.freshness_gate
-  - id: index
-    value:
-      type: script
-      path: f/affordabot/pipeline_daily_refresh_domain_boundary
-      retry:
-        attempts: 2
-        backoff:
-          initial_interval: 60
-          max_interval: 300
-          multiplier: 2
-      input_transforms:
-        step:
-          type: static
-          value: index
-        windmill_run_id:
-          type: static
-          value: $flow_job_id
-        windmill_job_id:
-          type: static
-          value: index
-        idempotency_key:
-          type: javascript
-          expr: flow_input.idempotency_key
-        jurisdiction:
-          type: javascript
-          expr: flow_input.jurisdiction
-        source_family:
-          type: javascript
-          expr: flow_input.source_family
-        previous_step_output:
-          type: javascript
-          expr: results.read_fetch
-  - id: analyze
-    value:
-      type: script
-      path: f/affordabot/pipeline_daily_refresh_domain_boundary
-      retry:
-        attempts: 1
-      input_transforms:
-        step:
-          type: static
-          value: analyze
-        windmill_run_id:
-          type: static
-          value: $flow_job_id
-        windmill_job_id:
-          type: static
-          value: analyze
-        idempotency_key:
-          type: javascript
-          expr: flow_input.idempotency_key
-        jurisdiction:
-          type: javascript
-          expr: flow_input.jurisdiction
-        source_family:
-          type: javascript
-          expr: flow_input.source_family
-        analysis_question:
-          type: javascript
-          expr: flow_input.analysis_question
-        previous_step_output:
-          type: javascript
-          expr: results.index
-  - id: summarize_run
+  - id: build_scope_matrix
     value:
       type: script
       path: f/affordabot/pipeline_daily_refresh_domain_boundary
       input_transforms:
         step:
           type: static
-          value: summarize_run
+          value: build_scope_matrix
         windmill_run_id:
           type: static
           value: $flow_job_id
         windmill_job_id:
           type: static
-          value: summarize_run
+          value: build_scope_matrix
         idempotency_key:
           type: javascript
           expr: flow_input.idempotency_key
-        jurisdiction:
+        mode:
           type: javascript
-          expr: flow_input.jurisdiction
-        source_family:
+          expr: flow_input.mode
+        jurisdictions:
           type: javascript
-          expr: flow_input.source_family
-        previous_step_output:
+          expr: flow_input.jurisdictions
+        source_families:
           type: javascript
-          expr: results.analyze
+          expr: flow_input.source_families
+  - id: per_scope_pipeline
+    value:
+      type: forloopflow
+      iterator:
+        type: javascript
+        expr: results.build_scope_matrix.scope_items
+      skip_failures: false
+      parallel: true
+      parallelism:
+        expr: flow_input.scope_parallelism
+      modules:
+      - id: run_scope_pipeline
+        value:
+          type: script
+          path: f/affordabot/pipeline_daily_refresh_domain_boundary
+          retry:
+            attempts: 2
+            backoff:
+              initial_interval: 30
+              max_interval: 300
+              multiplier: 2
+          input_transforms:
+            step:
+              type: static
+              value: run_scope_pipeline
+            windmill_run_id:
+              type: static
+              value: $flow_job_id
+            windmill_job_id:
+              type: static
+              value: run_scope_pipeline
+            idempotency_key:
+              type: javascript
+              expr: flow_input.idempotency_key
+            mode:
+              type: javascript
+              expr: flow_input.mode
+            scope_item:
+              type: javascript
+              expr: iter.value
+            scope_index:
+              type: javascript
+              expr: iter.index
+            stale_status:
+              type: javascript
+              expr: flow_input.stale_status
+            search_query:
+              type: javascript
+              expr: flow_input.search_query
+            analysis_question:
+              type: javascript
+              expr: flow_input.analysis_question
+      aggregate:
+        script:
+          type: javascript
+          expr: "return results;"
+  - id: branch_outcome_review
+    value:
+      type: branchone
+      branches:
+      - expr: results.per_scope_pipeline.some(item => item.status !== 'succeeded')
+        modules:
+        - id: blocked_or_failed_summary
+          value:
+            type: script
+            path: f/affordabot/pipeline_daily_refresh_domain_boundary
+            input_transforms:
+              step:
+                type: static
+                value: aggregate_run_summary
+              windmill_run_id:
+                type: static
+                value: $flow_job_id
+              windmill_job_id:
+                type: static
+                value: blocked_or_failed_summary
+              idempotency_key:
+                type: javascript
+                expr: flow_input.idempotency_key
+              scope_results:
+                type: javascript
+                expr: results.per_scope_pipeline
+      default:
+      - id: successful_summary
+        value:
+          type: script
+          path: f/affordabot/pipeline_daily_refresh_domain_boundary
+          input_transforms:
+            step:
+              type: static
+              value: aggregate_run_summary
+            windmill_run_id:
+              type: static
+              value: $flow_job_id
+            windmill_job_id:
+              type: static
+              value: successful_summary
+            idempotency_key:
+              type: javascript
+              expr: flow_input.idempotency_key
+            scope_results:
+              type: javascript
+              expr: results.per_scope_pipeline
 concurrency:
-  limit: 1
-  key: affordabot-domain-boundary-bakeoff
+  limit: 2
+  key: affordabot-domain-boundary
 schema:
   $schema: https://json-schema.org/draft/2020-12/schema
   type: object
   required:
     - idempotency_key
-    - jurisdiction
-    - source_family
+    - jurisdictions
+    - source_families
     - search_query
     - analysis_question
-    - stale_status
+    - mode
   properties:
     idempotency_key:
       type: string
-      default: san-jose-ca:meeting_minutes:2026-04-12
-    jurisdiction:
+      default: run:2026-04-13
+    jurisdictions:
+      type: array
+      items:
+        type: string
+      default:
+        - San Jose CA
+    source_families:
+      type: array
+      items:
+        type: string
+      default:
+        - meeting_minutes
+    mode:
       type: string
-      default: San Jose CA
-    source_family:
-      type: string
-      default: meeting_minutes
+      enum:
+        - scheduled
+        - manual
+        - replay
+      default: scheduled
+    scope_parallelism:
+      type: integer
+      minimum: 1
+      default: 2
     search_query:
       type: string
       default: San Jose CA city council meeting minutes housing
@@ -227,5 +207,7 @@ schema:
         - fresh
         - stale_but_usable
         - stale_blocked
+        - empty_but_usable
+        - empty_blocked
       default: fresh
 ws_error_handler_muted: false

--- a/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary__flow/flow.yaml
+++ b/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary__flow/flow.yaml
@@ -1,0 +1,231 @@
+summary: Affordabot Path B domain-boundary daily refresh
+description: >
+  Windmill-shaped flow export for Path B. Orchestration is step-separate while
+  product writes are owned by affordabot domain commands.
+value:
+  modules:
+  - id: search_materialize
+    value:
+      type: script
+      path: f/affordabot/pipeline_daily_refresh_domain_boundary
+      retry:
+        attempts: 3
+        backoff:
+          initial_interval: 30
+          max_interval: 300
+          multiplier: 2
+      input_transforms:
+        step:
+          type: static
+          value: search_materialize
+        windmill_run_id:
+          type: static
+          value: $flow_job_id
+        windmill_job_id:
+          type: static
+          value: search_materialize
+        idempotency_key:
+          type: javascript
+          expr: flow_input.idempotency_key
+        jurisdiction:
+          type: javascript
+          expr: flow_input.jurisdiction
+        source_family:
+          type: javascript
+          expr: flow_input.source_family
+        search_query:
+          type: javascript
+          expr: flow_input.search_query
+  - id: freshness_gate
+    value:
+      type: script
+      path: f/affordabot/pipeline_daily_refresh_domain_boundary
+      retry:
+        attempts: 2
+        backoff:
+          initial_interval: 30
+          max_interval: 120
+          multiplier: 2
+      input_transforms:
+        step:
+          type: static
+          value: freshness_gate
+        windmill_run_id:
+          type: static
+          value: $flow_job_id
+        windmill_job_id:
+          type: static
+          value: freshness_gate
+        idempotency_key:
+          type: javascript
+          expr: flow_input.idempotency_key
+        jurisdiction:
+          type: javascript
+          expr: flow_input.jurisdiction
+        source_family:
+          type: javascript
+          expr: flow_input.source_family
+        stale_status:
+          type: javascript
+          expr: flow_input.stale_status
+        previous_step_output:
+          type: javascript
+          expr: results.search_materialize
+  - id: read_fetch
+    value:
+      type: script
+      path: f/affordabot/pipeline_daily_refresh_domain_boundary
+      retry:
+        attempts: 2
+        backoff:
+          initial_interval: 60
+          max_interval: 300
+          multiplier: 2
+      input_transforms:
+        step:
+          type: static
+          value: read_fetch
+        windmill_run_id:
+          type: static
+          value: $flow_job_id
+        windmill_job_id:
+          type: static
+          value: read_fetch
+        idempotency_key:
+          type: javascript
+          expr: flow_input.idempotency_key
+        jurisdiction:
+          type: javascript
+          expr: flow_input.jurisdiction
+        source_family:
+          type: javascript
+          expr: flow_input.source_family
+        previous_step_output:
+          type: javascript
+          expr: results.freshness_gate
+  - id: index
+    value:
+      type: script
+      path: f/affordabot/pipeline_daily_refresh_domain_boundary
+      retry:
+        attempts: 2
+        backoff:
+          initial_interval: 60
+          max_interval: 300
+          multiplier: 2
+      input_transforms:
+        step:
+          type: static
+          value: index
+        windmill_run_id:
+          type: static
+          value: $flow_job_id
+        windmill_job_id:
+          type: static
+          value: index
+        idempotency_key:
+          type: javascript
+          expr: flow_input.idempotency_key
+        jurisdiction:
+          type: javascript
+          expr: flow_input.jurisdiction
+        source_family:
+          type: javascript
+          expr: flow_input.source_family
+        previous_step_output:
+          type: javascript
+          expr: results.read_fetch
+  - id: analyze
+    value:
+      type: script
+      path: f/affordabot/pipeline_daily_refresh_domain_boundary
+      retry:
+        attempts: 1
+      input_transforms:
+        step:
+          type: static
+          value: analyze
+        windmill_run_id:
+          type: static
+          value: $flow_job_id
+        windmill_job_id:
+          type: static
+          value: analyze
+        idempotency_key:
+          type: javascript
+          expr: flow_input.idempotency_key
+        jurisdiction:
+          type: javascript
+          expr: flow_input.jurisdiction
+        source_family:
+          type: javascript
+          expr: flow_input.source_family
+        analysis_question:
+          type: javascript
+          expr: flow_input.analysis_question
+        previous_step_output:
+          type: javascript
+          expr: results.index
+  - id: summarize_run
+    value:
+      type: script
+      path: f/affordabot/pipeline_daily_refresh_domain_boundary
+      input_transforms:
+        step:
+          type: static
+          value: summarize_run
+        windmill_run_id:
+          type: static
+          value: $flow_job_id
+        windmill_job_id:
+          type: static
+          value: summarize_run
+        idempotency_key:
+          type: javascript
+          expr: flow_input.idempotency_key
+        jurisdiction:
+          type: javascript
+          expr: flow_input.jurisdiction
+        source_family:
+          type: javascript
+          expr: flow_input.source_family
+        previous_step_output:
+          type: javascript
+          expr: results.analyze
+concurrency:
+  limit: 1
+  key: affordabot-domain-boundary-bakeoff
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  required:
+    - idempotency_key
+    - jurisdiction
+    - source_family
+    - search_query
+    - analysis_question
+    - stale_status
+  properties:
+    idempotency_key:
+      type: string
+      default: san-jose-ca:meeting_minutes:2026-04-12
+    jurisdiction:
+      type: string
+      default: San Jose CA
+    source_family:
+      type: string
+      default: meeting_minutes
+    search_query:
+      type: string
+      default: San Jose CA city council meeting minutes housing
+    analysis_question:
+      type: string
+      default: Summarize housing-related signals from recent San Jose meeting minutes.
+    stale_status:
+      type: string
+      enum:
+        - fresh
+        - stale_but_usable
+        - stale_blocked
+      default: fresh
+ws_error_handler_muted: false


### PR DESCRIPTION
Feature-Key: bd-9qjof
Agent: codex

Beads: bd-9qjof.1 through bd-9qjof.5 closed after validation; bd-9qjof.6 remains open for live Windmill auth/workspace validation; bd-9qjof.7 remains open for rollout/parity/final review.

## Summary
- Locks the Windmill/Affordabot boundary decision in docs: Windmill owns orchestration/control flow; affordabot owns product/domain invariants; backend owns read models/actions; Postgres/pgvector/MinIO remain distinct storage substrates; frontend consumes backend read APIs only.
- Adds deterministic bakeoff evidence for Path A (direct Windmill storage) and Path B (domain-boundary orchestration), with recommendation to proceed with Path B.
- Implements the first brownfield product foundation: typed domain command package, deterministic adapters/tests, additive storage migration/coordinator, Windmill flow skeleton, admin read APIs, and frontend admin pipeline status display.
- Adds Wave 3 local integration evidence proving Windmill-shaped orchestration can call the affordabot six-command domain boundary with idempotent rerun and stale-blocked behavior.

## Architecture Decision
Proceed with the hybrid/domain-boundary architecture:
- OSS/SearXNG search is primary discovery.
- Z.ai direct web search is deprecated for this pipeline and should be monitored separately as a health-check/fallback-bakeoff only.
- Z.ai direct reader remains canonical for extraction.
- Z.ai LLM analysis remains canonical for analysis.
- Windmill should use native scheduling, retries, branching, fanout, and failure handling, but must not own canonical document identity, freshness policy, provenance, or product writes.

## Validation
Local:
- Focused Wave 3 pytest set: `22 passed`.
- `poetry run python scripts/verification/verify_windmill_domain_boundary_local_integration.py`: `Run status: succeeded`.
- Targeted Ruff on Wave 3 files: pass.
- `git diff --check`: pass.
- `make ci-lite`: pass; backend tests `446 passed`; frontend lint warnings are pre-existing hook-dependency warnings.
- `pnpm --filter frontend build`: pass; build still prints pre-existing dynamic-server/backend connection warnings during static generation.

GitHub CI at head `11161c2c26601d1daa231d34b36af97640bf92c8`:
- Backend Lint & Test: pass.
- Backend Ruff Preflight: pass.
- Beads Validation: pass.
- Frontend Lint & Build: pass.
- Frontend Preservation Gate: pass.
- validate-skills: pass.

## Live Windmill Status
Non-mutating live preflight verdict: `blocked_by_auth`.

What is proven:
- `windmill-cli` is available via `npx`.
- No raw `op` commands or GUI 1Password prompts were used.
- No shared Windmill schedules/resources were mutated.

What remains before production/runtime lock:
- Configure/cache dev Windmill workspace/profile safely.
- Prove dev backend URL and internal auth token path.
- Prove isolated run namespace and no schedule mutation.
- Run the bounded San Jose live dry-run through Windmill against real backend/storage providers.

## Merge Scope
This PR merges the architecture foundation and safe local integration evidence. It does not enable a production schedule or perform a shared live Windmill run.
