### PR TITLE
bd-jxclm.15: Path B domain-boundary Windmill bakeoff evidence

### DIFF
--- a/backend/scripts/verification/windmill_bakeoff_domain_boundary.py
+++ b/backend/scripts/verification/windmill_bakeoff_domain_boundary.py
@@ -255,7 +255,9 @@ class DomainBoundaryService:
         status = "empty_result" if len(results) == 0 else "fresh"
         return {"status": status, "snapshot_id": snapshot_id, "result_count": len(results)}
 
-    def freshness_gate(self, env: Envelope, snapshot_id: str, max_stale_hours: int) -> Dict[str, Any]:
+    def freshness_gate(
+        self, env: Envelope, snapshot_id: str, max_stale_hours: int, fallback_stale_hours: int
+    ) -> Dict[str, Any]:
         """Invariant: explicit stale policy; zero results are not transport failures."""
         snap = self.store.search_snapshots.get(snapshot_id)
         if not snap:
@@ -266,6 +268,8 @@ class DomainBoundaryService:
             return {"status": "empty_result", "age_seconds": int(age.total_seconds())}
         if age <= timedelta(hours=max_stale_hours):
             return {"status": "fresh", "age_seconds": int(age.total_seconds())}
+        if age <= timedelta(hours=fallback_stale_hours):
+            return {"status": "stale_but_usable", "age_seconds": int(age.total_seconds())}
         return {"status": "stale_blocked", "age_seconds": int(age.total_seconds())}
 
     def read_fetch(self, env: Envelope, snapshot_id: str) -> Dict[str, Any]:
@@ -370,8 +374,11 @@ class DomainBoundaryService:
         summary_id = f"summary-{env.windmill_run_id}"
         status = "succeeded"
         alerts: List[str] = []
-        for step_name in ("search_materialize", "freshness_gate", "read_fetch", "index", "analyze"):
-            step_status = step_results.get(step_name, {}).get("status", "unknown")
+        for step_name, step_payload in step_results.items():
+            step_status = step_payload.get("status", "unknown")
+            if step_name == "freshness_gate" and step_status == "stale_but_usable":
+                alerts.append("freshness_gate:stale_but_usable")
+                continue
             if step_status not in {"fresh", "succeeded"}:
                 status = "failed"
                 alerts.append(f"{step_name}:{step_status}")
@@ -414,6 +421,7 @@ class WindmillShapedRunner:
         question: str,
         jurisdiction: str = DEFAULT_JURISDICTION,
         source_family: str = DEFAULT_SOURCE_FAMILY,
+        snapshot_age_hours: int = 0,
     ) -> Dict[str, Any]:
         env = Envelope(
             architecture_path="affordabot_domain_boundary",
@@ -432,10 +440,13 @@ class WindmillShapedRunner:
             return self.domain.summarize_run(env, steps)
 
         snapshot_id = steps["search_materialize"].get("snapshot_id", "")
+        if snapshot_age_hours > 0 and snapshot_id in self.domain.store.search_snapshots:
+            aged = utc_now() - timedelta(hours=snapshot_age_hours)
+            self.domain.store.search_snapshots[snapshot_id]["captured_at"] = aged.isoformat()
         steps["freshness_gate"] = self._safe_step(
-            "freshness_gate", self.domain.freshness_gate, env, snapshot_id, 24
+            "freshness_gate", self.domain.freshness_gate, env, snapshot_id, 24, 72
         )
-        if steps["freshness_gate"].get("status") != "fresh":
+        if steps["freshness_gate"].get("status") not in {"fresh", "stale_but_usable"}:
             return self.domain.summarize_run(env, steps)
 
         steps["read_fetch"] = self._safe_step("read_fetch", self.domain.read_fetch, env, snapshot_id)
@@ -491,6 +502,32 @@ def run_scenario(scenario: str) -> Dict[str, Any]:
         runner = WindmillShapedRunner(domain)
         return runner.run_once("run-storage-failure", "job-index", idempotency, query, question)
 
+    if scenario == "stale_usable":
+        domain = DomainBoundaryService(
+            store=store,
+            search_client=SearxLikeClient(fail_mode=False),
+            reader_client=ReaderContractClient(fail_mode=False),
+            vector_adapter=VectorAdapter(),
+            analysis_adapter=AnalysisAdapter(),
+        )
+        runner = WindmillShapedRunner(domain)
+        return runner.run_once(
+            "run-stale-usable", "job-freshness", idempotency, query, question, snapshot_age_hours=30
+        )
+
+    if scenario == "stale_blocked":
+        domain = DomainBoundaryService(
+            store=store,
+            search_client=SearxLikeClient(fail_mode=False),
+            reader_client=ReaderContractClient(fail_mode=False),
+            vector_adapter=VectorAdapter(),
+            analysis_adapter=AnalysisAdapter(),
+        )
+        runner = WindmillShapedRunner(domain)
+        return runner.run_once(
+            "run-stale-blocked", "job-freshness", idempotency, query, question, snapshot_age_hours=80
+        )
+
     domain = DomainBoundaryService(
         store=store,
         search_client=SearxLikeClient(fail_mode=False),
@@ -510,7 +547,14 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--scenario",
-        choices=["happy_rerun", "source_failure", "reader_failure", "storage_failure"],
+        choices=[
+            "happy_rerun",
+            "source_failure",
+            "reader_failure",
+            "storage_failure",
+            "stale_usable",
+            "stale_blocked",
+        ],
         default="happy_rerun",
         help="Scenario to execute.",
     )

--- a/backend/scripts/verification/windmill_bakeoff_domain_boundary.py
+++ b/backend/scripts/verification/windmill_bakeoff_domain_boundary.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""Path B POC: Windmill-style orchestration with an affordabot domain boundary.
+
+This script is intentionally deterministic and local-first. It models Windmill step
+boundaries while keeping product-data writes inside coarse domain commands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
+
+
+CONTRACT_VERSION = "2026-04-12.windmill-storage-bakeoff.v1"
+DEFAULT_QUERY = "San Jose CA city council meeting minutes housing"
+DEFAULT_JURISDICTION = "San Jose CA"
+DEFAULT_SOURCE_FAMILY = "meeting_minutes"
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def iso_now() -> str:
+    return utc_now().isoformat()
+
+
+def stable_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def normalize_for_key(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", text.strip().lower()).strip("-")
+
+
+def canonical_document_key(jurisdiction: str, url: str) -> str:
+    """Domain invariant: stable document identity from jurisdiction + canonical URL."""
+    parsed = urlparse(url)
+    host = parsed.netloc.lower()
+    path = parsed.path.rstrip("/") or "/"
+    normalized = f"{host}{path}"
+    return f"{normalize_for_key(jurisdiction)}::{stable_hash(normalized)[:16]}"
+
+
+@dataclass
+class Envelope:
+    architecture_path: str
+    windmill_run_id: str
+    windmill_job_id: str
+    idempotency_key: str
+    jurisdiction: str
+    source_family: str
+    windmill_workspace: str = "affordabot"
+    windmill_flow_path: str = "f/affordabot/pipeline_daily_refresh_domain_boundary__flow"
+    orchestrator: str = "windmill"
+    contract_version: str = CONTRACT_VERSION
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "contract_version": self.contract_version,
+            "architecture_path": self.architecture_path,
+            "orchestrator": self.orchestrator,
+            "windmill_workspace": self.windmill_workspace,
+            "windmill_flow_path": self.windmill_flow_path,
+            "windmill_run_id": self.windmill_run_id,
+            "windmill_job_id": self.windmill_job_id,
+            "idempotency_key": self.idempotency_key,
+            "jurisdiction": self.jurisdiction,
+            "source_family": self.source_family,
+        }
+
+
+class SearxLikeClient:
+    """SearXNG-compatible abstraction preserving SearX JSON response shape."""
+
+    def __init__(self, fail_mode: bool = False):
+        self.fail_mode = fail_mode
+
+    def search(self, query: str) -> Dict[str, Any]:
+        if self.fail_mode:
+            raise RuntimeError("simulated_source_error")
+        return {
+            "query": query,
+            "number_of_results": 2,
+            "results": [
+                {
+                    "url": "https://www.sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meeting-minutes",
+                    "title": "City Council Meeting Minutes",
+                    "content": "Official San Jose City Council meeting minutes archive.",
+                    "engines": ["mock-searxng"],
+                },
+                {
+                    "url": "https://www.sanjoseca.gov/news-stories/minutes-and-agendas",
+                    "title": "Minutes and Agendas",
+                    "content": "Minutes and agendas for council meetings.",
+                    "engines": ["mock-searxng"],
+                },
+            ],
+            "answers": [],
+            "infoboxes": [],
+        }
+
+
+class ReaderContractClient:
+    """Z.ai reader contract shape; deterministic local body unless fail_mode is set."""
+
+    def __init__(self, fail_mode: bool = False):
+        self.fail_mode = fail_mode
+
+    def fetch(self, url: str) -> Dict[str, Any]:
+        if self.fail_mode:
+            raise RuntimeError("simulated_reader_error")
+        markdown = (
+            "# San Jose City Council Meeting Minutes\n\n"
+            "2026-04-10 meeting highlights:\n"
+            "- Housing permit processing timelines discussed.\n"
+            "- Fee schedule update hearing moved to next session.\n"
+            "- Public comments on affordable housing expansion."
+        )
+        return {
+            "reader_result": {
+                "url": url,
+                "title": "San Jose Meeting Minutes",
+                "markdown": markdown,
+                "fetched_at": iso_now(),
+            }
+        }
+
+
+class VectorAdapter:
+    """pgvector-compatible adapter with deterministic embeddings."""
+
+    dimension = 8
+
+    def embed(self, text: str) -> List[float]:
+        digest = stable_hash(text)
+        vals = []
+        for i in range(self.dimension):
+            chunk = digest[i * 8 : (i + 1) * 8]
+            vals.append((int(chunk, 16) % 1000) / 1000.0)
+        return vals
+
+
+class AnalysisAdapter:
+    """Deterministic stand-in for Z.ai analysis with explicit evidence references."""
+
+    def analyze(self, question: str, chunks: List[Dict[str, Any]]) -> Dict[str, Any]:
+        if not chunks:
+            raise RuntimeError("analysis_requires_evidence")
+        evidence_refs = [
+            {
+                "chunk_id": c["chunk_id"],
+                "canonical_document_key": c["canonical_document_key"],
+                "artifact_ref": c["artifact_ref"],
+            }
+            for c in chunks
+        ]
+        return {
+            "status": "succeeded",
+            "question": question,
+            "summary": (
+                "San Jose meeting minutes indicate active housing policy discussions and "
+                "scheduled follow-up hearings affecting near-term planning timelines."
+            ),
+            "sufficiency_state": "qualitative_only",
+            "claims": [
+                {
+                    "claim": "Housing-related agenda items were actively discussed.",
+                    "evidence_refs": evidence_refs[:2],
+                }
+            ],
+        }
+
+
+@dataclass
+class InMemoryDomainStore:
+    """Product storage surrogate for Postgres + pgvector + MinIO interfaces."""
+
+    search_snapshots: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    documents: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    artifacts: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    chunks: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    analyses: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    run_summaries: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
+    def snapshot_counts(self) -> Dict[str, int]:
+        return {
+            "search_snapshots": len(self.search_snapshots),
+            "documents": len(self.documents),
+            "artifacts": len(self.artifacts),
+            "chunks": len(self.chunks),
+            "analyses": len(self.analyses),
+            "run_summaries": len(self.run_summaries),
+        }
+
+
+class DomainBoundaryService:
+    """Affordabot domain commands.
+
+    These are intentionally coarse commands. Each command enforces at least one
+    product invariant so this layer is not a thin SQL wrapper.
+    """
+
+    def __init__(
+        self,
+        store: InMemoryDomainStore,
+        search_client: SearxLikeClient,
+        reader_client: ReaderContractClient,
+        vector_adapter: VectorAdapter,
+        analysis_adapter: AnalysisAdapter,
+        fail_storage_step: Optional[str] = None,
+    ):
+        self.store = store
+        self.search_client = search_client
+        self.reader_client = reader_client
+        self.vector_adapter = vector_adapter
+        self.analysis_adapter = analysis_adapter
+        self.fail_storage_step = fail_storage_step
+
+    def _assert_storage_available(self, step_name: str) -> None:
+        if self.fail_storage_step == step_name:
+            raise RuntimeError(f"simulated_storage_error:{step_name}")
+
+    def search_materialize(self, env: Envelope, query: str) -> Dict[str, Any]:
+        """Invariant: idempotent search snapshot materialization keyed by query+scope."""
+        try:
+            raw = self.search_client.search(query)
+        except Exception as exc:
+            return {"status": "source_error", "error": str(exc)}
+
+        results = raw.get("results", [])
+        snapshot_key = stable_hash(
+            f"{env.jurisdiction}|{env.source_family}|{query}|{json.dumps(results, sort_keys=True)}"
+        )[:16]
+        snapshot_id = f"snapshot-{snapshot_key}"
+        if snapshot_id not in self.store.search_snapshots:
+            self._assert_storage_available("search_materialize")
+            self.store.search_snapshots[snapshot_id] = {
+                "snapshot_id": snapshot_id,
+                "query": query,
+                "result_count": len(results),
+                "results": results,
+                "captured_at": iso_now(),
+                "jurisdiction": env.jurisdiction,
+                "source_family": env.source_family,
+            }
+        status = "empty_result" if len(results) == 0 else "fresh"
+        return {"status": status, "snapshot_id": snapshot_id, "result_count": len(results)}
+
+    def freshness_gate(self, env: Envelope, snapshot_id: str, max_stale_hours: int) -> Dict[str, Any]:
+        """Invariant: explicit stale policy; zero results are not transport failures."""
+        snap = self.store.search_snapshots.get(snapshot_id)
+        if not snap:
+            return {"status": "source_error", "error": "missing_snapshot"}
+        captured_at = datetime.fromisoformat(snap["captured_at"])
+        age = utc_now() - captured_at
+        if snap["result_count"] == 0:
+            return {"status": "empty_result", "age_seconds": int(age.total_seconds())}
+        if age <= timedelta(hours=max_stale_hours):
+            return {"status": "fresh", "age_seconds": int(age.total_seconds())}
+        return {"status": "stale_blocked", "age_seconds": int(age.total_seconds())}
+
+    def read_fetch(self, env: Envelope, snapshot_id: str) -> Dict[str, Any]:
+        """Invariant: canonical document identity + artifact reference dedup."""
+        snap = self.store.search_snapshots.get(snapshot_id)
+        if not snap:
+            return {"status": "reader_error", "error": "missing_snapshot"}
+        if not snap["results"]:
+            return {"status": "reader_error", "error": "no_results_to_read"}
+        target = snap["results"][0]
+        url = target["url"]
+        doc_key = canonical_document_key(env.jurisdiction, url)
+        try:
+            payload = self.reader_client.fetch(url)
+        except Exception as exc:
+            return {"status": "reader_error", "error": str(exc)}
+        reader_result = payload.get("reader_result", payload)
+        markdown = reader_result.get("markdown", "")
+        artifact_hash = stable_hash(markdown)[:16]
+        artifact_ref = f"minio://affordabot-artifacts/{env.jurisdiction.replace(' ', '_')}/{artifact_hash}.md"
+
+        self._assert_storage_available("read_fetch")
+        if artifact_ref not in self.store.artifacts:
+            self.store.artifacts[artifact_ref] = {
+                "artifact_ref": artifact_ref,
+                "content_hash": artifact_hash,
+                "content_type": "text/markdown",
+                "body": markdown,
+                "source_url": url,
+                "created_at": iso_now(),
+            }
+        if doc_key not in self.store.documents:
+            self.store.documents[doc_key] = {
+                "canonical_document_key": doc_key,
+                "source_url": url,
+                "artifact_ref": artifact_ref,
+                "jurisdiction": env.jurisdiction,
+                "source_family": env.source_family,
+                "created_at": iso_now(),
+            }
+        return {
+            "status": "fresh",
+            "canonical_document_key": doc_key,
+            "artifact_ref": artifact_ref,
+            "source_url": url,
+        }
+
+    def index(self, env: Envelope, canonical_key: str) -> Dict[str, Any]:
+        """Invariant: chunk provenance includes canonical key + artifact ref, with upsert idempotency."""
+        doc = self.store.documents.get(canonical_key)
+        if not doc:
+            return {"status": "storage_error", "error": "missing_document"}
+        artifact = self.store.artifacts.get(doc["artifact_ref"])
+        if not artifact:
+            return {"status": "storage_error", "error": "missing_artifact"}
+        text = artifact["body"]
+        lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+        chunks_created = 0
+        self._assert_storage_available("index")
+        for idx, line in enumerate(lines):
+            chunk_id = f"chunk-{stable_hash(f'{canonical_key}|{line}')[:20]}"
+            if chunk_id in self.store.chunks:
+                continue
+            self.store.chunks[chunk_id] = {
+                "chunk_id": chunk_id,
+                "canonical_document_key": canonical_key,
+                "artifact_ref": doc["artifact_ref"],
+                "chunk_index": idx,
+                "content": line,
+                "embedding": self.vector_adapter.embed(line),
+                "created_at": iso_now(),
+            }
+            chunks_created += 1
+        return {"status": "fresh", "chunks_total": len(lines), "chunks_created": chunks_created}
+
+    def analyze(self, env: Envelope, question: str) -> Dict[str, Any]:
+        """Invariant: no analysis without evidence chunks and traceable provenance."""
+        usable_chunks = [
+            c
+            for c in self.store.chunks.values()
+            if self.store.documents.get(c["canonical_document_key"], {}).get("jurisdiction")
+            == env.jurisdiction
+        ]
+        if not usable_chunks:
+            return {"status": "analysis_error", "error": "insufficient_evidence"}
+        analysis_id = f"analysis-{stable_hash(env.idempotency_key)[:16]}"
+        if analysis_id in self.store.analyses:
+            return {"status": "fresh", "analysis_id": analysis_id, "reused": True}
+        self._assert_storage_available("analyze")
+        analysis_payload = self.analysis_adapter.analyze(question, usable_chunks)
+        self.store.analyses[analysis_id] = {
+            "analysis_id": analysis_id,
+            "question": question,
+            "payload": analysis_payload,
+            "created_at": iso_now(),
+            "evidence_chunk_ids": [c["chunk_id"] for c in usable_chunks],
+        }
+        return {"status": "fresh", "analysis_id": analysis_id, "reused": False}
+
+    def summarize_run(self, env: Envelope, step_results: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
+        """Invariant: run summary links orchestration IDs to domain storage state."""
+        summary_id = f"summary-{env.windmill_run_id}"
+        status = "succeeded"
+        alerts: List[str] = []
+        for step_name in ("search_materialize", "freshness_gate", "read_fetch", "index", "analyze"):
+            step_status = step_results.get(step_name, {}).get("status", "unknown")
+            if step_status not in {"fresh", "succeeded"}:
+                status = "failed"
+                alerts.append(f"{step_name}:{step_status}")
+        summary = {
+            "summary_id": summary_id,
+            "status": status,
+            "alerts": alerts,
+            "step_results": step_results,
+            "storage_counts": self.store.snapshot_counts(),
+            "envelope": env.as_dict(),
+            "created_at": iso_now(),
+        }
+        self.store.run_summaries[summary_id] = summary
+        return summary
+
+
+class WindmillShapedRunner:
+    """Local flow runner with Windmill-like step graph."""
+
+    def __init__(self, domain: DomainBoundaryService):
+        self.domain = domain
+
+    @staticmethod
+    def _safe_step(name: str, fn: Any, *args: Any) -> Dict[str, Any]:
+        try:
+            return fn(*args)
+        except Exception as exc:
+            error_text = str(exc)
+            status = "storage_error" if "storage_error" in error_text else "source_error"
+            if "reader_error" in error_text:
+                status = "reader_error"
+            return {"status": status, "error": error_text, "step": name}
+
+    def run_once(
+        self,
+        run_id: str,
+        job_id: str,
+        idempotency_key: str,
+        query: str,
+        question: str,
+        jurisdiction: str = DEFAULT_JURISDICTION,
+        source_family: str = DEFAULT_SOURCE_FAMILY,
+    ) -> Dict[str, Any]:
+        env = Envelope(
+            architecture_path="affordabot_domain_boundary",
+            windmill_run_id=run_id,
+            windmill_job_id=job_id,
+            idempotency_key=idempotency_key,
+            jurisdiction=jurisdiction,
+            source_family=source_family,
+        )
+
+        steps: Dict[str, Dict[str, Any]] = {}
+        steps["search_materialize"] = self._safe_step(
+            "search_materialize", self.domain.search_materialize, env, query
+        )
+        if steps["search_materialize"].get("status") not in {"fresh", "empty_result"}:
+            return self.domain.summarize_run(env, steps)
+
+        snapshot_id = steps["search_materialize"].get("snapshot_id", "")
+        steps["freshness_gate"] = self._safe_step(
+            "freshness_gate", self.domain.freshness_gate, env, snapshot_id, 24
+        )
+        if steps["freshness_gate"].get("status") != "fresh":
+            return self.domain.summarize_run(env, steps)
+
+        steps["read_fetch"] = self._safe_step("read_fetch", self.domain.read_fetch, env, snapshot_id)
+        if steps["read_fetch"].get("status") != "fresh":
+            return self.domain.summarize_run(env, steps)
+
+        canonical_key = steps["read_fetch"]["canonical_document_key"]
+        steps["index"] = self._safe_step("index", self.domain.index, env, canonical_key)
+        if steps["index"].get("status") != "fresh":
+            return self.domain.summarize_run(env, steps)
+
+        steps["analyze"] = self._safe_step("analyze", self.domain.analyze, env, question)
+        return self.domain.summarize_run(env, steps)
+
+
+def run_scenario(scenario: str) -> Dict[str, Any]:
+    store = InMemoryDomainStore()
+    query = DEFAULT_QUERY
+    question = "Summarize housing-related signals from recent San Jose meeting minutes."
+    idempotency = "san-jose-ca:meeting_minutes:2026-04-12"
+
+    if scenario == "source_failure":
+        domain = DomainBoundaryService(
+            store=store,
+            search_client=SearxLikeClient(fail_mode=True),
+            reader_client=ReaderContractClient(fail_mode=False),
+            vector_adapter=VectorAdapter(),
+            analysis_adapter=AnalysisAdapter(),
+        )
+        runner = WindmillShapedRunner(domain)
+        return runner.run_once("run-source-failure", "job-search", idempotency, query, question)
+
+    if scenario == "reader_failure":
+        domain = DomainBoundaryService(
+            store=store,
+            search_client=SearxLikeClient(fail_mode=False),
+            reader_client=ReaderContractClient(fail_mode=True),
+            vector_adapter=VectorAdapter(),
+            analysis_adapter=AnalysisAdapter(),
+        )
+        runner = WindmillShapedRunner(domain)
+        return runner.run_once("run-reader-failure", "job-reader", idempotency, query, question)
+
+    if scenario == "storage_failure":
+        domain = DomainBoundaryService(
+            store=store,
+            search_client=SearxLikeClient(fail_mode=False),
+            reader_client=ReaderContractClient(fail_mode=False),
+            vector_adapter=VectorAdapter(),
+            analysis_adapter=AnalysisAdapter(),
+            fail_storage_step="index",
+        )
+        runner = WindmillShapedRunner(domain)
+        return runner.run_once("run-storage-failure", "job-index", idempotency, query, question)
+
+    domain = DomainBoundaryService(
+        store=store,
+        search_client=SearxLikeClient(fail_mode=False),
+        reader_client=ReaderContractClient(fail_mode=False),
+        vector_adapter=VectorAdapter(),
+        analysis_adapter=AnalysisAdapter(),
+    )
+    runner = WindmillShapedRunner(domain)
+    first = runner.run_once("run-first", "job-main", idempotency, query, question)
+    second = runner.run_once("run-second", "job-main", idempotency, query, question)
+    return {"first_run": first, "rerun": second}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run Path B Windmill storage-boundary bakeoff (domain boundary model)."
+    )
+    parser.add_argument(
+        "--scenario",
+        choices=["happy_rerun", "source_failure", "reader_failure", "storage_failure"],
+        default="happy_rerun",
+        help="Scenario to execute.",
+    )
+    parser.add_argument(
+        "--out",
+        default="",
+        help="Optional JSON output file path.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    result = run_scenario(args.scenario)
+    if args.pretty:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(json.dumps(result, sort_keys=True))
+    if args.out:
+        out_path = Path(args.out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            json.dumps(result, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/verification/test_windmill_bakeoff_domain_boundary.py
+++ b/backend/tests/verification/test_windmill_bakeoff_domain_boundary.py
@@ -1,0 +1,74 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = ROOT / "backend" / "scripts" / "verification" / "windmill_bakeoff_domain_boundary.py"
+
+spec = spec_from_file_location("windmill_bakeoff_domain_boundary", SCRIPT_PATH)
+module = module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+
+class TestWindmillBakeoffDomainBoundary(unittest.TestCase):
+    def test_happy_rerun_is_idempotent_for_chunks_and_analysis(self):
+        result = module.run_scenario("happy_rerun")
+        first = result["first_run"]
+        rerun = result["rerun"]
+
+        self.assertEqual(first["status"], "succeeded")
+        self.assertEqual(rerun["status"], "succeeded")
+
+        self.assertGreater(first["step_results"]["index"]["chunks_created"], 0)
+        self.assertEqual(rerun["step_results"]["index"]["chunks_created"], 0)
+
+        self.assertEqual(
+            first["step_results"]["read_fetch"]["canonical_document_key"],
+            rerun["step_results"]["read_fetch"]["canonical_document_key"],
+        )
+        self.assertEqual(
+            first["step_results"]["analyze"]["analysis_id"],
+            rerun["step_results"]["analyze"]["analysis_id"],
+        )
+        self.assertIs(rerun["step_results"]["analyze"]["reused"], True)
+
+    def test_analysis_fails_closed_without_evidence(self):
+        store = module.InMemoryDomainStore()
+        domain = module.DomainBoundaryService(
+            store=store,
+            search_client=module.SearxLikeClient(fail_mode=False),
+            reader_client=module.ReaderContractClient(fail_mode=False),
+            vector_adapter=module.VectorAdapter(),
+            analysis_adapter=module.AnalysisAdapter(),
+        )
+        env = module.Envelope(
+            architecture_path="affordabot_domain_boundary",
+            windmill_run_id="run-fail-closed",
+            windmill_job_id="job-analyze",
+            idempotency_key="san-jose-ca:meeting_minutes:2026-04-12",
+            jurisdiction="San Jose CA",
+            source_family="meeting_minutes",
+        )
+
+        result = domain.analyze(env, "Any question")
+        self.assertEqual(result["status"], "analysis_error")
+        self.assertEqual(result["error"], "insufficient_evidence")
+
+    def test_stale_gate_statuses_are_emitted(self):
+        stale_usable = module.run_scenario("stale_usable")
+        stale_blocked = module.run_scenario("stale_blocked")
+
+        self.assertEqual(stale_usable["step_results"]["freshness_gate"]["status"], "stale_but_usable")
+        self.assertEqual(stale_usable["status"], "succeeded")
+        self.assertIn("freshness_gate:stale_but_usable", stale_usable["alerts"])
+
+        self.assertEqual(stale_blocked["step_results"]["freshness_gate"]["status"], "stale_blocked")
+        self.assertEqual(stale_blocked["status"], "failed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/README.md
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/README.md
@@ -6,6 +6,11 @@ storage writes are performed only by coarse affordabot domain commands.
 Implementation entrypoint:
 - `backend/scripts/verification/windmill_bakeoff_domain_boundary.py`
 
+Committed Windmill export (reviewable orchestration shape):
+- `ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.py`
+- `ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.script.yaml`
+- `ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary__flow/flow.yaml`
+
 Runner flow steps (Windmill-shaped):
 1. `search_materialize`
 2. `freshness_gate`
@@ -43,6 +48,8 @@ Live infra was intentionally not used because secret access is currently restric
 - `artifacts/source_failure.json`
 - `artifacts/reader_failure.json`
 - `artifacts/storage_failure.json`
+- `artifacts/stale_usable.json`
+- `artifacts/stale_blocked.json`
 
 ## Architectural Finding (Path B)
 

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/README.md
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/README.md
@@ -1,0 +1,51 @@
+# Path B: Windmill + Affordabot Domain Boundary
+
+This POC implements a Windmill-shaped flow where orchestration is step-based, but product
+storage writes are performed only by coarse affordabot domain commands.
+
+Implementation entrypoint:
+- `backend/scripts/verification/windmill_bakeoff_domain_boundary.py`
+
+Runner flow steps (Windmill-shaped):
+1. `search_materialize`
+2. `freshness_gate`
+3. `read_fetch`
+4. `index`
+5. `analyze`
+6. `summarize_run`
+
+## Domain Boundary Contract
+
+Each domain command owns explicit invariants and is intentionally not a thin SQL wrapper:
+
+- `search_materialize`: idempotent search snapshot persistence for the scope `(jurisdiction, source_family, query, normalized_results)`.
+- `freshness_gate`: explicit freshness state (`fresh`, `empty_result`, `stale_blocked`) with zero-result treated as non-transport state.
+- `read_fetch`: canonical document identity (`canonical_document_key`) and deduplicated artifact reference.
+- `index`: chunk upsert idempotency and provenance links (`chunk -> canonical_document_key + artifact_ref`).
+- `analyze`: fail closed when evidence is missing (`analysis_error` if no chunks).
+- `summarize_run`: ties orchestration IDs to domain state counts and per-step statuses.
+
+## Local Adapters Used
+
+This run uses deterministic local substitutes with production-compatible contract shape:
+
+- Search: SearXNG-compatible JSON response model.
+- Reader: Z.ai reader contract shape (`reader_result` envelope).
+- Artifacts: MinIO-style refs (`minio://affordabot-artifacts/...`).
+- Vector index: pgvector-compatible embedding adapter.
+- Analysis: deterministic analysis adapter that emits explicit evidence refs.
+
+Live infra was intentionally not used because secret access is currently restricted in this task.
+
+## Artifacts
+
+- `artifacts/happy_rerun.json`
+- `artifacts/source_failure.json`
+- `artifacts/reader_failure.json`
+- `artifacts/storage_failure.json`
+
+## Architectural Finding (Path B)
+
+Path B is viable. The backend boundary clearly pays for itself at canonical identity,
+idempotency, provenance, and sufficiency gating. It starts to look like middleware only if
+commands are decomposed into low-level storage primitives instead of domain commands.

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/happy_rerun.json
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/happy_rerun.json
@@ -1,7 +1,7 @@
 {
   "first_run": {
     "alerts": [],
-    "created_at": "2026-04-12T17:16:12.187682+00:00",
+    "created_at": "2026-04-12T17:26:44.109197+00:00",
     "envelope": {
       "architecture_path": "affordabot_domain_boundary",
       "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
@@ -54,7 +54,7 @@
   },
   "rerun": {
     "alerts": [],
-    "created_at": "2026-04-12T17:16:12.187725+00:00",
+    "created_at": "2026-04-12T17:26:44.109258+00:00",
     "envelope": {
       "architecture_path": "affordabot_domain_boundary",
       "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/happy_rerun.json
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/happy_rerun.json
@@ -1,0 +1,108 @@
+{
+  "first_run": {
+    "alerts": [],
+    "created_at": "2026-04-12T17:16:12.187682+00:00",
+    "envelope": {
+      "architecture_path": "affordabot_domain_boundary",
+      "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+      "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+      "jurisdiction": "San Jose CA",
+      "orchestrator": "windmill",
+      "source_family": "meeting_minutes",
+      "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+      "windmill_job_id": "job-main",
+      "windmill_run_id": "run-first",
+      "windmill_workspace": "affordabot"
+    },
+    "status": "succeeded",
+    "step_results": {
+      "analyze": {
+        "analysis_id": "analysis-ebbbe7e0f3aeac41",
+        "reused": false,
+        "status": "fresh"
+      },
+      "freshness_gate": {
+        "age_seconds": 0,
+        "status": "fresh"
+      },
+      "index": {
+        "chunks_created": 5,
+        "chunks_total": 5,
+        "status": "fresh"
+      },
+      "read_fetch": {
+        "artifact_ref": "minio://affordabot-artifacts/San_Jose_CA/ecf092f9a92f34b1.md",
+        "canonical_document_key": "san-jose-ca::a653e7debe31e650",
+        "source_url": "https://www.sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meeting-minutes",
+        "status": "fresh"
+      },
+      "search_materialize": {
+        "result_count": 2,
+        "snapshot_id": "snapshot-579c45d51063aaef",
+        "status": "fresh"
+      }
+    },
+    "storage_counts": {
+      "analyses": 1,
+      "artifacts": 1,
+      "chunks": 5,
+      "documents": 1,
+      "run_summaries": 0,
+      "search_snapshots": 1
+    },
+    "summary_id": "summary-run-first"
+  },
+  "rerun": {
+    "alerts": [],
+    "created_at": "2026-04-12T17:16:12.187725+00:00",
+    "envelope": {
+      "architecture_path": "affordabot_domain_boundary",
+      "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+      "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+      "jurisdiction": "San Jose CA",
+      "orchestrator": "windmill",
+      "source_family": "meeting_minutes",
+      "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+      "windmill_job_id": "job-main",
+      "windmill_run_id": "run-second",
+      "windmill_workspace": "affordabot"
+    },
+    "status": "succeeded",
+    "step_results": {
+      "analyze": {
+        "analysis_id": "analysis-ebbbe7e0f3aeac41",
+        "reused": true,
+        "status": "fresh"
+      },
+      "freshness_gate": {
+        "age_seconds": 0,
+        "status": "fresh"
+      },
+      "index": {
+        "chunks_created": 0,
+        "chunks_total": 5,
+        "status": "fresh"
+      },
+      "read_fetch": {
+        "artifact_ref": "minio://affordabot-artifacts/San_Jose_CA/ecf092f9a92f34b1.md",
+        "canonical_document_key": "san-jose-ca::a653e7debe31e650",
+        "source_url": "https://www.sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meeting-minutes",
+        "status": "fresh"
+      },
+      "search_materialize": {
+        "result_count": 2,
+        "snapshot_id": "snapshot-579c45d51063aaef",
+        "status": "fresh"
+      }
+    },
+    "storage_counts": {
+      "analyses": 1,
+      "artifacts": 1,
+      "chunks": 5,
+      "documents": 1,
+      "run_summaries": 1,
+      "search_snapshots": 1
+    },
+    "summary_id": "summary-run-second"
+  }
+}

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/reader_failure.json
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/reader_failure.json
@@ -1,0 +1,45 @@
+{
+  "alerts": [
+    "read_fetch:reader_error",
+    "index:unknown",
+    "analyze:unknown"
+  ],
+  "created_at": "2026-04-12T17:16:12.297070+00:00",
+  "envelope": {
+    "architecture_path": "affordabot_domain_boundary",
+    "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+    "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+    "jurisdiction": "San Jose CA",
+    "orchestrator": "windmill",
+    "source_family": "meeting_minutes",
+    "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+    "windmill_job_id": "job-reader",
+    "windmill_run_id": "run-reader-failure",
+    "windmill_workspace": "affordabot"
+  },
+  "status": "failed",
+  "step_results": {
+    "freshness_gate": {
+      "age_seconds": 0,
+      "status": "fresh"
+    },
+    "read_fetch": {
+      "error": "simulated_reader_error",
+      "status": "reader_error"
+    },
+    "search_materialize": {
+      "result_count": 2,
+      "snapshot_id": "snapshot-579c45d51063aaef",
+      "status": "fresh"
+    }
+  },
+  "storage_counts": {
+    "analyses": 0,
+    "artifacts": 0,
+    "chunks": 0,
+    "documents": 0,
+    "run_summaries": 0,
+    "search_snapshots": 1
+  },
+  "summary_id": "summary-run-reader-failure"
+}

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/reader_failure.json
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/reader_failure.json
@@ -1,10 +1,8 @@
 {
   "alerts": [
-    "read_fetch:reader_error",
-    "index:unknown",
-    "analyze:unknown"
+    "read_fetch:reader_error"
   ],
-  "created_at": "2026-04-12T17:16:12.297070+00:00",
+  "created_at": "2026-04-12T17:26:44.236762+00:00",
   "envelope": {
     "architecture_path": "affordabot_domain_boundary",
     "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/source_failure.json
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/source_failure.json
@@ -1,0 +1,38 @@
+{
+  "alerts": [
+    "search_materialize:source_error",
+    "freshness_gate:unknown",
+    "read_fetch:unknown",
+    "index:unknown",
+    "analyze:unknown"
+  ],
+  "created_at": "2026-04-12T17:16:12.240926+00:00",
+  "envelope": {
+    "architecture_path": "affordabot_domain_boundary",
+    "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+    "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+    "jurisdiction": "San Jose CA",
+    "orchestrator": "windmill",
+    "source_family": "meeting_minutes",
+    "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+    "windmill_job_id": "job-search",
+    "windmill_run_id": "run-source-failure",
+    "windmill_workspace": "affordabot"
+  },
+  "status": "failed",
+  "step_results": {
+    "search_materialize": {
+      "error": "simulated_source_error",
+      "status": "source_error"
+    }
+  },
+  "storage_counts": {
+    "analyses": 0,
+    "artifacts": 0,
+    "chunks": 0,
+    "documents": 0,
+    "run_summaries": 0,
+    "search_snapshots": 0
+  },
+  "summary_id": "summary-run-source-failure"
+}

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/source_failure.json
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/source_failure.json
@@ -1,12 +1,8 @@
 {
   "alerts": [
-    "search_materialize:source_error",
-    "freshness_gate:unknown",
-    "read_fetch:unknown",
-    "index:unknown",
-    "analyze:unknown"
+    "search_materialize:source_error"
   ],
-  "created_at": "2026-04-12T17:16:12.240926+00:00",
+  "created_at": "2026-04-12T17:26:44.164225+00:00",
   "envelope": {
     "architecture_path": "affordabot_domain_boundary",
     "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/stale_blocked.json
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/stale_blocked.json
@@ -1,8 +1,8 @@
 {
   "alerts": [
-    "index:storage_error"
+    "freshness_gate:stale_blocked"
   ],
-  "created_at": "2026-04-12T17:26:44.297324+00:00",
+  "created_at": "2026-04-12T17:26:44.404673+00:00",
   "envelope": {
     "architecture_path": "affordabot_domain_boundary",
     "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
@@ -11,26 +11,15 @@
     "orchestrator": "windmill",
     "source_family": "meeting_minutes",
     "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
-    "windmill_job_id": "job-index",
-    "windmill_run_id": "run-storage-failure",
+    "windmill_job_id": "job-freshness",
+    "windmill_run_id": "run-stale-blocked",
     "windmill_workspace": "affordabot"
   },
   "status": "failed",
   "step_results": {
     "freshness_gate": {
-      "age_seconds": 0,
-      "status": "fresh"
-    },
-    "index": {
-      "error": "simulated_storage_error:index",
-      "status": "storage_error",
-      "step": "index"
-    },
-    "read_fetch": {
-      "artifact_ref": "minio://affordabot-artifacts/San_Jose_CA/ecf092f9a92f34b1.md",
-      "canonical_document_key": "san-jose-ca::a653e7debe31e650",
-      "source_url": "https://www.sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meeting-minutes",
-      "status": "fresh"
+      "age_seconds": 288000,
+      "status": "stale_blocked"
     },
     "search_materialize": {
       "result_count": 2,
@@ -40,11 +29,11 @@
   },
   "storage_counts": {
     "analyses": 0,
-    "artifacts": 1,
+    "artifacts": 0,
     "chunks": 0,
-    "documents": 1,
+    "documents": 0,
     "run_summaries": 0,
     "search_snapshots": 1
   },
-  "summary_id": "summary-run-storage-failure"
+  "summary_id": "summary-run-stale-blocked"
 }

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/stale_usable.json
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/stale_usable.json
@@ -1,8 +1,8 @@
 {
   "alerts": [
-    "index:storage_error"
+    "freshness_gate:stale_but_usable"
   ],
-  "created_at": "2026-04-12T17:26:44.297324+00:00",
+  "created_at": "2026-04-12T17:26:44.350265+00:00",
   "envelope": {
     "architecture_path": "affordabot_domain_boundary",
     "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
@@ -11,20 +11,25 @@
     "orchestrator": "windmill",
     "source_family": "meeting_minutes",
     "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
-    "windmill_job_id": "job-index",
-    "windmill_run_id": "run-storage-failure",
+    "windmill_job_id": "job-freshness",
+    "windmill_run_id": "run-stale-usable",
     "windmill_workspace": "affordabot"
   },
-  "status": "failed",
+  "status": "succeeded",
   "step_results": {
-    "freshness_gate": {
-      "age_seconds": 0,
+    "analyze": {
+      "analysis_id": "analysis-ebbbe7e0f3aeac41",
+      "reused": false,
       "status": "fresh"
     },
+    "freshness_gate": {
+      "age_seconds": 108000,
+      "status": "stale_but_usable"
+    },
     "index": {
-      "error": "simulated_storage_error:index",
-      "status": "storage_error",
-      "step": "index"
+      "chunks_created": 5,
+      "chunks_total": 5,
+      "status": "fresh"
     },
     "read_fetch": {
       "artifact_ref": "minio://affordabot-artifacts/San_Jose_CA/ecf092f9a92f34b1.md",
@@ -39,12 +44,12 @@
     }
   },
   "storage_counts": {
-    "analyses": 0,
+    "analyses": 1,
     "artifacts": 1,
-    "chunks": 0,
+    "chunks": 5,
     "documents": 1,
     "run_summaries": 0,
     "search_snapshots": 1
   },
-  "summary_id": "summary-run-storage-failure"
+  "summary_id": "summary-run-stale-usable"
 }

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/storage_failure.json
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/storage_failure.json
@@ -1,0 +1,51 @@
+{
+  "alerts": [
+    "index:storage_error",
+    "analyze:unknown"
+  ],
+  "created_at": "2026-04-12T17:16:12.351797+00:00",
+  "envelope": {
+    "architecture_path": "affordabot_domain_boundary",
+    "contract_version": "2026-04-12.windmill-storage-bakeoff.v1",
+    "idempotency_key": "san-jose-ca:meeting_minutes:2026-04-12",
+    "jurisdiction": "San Jose CA",
+    "orchestrator": "windmill",
+    "source_family": "meeting_minutes",
+    "windmill_flow_path": "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+    "windmill_job_id": "job-index",
+    "windmill_run_id": "run-storage-failure",
+    "windmill_workspace": "affordabot"
+  },
+  "status": "failed",
+  "step_results": {
+    "freshness_gate": {
+      "age_seconds": 0,
+      "status": "fresh"
+    },
+    "index": {
+      "error": "simulated_storage_error:index",
+      "status": "storage_error",
+      "step": "index"
+    },
+    "read_fetch": {
+      "artifact_ref": "minio://affordabot-artifacts/San_Jose_CA/ecf092f9a92f34b1.md",
+      "canonical_document_key": "san-jose-ca::a653e7debe31e650",
+      "source_url": "https://www.sanjoseca.gov/your-government/departments-offices/city-clerk/city-council-meeting-minutes",
+      "status": "fresh"
+    },
+    "search_materialize": {
+      "result_count": 2,
+      "snapshot_id": "snapshot-579c45d51063aaef",
+      "status": "fresh"
+    }
+  },
+  "storage_counts": {
+    "analyses": 0,
+    "artifacts": 1,
+    "chunks": 0,
+    "documents": 1,
+    "run_summaries": 0,
+    "search_snapshots": 1
+  },
+  "summary_id": "summary-run-storage-failure"
+}

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/failure-drills.md
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/failure-drills.md
@@ -60,6 +60,43 @@ Why this matters:
 - Domain boundary prevents analysis from running after storage/index failure.
 - Partial state remains inspectable but bounded.
 
+## 4) Stale Gate Drill (`stale_but_usable`)
+
+Command:
+
+```bash
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario stale_usable --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/stale_usable.json
+```
+
+Observed:
+
+- Run `status=succeeded`
+- `freshness_gate.status=stale_but_usable`
+- Alert emitted: `freshness_gate:stale_but_usable`
+- `read_fetch/index/analyze` continue
+
+Why this matters:
+- Staleness can degrade gracefully with explicit alerting.
+- Supports "use yesterday's data" behavior while retaining traceability.
+
+## 5) Stale Gate Drill (`stale_blocked`)
+
+Command:
+
+```bash
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario stale_blocked --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/stale_blocked.json
+```
+
+Observed:
+
+- Run `status=failed`
+- `freshness_gate.status=stale_blocked`
+- Pipeline stops before `read_fetch`
+
+Why this matters:
+- Fail-closed behavior is explicit at the freshness boundary.
+- Prevents stale evidence from flowing into analysis.
+
 ## Assessment
 
 Path B failure behavior is explicit and step-scoped. Windmill can orchestrate retries/branches,

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/failure-drills.md
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/failure-drills.md
@@ -1,0 +1,66 @@
+# Failure Drills
+
+Date: 2026-04-12  
+Runner: `backend/scripts/verification/windmill_bakeoff_domain_boundary.py`
+
+## 1) SearXNG Failure Drill
+
+Command:
+
+```bash
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario source_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/source_failure.json
+```
+
+Observed:
+
+- Run `status=failed`
+- `search_materialize.status=source_error`
+- downstream steps did not execute
+- storage counts remained zero
+
+Why this matters:
+- Transport failure is isolated at discovery step.
+- No partial product records are created.
+
+## 2) Reader Failure Drill
+
+Command:
+
+```bash
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario reader_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/reader_failure.json
+```
+
+Observed:
+
+- Run `status=failed`
+- `search_materialize` and `freshness_gate` succeeded
+- `read_fetch.status=reader_error`
+- `index` and `analyze` did not execute
+
+Why this matters:
+- Reader errors fail before index/analyze.
+- Prevents non-provenanced downstream outputs.
+
+## 3) Storage Failure Drill
+
+Command:
+
+```bash
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario storage_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/storage_failure.json
+```
+
+Observed:
+
+- Run `status=failed`
+- Failure at `index.status=storage_error`
+- `read_fetch` succeeded (document + artifact present)
+- `chunks=0`, `analyses=0`
+
+Why this matters:
+- Domain boundary prevents analysis from running after storage/index failure.
+- Partial state remains inspectable but bounded.
+
+## Assessment
+
+Path B failure behavior is explicit and step-scoped. Windmill can orchestrate retries/branches,
+while affordabot domain commands enforce product integrity before each transition.

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/run-evidence.md
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/run-evidence.md
@@ -12,6 +12,9 @@ Path: `B / affordabot_domain_boundary`
 /usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario source_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/source_failure.json
 /usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario reader_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/reader_failure.json
 /usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario storage_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/storage_failure.json
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario stale_usable --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/stale_usable.json
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario stale_blocked --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/stale_blocked.json
+/usr/bin/python3 -m unittest backend/tests/verification/test_windmill_bakeoff_domain_boundary.py
 ```
 
 ## Outcome Summary
@@ -22,6 +25,9 @@ Path: `B / affordabot_domain_boundary`
 - Source failure drill: `status=failed` with `search_materialize:source_error`
 - Reader failure drill: `status=failed` with `read_fetch:reader_error`
 - Storage failure drill: `status=failed` with `index:storage_error`
+- Stale usable drill: `status=succeeded` with `freshness_gate:stale_but_usable`
+- Stale blocked drill: `status=failed` with `freshness_gate:stale_blocked`
+- Narrow tests: pass (`Ran 3 tests ... OK`)
 
 ## Key Evidence
 
@@ -44,3 +50,11 @@ Interpretation: idempotency is preserved across document identity, artifacts, ch
 
 - None for deterministic contract validation.
 - Live Windmill/SearXNG/Z.ai credentials were intentionally not used under current safety constraints.
+
+## Windmill Export Evidence
+
+The Path B orchestration shape is committed as reviewable repo code:
+
+- `ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.py`
+- `ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.script.yaml`
+- `ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary__flow/flow.yaml`

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/run-evidence.md
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/run-evidence.md
@@ -1,0 +1,46 @@
+# Run Evidence
+
+Date: 2026-04-12  
+Feature key: `bd-jxclm.15` (Beads reconciliation pending infra repair)  
+Path: `B / affordabot_domain_boundary`
+
+## Commands
+
+```bash
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --help
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario happy_rerun --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/happy_rerun.json
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario source_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/source_failure.json
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario reader_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/reader_failure.json
+/usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario storage_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/storage_failure.json
+```
+
+## Outcome Summary
+
+- `--help`: pass
+- Happy path first run: `status=succeeded`
+- Rerun/idempotency: `status=succeeded` with no duplicate writes
+- Source failure drill: `status=failed` with `search_materialize:source_error`
+- Reader failure drill: `status=failed` with `read_fetch:reader_error`
+- Storage failure drill: `status=failed` with `index:storage_error`
+
+## Key Evidence
+
+From `happy_rerun.json`:
+
+- First run:
+  - `canonical_document_key`: `san-jose-ca::a653e7debe31e650`
+  - `artifact_ref`: `minio://affordabot-artifacts/San_Jose_CA/ecf092f9a92f34b1.md`
+  - `chunks_created`: `5`
+  - `analysis_id`: `analysis-ebbbe7e0f3aeac41` (`reused=false`)
+- Rerun:
+  - same `canonical_document_key`
+  - same `artifact_ref`
+  - `chunks_created`: `0`
+  - same `analysis_id` with `reused=true`
+
+Interpretation: idempotency is preserved across document identity, artifacts, chunks, and analysis.
+
+## Live Infra Blockers
+
+- None for deterministic contract validation.
+- Live Windmill/SearXNG/Z.ai credentials were intentionally not used under current safety constraints.

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/storage-snapshots.md
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/storage-snapshots.md
@@ -1,6 +1,9 @@
 # Storage Snapshots
 
 This file captures storage-state evidence from `artifacts/happy_rerun.json`.
+Additional stale-gate evidence comes from:
+- `artifacts/stale_usable.json`
+- `artifacts/stale_blocked.json`
 
 ## After First Run (`run-first`)
 
@@ -45,3 +48,15 @@ Idempotency signals:
 
 Path B can keep Windmill-style orchestration while preserving product write invariants in affordabot:
 stable identity, deduplicated artifacts/chunks, and evidence-gated analysis.
+
+## Stale Gate Storage Effects
+
+From `stale_usable.json`:
+- `freshness_gate.status = stale_but_usable`
+- downstream `read_fetch`, `index`, and `analyze` still execute
+- run carries alert `freshness_gate:stale_but_usable`
+
+From `stale_blocked.json`:
+- `freshness_gate.status = stale_blocked`
+- pipeline fails closed before `read_fetch`
+- storage remains bounded at discovery snapshot only

--- a/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/storage-snapshots.md
+++ b/docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/storage-snapshots.md
@@ -1,0 +1,47 @@
+# Storage Snapshots
+
+This file captures storage-state evidence from `artifacts/happy_rerun.json`.
+
+## After First Run (`run-first`)
+
+Storage counts:
+
+- `search_snapshots`: 1
+- `documents`: 1
+- `artifacts`: 1
+- `chunks`: 5
+- `analyses`: 1
+
+Representative keys:
+
+- `snapshot_id`: `snapshot-579c45d51063aaef`
+- `canonical_document_key`: `san-jose-ca::a653e7debe31e650`
+- `artifact_ref`: `minio://affordabot-artifacts/San_Jose_CA/ecf092f9a92f34b1.md`
+- `analysis_id`: `analysis-ebbbe7e0f3aeac41`
+
+Provenance chain demonstrated:
+
+`claim -> evidence chunk ids -> canonical_document_key + artifact_ref -> search snapshot`
+
+## After Rerun (`run-second`)
+
+Storage counts:
+
+- `search_snapshots`: 1 (unchanged)
+- `documents`: 1 (unchanged)
+- `artifacts`: 1 (unchanged)
+- `chunks`: 5 (unchanged)
+- `analyses`: 1 (unchanged)
+
+Idempotency signals:
+
+- `search_materialize.snapshot_id` unchanged.
+- `read_fetch.canonical_document_key` unchanged.
+- `read_fetch.artifact_ref` unchanged.
+- `index.chunks_created = 0`.
+- `analyze.analysis_id` unchanged with `reused=true`.
+
+## Interpretation
+
+Path B can keep Windmill-style orchestration while preserving product write invariants in affordabot:
+stable identity, deduplicated artifacts/chunks, and evidence-gated analysis.

--- a/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.py
+++ b/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.py
@@ -1,0 +1,108 @@
+"""Windmill script surface for Path B orchestration review.
+
+This script models step-level orchestration payloads for the domain-boundary pipeline.
+It is committed for flow-shape review and contract comparison with Path A.
+"""
+
+from typing import Any, Dict, Optional
+
+
+def _step_result(
+    step: str,
+    envelope: Dict[str, Any],
+    stale_status: str,
+    previous_step_output: Optional[Dict[str, Any]],
+    search_query: Optional[str],
+    analysis_question: Optional[str],
+) -> Dict[str, Any]:
+    if step == "search_materialize":
+        return {
+            "status": "fresh",
+            "snapshot_id": "snapshot-579c45d51063aaef",
+            "result_count": 2,
+            "query": search_query,
+            "envelope": envelope,
+        }
+
+    if step == "freshness_gate":
+        if stale_status not in {"fresh", "stale_but_usable", "stale_blocked"}:
+            return {"status": "source_error", "error": "invalid_stale_status", "envelope": envelope}
+        return {"status": stale_status, "age_seconds": 3600, "envelope": envelope}
+
+    if step == "read_fetch":
+        if not previous_step_output:
+            return {"status": "reader_error", "error": "missing_freshness_gate_output", "envelope": envelope}
+        return {
+            "status": "fresh",
+            "canonical_document_key": "san-jose-ca::a653e7debe31e650",
+            "artifact_ref": "minio://affordabot-artifacts/San_Jose_CA/ecf092f9a92f34b1.md",
+            "envelope": envelope,
+        }
+
+    if step == "index":
+        if not previous_step_output:
+            return {"status": "storage_error", "error": "missing_read_fetch_output", "envelope": envelope}
+        return {
+            "status": "fresh",
+            "chunks_total": 5,
+            "chunks_created": 5,
+            "envelope": envelope,
+        }
+
+    if step == "analyze":
+        if not previous_step_output:
+            return {"status": "analysis_error", "error": "missing_index_output", "envelope": envelope}
+        return {
+            "status": "fresh",
+            "analysis_id": "analysis-ebbbe7e0f3aeac41",
+            "question": analysis_question,
+            "envelope": envelope,
+        }
+
+    if step == "summarize_run":
+        return {
+            "status": "succeeded",
+            "summary": "Path B flow-shape export. Domain writes belong to affordabot commands.",
+            "envelope": envelope,
+        }
+
+    return {"status": "source_error", "error": f"unsupported_step:{step}", "envelope": envelope}
+
+
+def main(
+    step: str,
+    contract_version: str = "2026-04-12.windmill-storage-bakeoff.v1",
+    architecture_path: str = "affordabot_domain_boundary",
+    windmill_workspace: str = "affordabot",
+    windmill_flow_path: str = "f/affordabot/pipeline_daily_refresh_domain_boundary__flow",
+    windmill_run_id: str = "windmill-run-id",
+    windmill_job_id: str = "windmill-job-id",
+    idempotency_key: str = "san-jose-ca:meeting_minutes:2026-04-12",
+    jurisdiction: str = "San Jose CA",
+    source_family: str = "meeting_minutes",
+    stale_status: str = "fresh",
+    search_query: Optional[str] = None,
+    analysis_question: Optional[str] = None,
+    previous_step_output: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    envelope = {
+        "contract_version": contract_version,
+        "architecture_path": architecture_path,
+        "orchestrator": "windmill",
+        "windmill_workspace": windmill_workspace,
+        "windmill_flow_path": windmill_flow_path,
+        "windmill_run_id": windmill_run_id,
+        "windmill_job_id": windmill_job_id,
+        "idempotency_key": idempotency_key,
+        "jurisdiction": jurisdiction,
+        "source_family": source_family,
+    }
+
+    return _step_result(
+        step=step,
+        envelope=envelope,
+        stale_status=stale_status,
+        previous_step_output=previous_step_output,
+        search_query=search_query,
+        analysis_question=analysis_question,
+    )

--- a/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.script.yaml
+++ b/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.script.yaml
@@ -1,0 +1,65 @@
+summary: Affordabot Path B domain-boundary bakeoff step
+description: >
+  Step-level script for the Path B windmill storage-boundary bakeoff.
+  This export is for orchestration-shape review and contract comparison.
+lock: ""
+kind: script
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  properties:
+    step:
+      type: string
+      description: Pipeline step name.
+      enum:
+        - search_materialize
+        - freshness_gate
+        - read_fetch
+        - index
+        - analyze
+        - summarize_run
+    contract_version:
+      type: string
+      default: 2026-04-12.windmill-storage-bakeoff.v1
+    architecture_path:
+      type: string
+      default: affordabot_domain_boundary
+    windmill_workspace:
+      type: string
+      default: affordabot
+    windmill_flow_path:
+      type: string
+      default: f/affordabot/pipeline_daily_refresh_domain_boundary__flow
+    windmill_run_id:
+      type: string
+      default: windmill-run-id
+    windmill_job_id:
+      type: string
+      default: windmill-job-id
+    idempotency_key:
+      type: string
+      default: san-jose-ca:meeting_minutes:2026-04-12
+    jurisdiction:
+      type: string
+      default: San Jose CA
+    source_family:
+      type: string
+      default: meeting_minutes
+    stale_status:
+      type: string
+      default: fresh
+      enum:
+        - fresh
+        - stale_but_usable
+        - stale_blocked
+    search_query:
+      type: string
+      default: San Jose CA city council meeting minutes housing
+    analysis_question:
+      type: string
+      default: Summarize housing-related signals from recent San Jose meeting minutes.
+    previous_step_output:
+      type: object
+      default: null
+  required:
+    - step

--- a/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary__flow/flow.yaml
+++ b/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary__flow/flow.yaml
@@ -1,0 +1,231 @@
+summary: Affordabot Path B domain-boundary daily refresh
+description: >
+  Windmill-shaped flow export for Path B. Orchestration is step-separate while
+  product writes are owned by affordabot domain commands.
+value:
+  modules:
+  - id: search_materialize
+    value:
+      type: script
+      path: f/affordabot/pipeline_daily_refresh_domain_boundary
+      retry:
+        attempts: 3
+        backoff:
+          initial_interval: 30
+          max_interval: 300
+          multiplier: 2
+      input_transforms:
+        step:
+          type: static
+          value: search_materialize
+        windmill_run_id:
+          type: static
+          value: $flow_job_id
+        windmill_job_id:
+          type: static
+          value: search_materialize
+        idempotency_key:
+          type: javascript
+          expr: flow_input.idempotency_key
+        jurisdiction:
+          type: javascript
+          expr: flow_input.jurisdiction
+        source_family:
+          type: javascript
+          expr: flow_input.source_family
+        search_query:
+          type: javascript
+          expr: flow_input.search_query
+  - id: freshness_gate
+    value:
+      type: script
+      path: f/affordabot/pipeline_daily_refresh_domain_boundary
+      retry:
+        attempts: 2
+        backoff:
+          initial_interval: 30
+          max_interval: 120
+          multiplier: 2
+      input_transforms:
+        step:
+          type: static
+          value: freshness_gate
+        windmill_run_id:
+          type: static
+          value: $flow_job_id
+        windmill_job_id:
+          type: static
+          value: freshness_gate
+        idempotency_key:
+          type: javascript
+          expr: flow_input.idempotency_key
+        jurisdiction:
+          type: javascript
+          expr: flow_input.jurisdiction
+        source_family:
+          type: javascript
+          expr: flow_input.source_family
+        stale_status:
+          type: javascript
+          expr: flow_input.stale_status
+        previous_step_output:
+          type: javascript
+          expr: results.search_materialize
+  - id: read_fetch
+    value:
+      type: script
+      path: f/affordabot/pipeline_daily_refresh_domain_boundary
+      retry:
+        attempts: 2
+        backoff:
+          initial_interval: 60
+          max_interval: 300
+          multiplier: 2
+      input_transforms:
+        step:
+          type: static
+          value: read_fetch
+        windmill_run_id:
+          type: static
+          value: $flow_job_id
+        windmill_job_id:
+          type: static
+          value: read_fetch
+        idempotency_key:
+          type: javascript
+          expr: flow_input.idempotency_key
+        jurisdiction:
+          type: javascript
+          expr: flow_input.jurisdiction
+        source_family:
+          type: javascript
+          expr: flow_input.source_family
+        previous_step_output:
+          type: javascript
+          expr: results.freshness_gate
+  - id: index
+    value:
+      type: script
+      path: f/affordabot/pipeline_daily_refresh_domain_boundary
+      retry:
+        attempts: 2
+        backoff:
+          initial_interval: 60
+          max_interval: 300
+          multiplier: 2
+      input_transforms:
+        step:
+          type: static
+          value: index
+        windmill_run_id:
+          type: static
+          value: $flow_job_id
+        windmill_job_id:
+          type: static
+          value: index
+        idempotency_key:
+          type: javascript
+          expr: flow_input.idempotency_key
+        jurisdiction:
+          type: javascript
+          expr: flow_input.jurisdiction
+        source_family:
+          type: javascript
+          expr: flow_input.source_family
+        previous_step_output:
+          type: javascript
+          expr: results.read_fetch
+  - id: analyze
+    value:
+      type: script
+      path: f/affordabot/pipeline_daily_refresh_domain_boundary
+      retry:
+        attempts: 1
+      input_transforms:
+        step:
+          type: static
+          value: analyze
+        windmill_run_id:
+          type: static
+          value: $flow_job_id
+        windmill_job_id:
+          type: static
+          value: analyze
+        idempotency_key:
+          type: javascript
+          expr: flow_input.idempotency_key
+        jurisdiction:
+          type: javascript
+          expr: flow_input.jurisdiction
+        source_family:
+          type: javascript
+          expr: flow_input.source_family
+        analysis_question:
+          type: javascript
+          expr: flow_input.analysis_question
+        previous_step_output:
+          type: javascript
+          expr: results.index
+  - id: summarize_run
+    value:
+      type: script
+      path: f/affordabot/pipeline_daily_refresh_domain_boundary
+      input_transforms:
+        step:
+          type: static
+          value: summarize_run
+        windmill_run_id:
+          type: static
+          value: $flow_job_id
+        windmill_job_id:
+          type: static
+          value: summarize_run
+        idempotency_key:
+          type: javascript
+          expr: flow_input.idempotency_key
+        jurisdiction:
+          type: javascript
+          expr: flow_input.jurisdiction
+        source_family:
+          type: javascript
+          expr: flow_input.source_family
+        previous_step_output:
+          type: javascript
+          expr: results.analyze
+concurrency:
+  limit: 1
+  key: affordabot-domain-boundary-bakeoff
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  required:
+    - idempotency_key
+    - jurisdiction
+    - source_family
+    - search_query
+    - analysis_question
+    - stale_status
+  properties:
+    idempotency_key:
+      type: string
+      default: san-jose-ca:meeting_minutes:2026-04-12
+    jurisdiction:
+      type: string
+      default: San Jose CA
+    source_family:
+      type: string
+      default: meeting_minutes
+    search_query:
+      type: string
+      default: San Jose CA city council meeting minutes housing
+    analysis_question:
+      type: string
+      default: Summarize housing-related signals from recent San Jose meeting minutes.
+    stale_status:
+      type: string
+      enum:
+        - fresh
+        - stale_but_usable
+        - stale_blocked
+      default: fresh
+ws_error_handler_muted: false


### PR DESCRIPTION
Feature-Key: bd-jxclm.15
Agent: codex

Beads reconciliation is pending infra repair (local Beads mutations currently broken).

## Scope
- Add deterministic Path B Windmill-shaped runner with coarse affordabot domain commands.
- Enforce invariants: canonical_document_key, idempotency, artifact refs, chunk provenance, sufficiency gate.
- Add evidence artifacts for happy path, rerun proof, source failure, reader failure, and storage failure drills.

## Validation
- /usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --help
- /usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario happy_rerun --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/happy_rerun.json
- /usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario source_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/source_failure.json
- /usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario reader_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/reader_failure.json
- /usr/bin/python3 backend/scripts/verification/windmill_bakeoff_domain_boundary.py --scenario storage_failure --pretty --out docs/poc/windmill-storage-bakeoff/path-b-domain-boundary/artifacts/storage_failure.json
- /usr/bin/python3 -m py_compile backend/scripts/verification/windmill_bakeoff_domain_boundary.py
- git diff --check