### PR TITLE
bd-1ebyt.6: add CI preflights for ruff, preservation, and PR metadata

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,11 @@
 
 Describe the change and link the Beads issue.
 
+## Preflight (required)
+
+- [ ] `scripts/ci/backend-ruff-preflight.sh`
+- [ ] `python3 scripts/ci/check-pr-metadata.py --title "bd-xyz: summary" --body "Agent: <id>"`
+
 ## Feature Metadata
 
 **Required fields:**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,19 @@ jobs:
       - name: Anti-Prime Contamination Check
         run: bash scripts/ci/check-prime-contamination.sh frontend
 
+      - name: Preservation preflight
+        env:
+          NEXT_PUBLIC_TEST_AUTH_BYPASS: 'true'
+          TEST_AUTH_BYPASS_SECRET: ci-test-secret-for-playwright-only
+          NEXT_PUBLIC_API_URL: http://127.0.0.1:65535
+        run: bash scripts/ci/preservation-preflight.sh
+
       - name: Run Preservation Tests
         env:
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_ci_placeholder_for_build_only
           CLERK_SECRET_KEY: sk_test_ci_placeholder_for_build_only
           NEXT_PUBLIC_TEST_AUTH_BYPASS: 'true'
+          NEXT_PUBLIC_API_URL: http://127.0.0.1:65535
           RAILWAY_ENVIRONMENT_NAME: 'dev'
           TEST_AUTH_BYPASS_SECRET: ci-test-secret-for-playwright-only
         run: cd frontend && pnpm test
@@ -78,9 +86,29 @@ jobs:
           path: frontend/playwright-report/
           retention-days: 30
 
+  backend-ruff-preflight:
+    name: Backend Ruff Preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install Ruff
+        run: python3 -m pip install --upgrade ruff
+
+      - name: Run fast Ruff preflight
+        run: |
+          chmod +x scripts/ci/backend-ruff-preflight.sh
+          scripts/ci/backend-ruff-preflight.sh
+
   backend-lint-and-test:
     name: Backend Lint & Test
     runs-on: ubuntu-latest
+    needs: backend-ruff-preflight
     services:
       postgres:
         image: pgvector/pgvector:pg16
@@ -150,36 +178,4 @@ jobs:
 
       - name: Enforce PR metadata (Feature-Key + Agent)
         run: |
-          python3 - <<'PY'
-          import json, os, re, sys
-          event_path = os.environ.get("GITHUB_EVENT_PATH")
-          if not event_path:
-            print("ERROR: GITHUB_EVENT_PATH not set")
-            sys.exit(1)
-
-          with open(event_path, "r", encoding="utf-8") as f:
-            event = json.load(f)
-
-          pr = event.get("pull_request") or {}
-          title = pr.get("title") or ""
-          body = pr.get("body") or ""
-          author = (pr.get("user") or {}).get("login") or ""
-
-          if not re.search(r"\bbd-[a-z0-9]+\b", title):
-            print("ERROR: PR title missing Feature-Key (bd-<beads-id>)")
-            print("Include the Beads id in the PR title, e.g.:")
-            print("  bd-f6fh: Short summary")
-            sys.exit(1)
-
-          if author in {"dependabot[bot]", "renovate[bot]", "github-actions[bot]"}:
-            print(f"INFO: Bot PR ({author}): skipping Agent: enforcement")
-            sys.exit(0)
-
-          if "Agent:" not in body:
-            print("ERROR: PR body missing 'Agent:'")
-            print("Add to PR body, e.g.:")
-            print("  Agent: codex")
-            sys.exit(1)
-
-          print("OK: PR metadata enforcement passed")
-          PY
+          python3 scripts/ci/check-pr-metadata.py

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || '',
       CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY || '',
       NEXT_PUBLIC_TEST_AUTH_BYPASS: 'true',
+      NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || 'http://127.0.0.1:65535',
       RAILWAY_ENVIRONMENT_NAME: 'dev',
       TEST_AUTH_BYPASS_SECRET: process.env.TEST_AUTH_BYPASS_SECRET || 'ci-test-secret-for-playwright-only',
     },

--- a/frontend/tests/e2e/preserved-admin.spec.ts
+++ b/frontend/tests/e2e/preserved-admin.spec.ts
@@ -29,6 +29,13 @@ async function mockAdminAPIDefault(page) {
   await page.route('**/api/admin/**', async (route) => {
     await route.fulfill({ json: [] });
   });
+  await page.route('**/api/sources**', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({ json: [] });
+      return;
+    }
+    await route.fulfill({ json: { ok: true } });
+  });
 }
 
 adminTest.describe('Preserved Admin Routes', () => {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,6 +24,14 @@
 - `bulk_validation.py`: Batch validation logic.
 - `validate_pipeline_sanjose.py`: Specific pipeline verification.
 - `e2e_test.py`: End-to-end testing script.
+- `backend-ruff-preflight.sh`: Fast backend Ruff gate (no full backend test suite).
+- `preservation-preflight.sh`: Frontend preservation env/fixture preflight.
+- `check-pr-metadata.py`: Feature-Key + Agent PR metadata check (local/CI).
+
+### CI quick commands
+- `scripts/ci/backend-ruff-preflight.sh`
+- `NEXT_PUBLIC_TEST_AUTH_BYPASS=true TEST_AUTH_BYPASS_SECRET=ci-test-secret-for-playwright-only NEXT_PUBLIC_API_URL=http://127.0.0.1:65535 scripts/ci/preservation-preflight.sh`
+- `python3 scripts/ci/check-pr-metadata.py --title "bd-xyz: summary" --body "Agent: codex"`
 
 ### Maintenance
 - `create_minio_bucket.py`: Infrastructure setup.

--- a/scripts/ci/backend-ruff-preflight.sh
+++ b/scripts/ci/backend-ruff-preflight.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+export PATH="$HOME/.local/bin:$HOME/Library/Python/3.13/bin:$HOME/Library/Python/3.14/bin:$PATH"
+
+if command -v ruff >/dev/null 2>&1; then
+  echo "Running Ruff via PATH..."
+  ruff check backend
+  exit 0
+fi
+
+if [[ -x "$REPO_ROOT/backend/.venv/bin/ruff" ]]; then
+  echo "Running Ruff via backend virtualenv..."
+  "$REPO_ROOT/backend/.venv/bin/ruff" check "$REPO_ROOT/backend"
+  exit 0
+fi
+
+if python3 -c "import ruff" >/dev/null 2>&1; then
+  echo "Running Ruff via python module..."
+  python3 -m ruff check backend
+  exit 0
+fi
+
+if command -v poetry >/dev/null 2>&1; then
+  echo "Running Ruff via Poetry environment..."
+  cd backend
+  poetry run ruff check .
+  exit 0
+fi
+
+echo "ERROR: Ruff is unavailable."
+echo "Fix command:"
+echo "  python3 -m pip install --user ruff"
+echo "Then rerun:"
+echo "  scripts/ci/backend-ruff-preflight.sh"
+exit 1

--- a/scripts/ci/check-pr-metadata.py
+++ b/scripts/ci/check-pr-metadata.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Validate Feature-Key and Agent metadata for PRs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+FEATURE_KEY_RE = re.compile(r"\bbd-[a-z0-9.]+\b")
+BOT_AUTHORS = {"dependabot[bot]", "renovate[bot]", "github-actions[bot]"}
+
+
+def _load_from_event(event_path: Path) -> tuple[str, str, str]:
+    event = json.loads(event_path.read_text(encoding="utf-8"))
+    pr = event.get("pull_request") or {}
+    title = pr.get("title") or ""
+    body = pr.get("body") or ""
+    author = (pr.get("user") or {}).get("login") or ""
+    return title, body, author
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--title", help="PR title for local checks")
+    parser.add_argument("--body", help="PR body for local checks")
+    parser.add_argument("--author", default="", help="PR author login (optional)")
+    parser.add_argument("--event-path", help="Path to GitHub event JSON")
+    args = parser.parse_args()
+
+    event_path = args.event_path or os.environ.get("GITHUB_EVENT_PATH")
+    if event_path:
+        title, body, author = _load_from_event(Path(event_path))
+    else:
+        title = args.title or ""
+        body = args.body or ""
+        author = args.author or ""
+
+    if not title:
+        print("ERROR: missing PR title input")
+        print("Local usage:")
+        print('  python3 scripts/ci/check-pr-metadata.py --title "bd-xxxx: summary" --body "Agent: codex"')
+        return 1
+
+    if not FEATURE_KEY_RE.search(title):
+        print("ERROR: PR title missing Feature-Key (bd-<beads-id>)")
+        print("Example title:")
+        print("  bd-1ebyt.6: harden affordabot CI preflights")
+        return 1
+
+    if author in BOT_AUTHORS:
+        print(f"OK: bot PR detected ({author}); Agent metadata check skipped")
+        return 0
+
+    if "Agent:" not in body:
+        print("ERROR: PR body missing 'Agent:'")
+        print("Add line:")
+        print("  Agent: codex")
+        return 1
+
+    print("OK: PR metadata enforcement passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/preservation-preflight.sh
+++ b/scripts/ci/preservation-preflight.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT/frontend"
+
+required_files=(
+  "tests/e2e/fixtures/legislation-california.json"
+  "tests/e2e/fixtures/bill-detail.json"
+)
+
+for file in "${required_files[@]}"; do
+  if [[ ! -f "$file" ]]; then
+    echo "ERROR: required preservation fixture missing: frontend/$file"
+    echo "Fix command:"
+    echo "  git checkout -- frontend/$file"
+    exit 1
+  fi
+done
+
+if [[ "${NEXT_PUBLIC_TEST_AUTH_BYPASS:-}" != "true" ]]; then
+  echo "ERROR: NEXT_PUBLIC_TEST_AUTH_BYPASS must be true for preservation tests."
+  echo "Fix command:"
+  echo "  export NEXT_PUBLIC_TEST_AUTH_BYPASS=true"
+  exit 1
+fi
+
+if [[ -z "${TEST_AUTH_BYPASS_SECRET:-}" ]]; then
+  echo "ERROR: TEST_AUTH_BYPASS_SECRET is required."
+  echo "Fix command:"
+  echo "  export TEST_AUTH_BYPASS_SECRET=ci-test-secret-for-playwright-only"
+  exit 1
+fi
+
+if [[ -z "${NEXT_PUBLIC_API_URL:-}" ]]; then
+  echo "ERROR: NEXT_PUBLIC_API_URL is required for deterministic preservation routing."
+  echo "Fix command:"
+  echo "  export NEXT_PUBLIC_API_URL=http://127.0.0.1:65535"
+  exit 1
+fi
+
+echo "OK: frontend preservation preflight passed"


### PR DESCRIPTION
## Summary
- add fast backend Ruff preflight script and dedicated CI job before full backend test job
- add frontend preservation preflight (fixture/env checks) and pass deterministic NEXT_PUBLIC_API_URL in CI
- close preservation mock gap by mocking /api/sources in preserved-admin Playwright tests
- extract PR metadata enforcement into scripts/ci/check-pr-metadata.py for CI + local preflight use
- document preflight commands in scripts/README and PR template

## Root Causes Addressed
- historical backend lint failures now fail early with a fast Ruff-only gate
- preservation gate no longer depends on ambient backend readiness for /api/sources calls
- Feature-Key/Agent metadata can be preflighted locally before opening PR

## Validation
- python3 scripts/ci/check-pr-metadata.py --title bd-1ebyt.6:ci-hardening --body Agent:codex
- NEXT_PUBLIC_TEST_AUTH_BYPASS=true TEST_AUTH_BYPASS_SECRET=ci-test-secret-for-playwright-only NEXT_PUBLIC_API_URL=http://127.0.0.1:65535 scripts/ci/preservation-preflight.sh
- scripts/ci/backend-ruff-preflight.sh
- cd frontend && pnpm install --frozen-lockfile && pnpm exec playwright test tests/e2e/preserved-admin.spec.ts --list
- actionlint .github/workflows/ci.yml

## Deferred
- no broad frontend test refactor; this PR stays on CI reliability hardening only

Agent: codex
