### PR TITLE
bd-bupjb: consolidate admin pipeline observability surfaces

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1194,21 +1194,27 @@ async def get_pipeline_jurisdiction_status(
                 windmill_run_id
             FROM pipeline_runs
             WHERE LOWER(COALESCE(jurisdiction, '')) IN (LOWER($1), LOWER($2))
+              AND (source_family = $3 OR source_family IS NULL)
+            ORDER BY
+                CASE WHEN source_family = $3 THEN 0 ELSE 1 END,
+                started_at DESC
+            LIMIT 1
+        """
+        latest_run = await db._fetchrow(run_query, jur_name, jur_id, normalized_source_family)
+
+        latest_success_query = """
+            SELECT id, completed_at
+            FROM pipeline_runs
+            WHERE LOWER(COALESCE(jurisdiction, '')) IN (LOWER($1), LOWER($2))
+              AND (source_family = $3 OR source_family IS NULL)
+              AND status = 'completed'
+              AND completed_at IS NOT NULL
             ORDER BY started_at DESC
             LIMIT 1
         """
-        latest_run = await db._fetchrow(run_query, jur_name, jur_id)
-
-        latest_success_query = """
-            SELECT completed_at
-            FROM pipeline_runs
-            WHERE LOWER(COALESCE(jurisdiction, '')) IN (LOWER($1), LOWER($2))
-              AND status = 'completed'
-              AND completed_at IS NOT NULL
-            ORDER BY completed_at DESC
-            LIMIT 1
-        """
-        latest_success = await db._fetchrow(latest_success_query, jur_name, jur_id)
+        latest_success = await db._fetchrow(
+            latest_success_query, jur_name, jur_id, normalized_source_family
+        )
 
         result = _json_payload(latest_run.get("result")) if latest_run else {}
         run_status = _to_text(latest_run.get("status")) if latest_run else ""
@@ -1221,12 +1227,14 @@ async def get_pipeline_jurisdiction_status(
         if not isinstance(freshness_alerts, list):
             freshness_alerts = _extract_pipeline_alerts(result)
         pipeline_status = _derive_pipeline_status(run_status, freshness_status)
+        latest_pipeline_run_id = _to_text(latest_run.get("id")) if latest_run else None
 
         response = {
             "contract_version": CONTRACT_VERSION,
             "jurisdiction_id": jur_id,
             "jurisdiction_name": jur_name,
             "source_family": normalized_source_family,
+            "latest_pipeline_run_id": latest_pipeline_run_id,
             "pipeline_status": pipeline_status,
             "last_success_at": str(latest_success["completed_at"])
             if latest_success and latest_success.get("completed_at")
@@ -1242,6 +1250,7 @@ async def get_pipeline_jurisdiction_status(
             "latest_analysis": latest_analysis,
             "alerts": _extract_pipeline_alerts(result),
             "operator_links": {
+                "pipeline_run_id": latest_pipeline_run_id,
                 "windmill_run_url": _build_windmill_run_url(
                     latest_run.get("windmill_run_id") if latest_run else None
                 ),

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1257,52 +1257,41 @@ async def get_pipeline_jurisdiction_status(
 
 
 @router.get("/pipeline/runs/{run_id}")
-async def get_pipeline_run_read_model(run_id: str, db: PostgresDB = Depends(get_db)):
-    """Return backend-authored run summary for pipeline UI."""
+async def get_pipeline_run_read_model(
+    run_id: str,
+    service: GlassBoxService = Depends(get_glass_box_service),
+):
+    """Compatibility alias over GlassBox run semantics for pipeline UI."""
     try:
-        row = await db._fetchrow(
-            """
-            SELECT
-                id,
-                bill_id,
-                jurisdiction,
-                status,
-                started_at,
-                completed_at,
-                error,
-                result,
-                trigger_source,
-                windmill_workspace,
-                windmill_run_id,
-                source_family
-            FROM pipeline_runs
-            WHERE id::text = $1
-            LIMIT 1
-            """,
-            run_id,
-        )
-        if not row:
+        run = await service.get_pipeline_run(run_id)
+        if not run:
             raise HTTPException(status_code=404, detail="Pipeline run not found")
 
-        result = _json_payload(row.get("result"))
+        result = _json_payload(run.get("result"))
         counts = _extract_counts(result)
+        pipeline_run_id = _to_text(run.get("id"))
+        source_family = _to_text(run.get("source_family")) or DEFAULT_SOURCE_FAMILY
+        windmill_run_id = _to_text(run.get("windmill_run_id"))
+
         return {
             "contract_version": CONTRACT_VERSION,
-            "run_id": _to_text(row.get("id")),
-            "status": _to_text(row.get("status")),
-            "jurisdiction": _to_text(row.get("jurisdiction")),
-            "source_family": _to_text(row.get("source_family")) or DEFAULT_SOURCE_FAMILY,
-            "bill_id": _to_text(row.get("bill_id")) or None,
-            "started_at": str(row["started_at"]) if row.get("started_at") else None,
-            "completed_at": str(row["completed_at"]) if row.get("completed_at") else None,
-            "error": _to_text(row.get("error")) or None,
-            "trigger_source": _to_text(row.get("trigger_source")) or None,
+            "run_id": pipeline_run_id,
+            "pipeline_run_id": pipeline_run_id,
+            "status": _to_text(run.get("status")),
+            "jurisdiction": _to_text(run.get("jurisdiction")),
+            "source_family": source_family,
+            "bill_id": _to_text(run.get("bill_id")) or None,
+            "started_at": _to_text(run.get("started_at")) or None,
+            "completed_at": _to_text(run.get("completed_at")) or None,
+            "error": _to_text(run.get("error")) or None,
+            "trigger_source": _to_text(run.get("trigger_source")) or None,
             "counts": counts,
             "latest_analysis": _extract_latest_analysis(result, counts),
             "alerts": _extract_pipeline_alerts(result),
             "operator_links": {
-                "windmill_workspace": _to_text(row.get("windmill_workspace")) or "affordabot",
-                "windmill_run_url": _build_windmill_run_url(row.get("windmill_run_id")),
+                "windmill_workspace": _to_text(run.get("windmill_workspace"))
+                or "affordabot",
+                "windmill_run_url": _build_windmill_run_url(windmill_run_id),
             },
         }
     except HTTPException:
@@ -1313,75 +1302,59 @@ async def get_pipeline_run_read_model(run_id: str, db: PostgresDB = Depends(get_
         )
 
 
+def _normalize_pipeline_step(step: PipelineStep) -> dict[str, Any]:
+    output_result = _json_payload(step.output_result)
+    step_alerts = output_result.get("alerts")
+    if not isinstance(step_alerts, list):
+        step_alerts = []
+    refs = output_result.get("refs")
+    if not isinstance(refs, dict):
+        refs = {}
+    decision_reason = _to_text(output_result.get("decision_reason"))
+    retry_class = _to_text(output_result.get("retry_class")) or "none"
+    command = _to_text(output_result.get("command")) or _to_text(step.step_name)
+
+    return {
+        "contract_version": CONTRACT_VERSION,
+        "step_id": _to_text(step.id),
+        "run_id": _to_text(step.run_id),
+        "pipeline_run_id": _to_text(step.run_id),
+        "command": command,
+        "status": _to_text(step.status),
+        "decision_reason": decision_reason or None,
+        "retry_class": retry_class,
+        "alerts": [_to_text(item) for item in step_alerts if _to_text(item)],
+        "counts": output_result.get("counts")
+        if isinstance(output_result.get("counts"), dict)
+        else {},
+        "refs": refs,
+        "duration_ms": _coerce_int(step.duration_ms),
+        "error": _to_text(output_result.get("error")) or None,
+        "timestamp": str(step.created_at) if step.created_at else None,
+    }
+
+
 @router.get("/pipeline/runs/{run_id}/steps")
 async def get_pipeline_run_steps_read_model(
-    run_id: str, db: PostgresDB = Depends(get_db)
+    run_id: str,
+    service: GlassBoxService = Depends(get_glass_box_service),
 ):
-    """Return run steps in a stable read-model shape."""
+    """Compatibility alias over GlassBox step semantics for pipeline UI."""
     try:
-        rows = await db._fetch(
-            """
-            SELECT
-                id,
-                run_id,
-                command,
-                step_name,
-                status,
-                duration_ms,
-                input_context,
-                output_result,
-                retry_class,
-                decision_reason,
-                alerts,
-                refs,
-                created_at
-            FROM pipeline_steps
-            WHERE run_id::text = $1
-            ORDER BY created_at ASC
-            """,
-            run_id,
-        )
-        steps: list[dict[str, Any]] = []
-        for row in rows:
-            output_result = _json_payload(row.get("output_result"))
-            step_alerts = output_result.get("alerts")
-            if not isinstance(step_alerts, list):
-                step_alerts = row.get("alerts")
-            if not isinstance(step_alerts, list):
-                step_alerts = []
-            refs = output_result.get("refs")
-            if not isinstance(refs, dict):
-                refs = row.get("refs")
-            if not isinstance(refs, dict):
-                refs = {}
-            decision_reason = _to_text(row.get("decision_reason")) or _to_text(
-                output_result.get("decision_reason")
-            )
-            retry_class = _to_text(row.get("retry_class")) or _to_text(
-                output_result.get("retry_class")
-            )
+        run = await service.get_pipeline_run(run_id)
+        if not run:
+            raise HTTPException(status_code=404, detail="Pipeline run not found")
 
-            steps.append(
-                {
-                    "contract_version": CONTRACT_VERSION,
-                    "step_id": _to_text(row.get("id")),
-                    "run_id": _to_text(row.get("run_id")),
-                    "command": _to_text(row.get("command"))
-                    or _to_text(row.get("step_name")),
-                    "status": _to_text(row.get("status")),
-                    "decision_reason": decision_reason or None,
-                    "retry_class": retry_class or "none",
-                    "alerts": [_to_text(item) for item in step_alerts if _to_text(item)],
-                    "counts": output_result.get("counts")
-                    if isinstance(output_result.get("counts"), dict)
-                    else {},
-                    "refs": refs,
-                    "duration_ms": _coerce_int(row.get("duration_ms")),
-                    "error": _to_text(output_result.get("error")) or None,
-                    "timestamp": str(row["created_at"]) if row.get("created_at") else None,
-                }
-            )
-        return {"contract_version": CONTRACT_VERSION, "run_id": run_id, "steps": steps}
+        steps = await service.get_pipeline_steps(run_id)
+        normalized = [_normalize_pipeline_step(step) for step in steps]
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "run_id": run_id,
+            "pipeline_run_id": run_id,
+            "steps": normalized,
+        }
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(
             status_code=500, detail=f"Failed to fetch pipeline run steps: {str(e)}"
@@ -1389,22 +1362,17 @@ async def get_pipeline_run_steps_read_model(
 
 
 @router.get("/pipeline/runs/{run_id}/evidence")
-async def get_pipeline_run_evidence(run_id: str, db: PostgresDB = Depends(get_db)):
+async def get_pipeline_run_evidence(
+    run_id: str,
+    service: GlassBoxService = Depends(get_glass_box_service),
+):
     """Return evidence refs for a run without exposing storage internals."""
     try:
-        row = await db._fetchrow(
-            """
-            SELECT id, result
-            FROM pipeline_runs
-            WHERE id::text = $1
-            LIMIT 1
-            """,
-            run_id,
-        )
-        if not row:
+        run = await service.get_pipeline_run(run_id)
+        if not run:
             raise HTTPException(status_code=404, detail="Pipeline run not found")
 
-        result = _json_payload(row.get("result"))
+        result = _json_payload(run.get("result"))
         analysis = result.get("analysis")
         evidence_items: list[dict[str, Any]] = []
         if isinstance(analysis, dict):

--- a/backend/services/glass_box.py
+++ b/backend/services/glass_box.py
@@ -469,9 +469,21 @@ class GlassBoxService:
 
         try:
             query = """
-                SELECT id, bill_id, jurisdiction, status, started_at, completed_at, error, models, result,
-                       trigger_source
-                FROM pipeline_runs 
+                SELECT
+                    id,
+                    bill_id,
+                    jurisdiction,
+                    status,
+                    started_at,
+                    completed_at,
+                    error,
+                    models,
+                    result,
+                    trigger_source,
+                    source_family,
+                    windmill_workspace,
+                    windmill_run_id
+                FROM pipeline_runs
                 WHERE id::text = $1
             """
             r = await self.db._fetchrow(query, run_id)
@@ -525,6 +537,9 @@ class GlassBoxService:
                 ),
                 "aggregate_scenario_bounds": analysis.get("aggregate_scenario_bounds"),
                 "trigger_source": trigger_source,
+                "source_family": r.get("source_family"),
+                "windmill_workspace": r.get("windmill_workspace"),
+                "windmill_run_id": r.get("windmill_run_id"),
                 "is_prefix_run": is_prefix_run,
                 "is_fixture_run": is_fixture_run,
                 "run_label": run_label,

--- a/backend/tests/routers/test_admin_pipeline_read_model.py
+++ b/backend/tests/routers/test_admin_pipeline_read_model.py
@@ -124,6 +124,7 @@ def test_get_pipeline_run_detail_shape(client, mock_db):
         "started_at": "2026-04-13T02:00:00Z",
         "completed_at": "2026-04-13T02:01:00Z",
         "error": None,
+        "models": {"analysis": "zai"},
         "trigger_source": "windmill",
         "windmill_workspace": "affordabot",
         "windmill_run_id": "wm-run-2",
@@ -143,32 +144,47 @@ def test_get_pipeline_run_detail_shape(client, mock_db):
     data = response.json()
     assert data["contract_version"] == CONTRACT_VERSION
     assert data["run_id"] == "run-2"
+    assert data["pipeline_run_id"] == "run-2"
     assert data["counts"]["search_results"] == 3
     assert data["latest_analysis"]["evidence_count"] == 5
     assert data["operator_links"]["windmill_run_url"].endswith("/wm-run-2")
 
 
 def test_get_pipeline_run_steps_shape(client, mock_db):
+    mock_db._fetchrow.return_value = {
+        "id": "run-2",
+        "bill_id": "SB-1",
+        "jurisdiction": "San Jose CA",
+        "status": "completed",
+        "started_at": "2026-04-13T02:00:00Z",
+        "completed_at": "2026-04-13T02:01:00Z",
+        "error": None,
+        "models": {"analysis": "zai"},
+        "trigger_source": "windmill",
+        "windmill_workspace": "affordabot",
+        "windmill_run_id": "wm-run-2",
+        "source_family": "meeting_minutes",
+        "result": {},
+    }
     mock_db._fetch.return_value = [
         {
             "id": "step-1",
             "run_id": "run-2",
+            "step_number": 1,
             "step_name": "search_materialize",
-            "command": "search_materialize",
             "status": "succeeded",
             "duration_ms": 42,
             "input_context": {"q": "san jose meeting minutes"},
             "output_result": {
+                "command": "search_materialize",
                 "decision_reason": "fresh_snapshot_materialized",
                 "retry_class": "none",
                 "counts": {"search_results": 2},
+                "refs": {"search_snapshot_id": "snap-1"},
             },
-            "decision_reason": "fresh_snapshot_materialized",
-            "retry_class": "none",
-            "alerts": [],
-            "refs": {"search_snapshot_id": "snap-1"},
+            "model_config": {},
             "created_at": "2026-04-13T02:00:10Z",
-        }
+        },
     ]
     client.set_auth("admin")
     response = client.get("/api/admin/pipeline/runs/run-2/steps")
@@ -176,6 +192,7 @@ def test_get_pipeline_run_steps_shape(client, mock_db):
     data = response.json()
     assert data["contract_version"] == CONTRACT_VERSION
     assert data["run_id"] == "run-2"
+    assert data["pipeline_run_id"] == "run-2"
     assert len(data["steps"]) == 1
     assert data["steps"][0]["command"] == "search_materialize"
     assert data["steps"][0]["refs"]["search_snapshot_id"] == "snap-1"
@@ -184,6 +201,17 @@ def test_get_pipeline_run_steps_shape(client, mock_db):
 def test_get_pipeline_run_evidence_shape(client, mock_db):
     mock_db._fetchrow.return_value = {
         "id": "run-3",
+        "bill_id": "SB-1",
+        "jurisdiction": "San Jose CA",
+        "status": "completed",
+        "started_at": "2026-04-13T02:00:00Z",
+        "completed_at": "2026-04-13T02:01:00Z",
+        "error": None,
+        "models": {"analysis": "zai"},
+        "trigger_source": "windmill",
+        "windmill_workspace": "affordabot",
+        "windmill_run_id": "wm-run-3",
+        "source_family": "meeting_minutes",
         "result": {
             "analysis": {
                 "citations": [
@@ -199,6 +227,16 @@ def test_get_pipeline_run_evidence_shape(client, mock_db):
     assert data["contract_version"] == CONTRACT_VERSION
     assert data["evidence_count"] == 1
     assert data["items"][0]["label"] == "City Agenda Packet"
+
+
+def test_get_pipeline_run_steps_rejects_non_run_uuid_query_key(client, mock_db):
+    # get_pipeline_run is strict id lookup; bill/manual keys should not resolve here.
+    mock_db._fetchrow.return_value = None
+    client.set_auth("admin")
+    response = client.get("/api/admin/pipeline/runs/SR-2026-001/steps")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Pipeline run not found"
+    mock_db._fetch.assert_not_called()
 
 
 def test_post_pipeline_jurisdiction_refresh_shape(client, mock_db):

--- a/backend/tests/routers/test_admin_pipeline_read_model.py
+++ b/backend/tests/routers/test_admin_pipeline_read_model.py
@@ -109,10 +109,14 @@ def test_get_pipeline_jurisdiction_status_shape(client, mock_db):
     assert data["contract_version"] == CONTRACT_VERSION
     assert data["jurisdiction_id"] == "jur-1"
     assert data["source_family"] == "meeting_minutes"
+    assert data["latest_pipeline_run_id"] == "run-1"
+    assert data["operator_links"]["pipeline_run_id"] == "run-1"
     assert data["pipeline_status"] == "stale_but_usable"
     assert data["freshness"]["stale_usable_ceiling_hours"] == 72
     assert data["counts"]["chunks"] == 4
     assert data["latest_analysis"]["status"] == "ready"
+    first_query = mock_db._fetchrow.call_args_list[1]
+    assert first_query.args[3] == "meeting_minutes"
 
 
 def test_get_pipeline_run_detail_shape(client, mock_db):

--- a/docs/ADMIN_PIPELINE_FRONTEND_OWNERSHIP_MAP_2026-04-13.md
+++ b/docs/ADMIN_PIPELINE_FRONTEND_OWNERSHIP_MAP_2026-04-13.md
@@ -1,0 +1,34 @@
+# Admin Pipeline Frontend Ownership Map (bd-bupjb.2)
+
+Date: 2026-04-13  
+Feature-Key: `bd-bupjb`
+
+## Surface Ownership
+
+1. Audit Trace pages own pipeline run debugging:
+   - run list (`/admin/audits/trace`)
+   - run detail (`/admin/audits/trace/[id]`)
+   - step-level prompt/response inspection
+   - analysis output and citation inspection
+
+2. Substrate Explorer owns substrate ingestion debugging:
+   - substrate run list and summary
+   - failure buckets
+   - raw row filtering and row detail inspection
+   - it must not treat substrate/manual run ids as pipeline run UUIDs
+
+3. Pipeline Status panel owns jurisdiction/source-family health:
+   - freshness status and policy windows
+   - coverage counts and latest analysis readiness
+   - operator alerts and refresh action
+   - optional link to Audit Trace run only when a real `pipeline_run_id` is present in backend status payload
+
+4. Scrape Manager and Analysis Lab remain separate operational surfaces:
+   - Scrape Manager: scrape trigger + scrape task execution tracking
+   - Analysis Lab: analysis workflow/operator tooling
+
+## Consolidation Rules Applied
+
+- Removed duplicate run-detail/steps/evidence rendering from `PipelineStatusPanel`.
+- Stopped `SubstrateExplorer` from passing selected substrate run id into pipeline run endpoints.
+- Kept Pipeline Status focused on jurisdiction/source-family status and refresh controls.

--- a/docs/architecture/2026-04-13-admin-pipeline-read-model-map.md
+++ b/docs/architecture/2026-04-13-admin-pipeline-read-model-map.md
@@ -1,0 +1,23 @@
+# Admin Pipeline Read-Model Map (Backend)
+
+Date: 2026-04-13  
+Scope: backend API/read-model consolidation for `bd-bupjb.1`
+
+## Endpoint Surface
+
+| Endpoint | Owner | DB Tables | Identifier Semantics | Frontend Consumer (observed) |
+| --- | --- | --- | --- | --- |
+| `GET /api/admin/pipeline-runs` | GlassBox (`GlassBoxService.list_pipeline_runs`) | `pipeline_runs` | Run list (`pipeline_runs.id`) | Audit Trace list page |
+| `GET /api/admin/pipeline-runs/{run_id}` | GlassBox (`GlassBoxService.get_pipeline_run`) | `pipeline_runs` + `pipeline_steps` | **Strict** pipeline run id (`pipeline_runs.id`) | Audit Trace detail page |
+| `GET /api/admin/runs/{run_id}/steps` | GlassBox (`GlassBoxService.get_pipeline_steps`) | `pipeline_steps` | Historically permissive query key; typically run id | Audit Trace and diagnostics |
+| `GET /api/admin/pipeline/jurisdictions/{jurisdiction_id}/status` | Pipeline status read-model | `jurisdictions`, `pipeline_runs` | Jurisdiction id/name key, source-family scoped | Admin substrate/pipeline status panel |
+| `GET /api/admin/pipeline/runs/{run_id}` | **Compatibility alias** over GlassBox | GlassBox-backed (`pipeline_runs`, `pipeline_steps`) | **Strict** pipeline run id (`pipeline_runs.id`) | New pipeline status panel (run detail card) |
+| `GET /api/admin/pipeline/runs/{run_id}/steps` | **Compatibility alias** over GlassBox | GlassBox-backed (`pipeline_steps`) | **Strict** pipeline run id (`pipeline_runs.id`) | New pipeline status panel (step timeline) |
+| `GET /api/admin/pipeline/runs/{run_id}/evidence` | GlassBox-backed evidence projection | GlassBox-backed run payload (`pipeline_runs.result`) | **Strict** pipeline run id (`pipeline_runs.id`) | New pipeline status panel (evidence tab) |
+| `POST /api/admin/pipeline/jurisdictions/{jurisdiction_id}/refresh` | Backend accepted/manual wiring | `jurisdictions` lookup only | Jurisdiction id/name key | Admin status panel refresh action |
+
+## Consolidation Notes
+
+- Duplicated SQL run/steps read-shaping was removed from `/api/admin/pipeline/runs/*`.
+- Compatibility endpoints now normalize their response from GlassBox outputs.
+- Product-specific freshness/status remains a distinct endpoint because it is jurisdiction/source-family scoped and not part of generic run trace inspection.

--- a/docs/architecture/2026-04-13-admin-pipeline-read-model-map.md
+++ b/docs/architecture/2026-04-13-admin-pipeline-read-model-map.md
@@ -11,9 +11,9 @@ Scope: backend API/read-model consolidation for `bd-bupjb.1`
 | `GET /api/admin/pipeline-runs/{run_id}` | GlassBox (`GlassBoxService.get_pipeline_run`) | `pipeline_runs` + `pipeline_steps` | **Strict** pipeline run id (`pipeline_runs.id`) | Audit Trace detail page |
 | `GET /api/admin/runs/{run_id}/steps` | GlassBox (`GlassBoxService.get_pipeline_steps`) | `pipeline_steps` | Historically permissive query key; typically run id | Audit Trace and diagnostics |
 | `GET /api/admin/pipeline/jurisdictions/{jurisdiction_id}/status` | Pipeline status read-model | `jurisdictions`, `pipeline_runs` | Jurisdiction id/name key, source-family scoped | Admin substrate/pipeline status panel |
-| `GET /api/admin/pipeline/runs/{run_id}` | **Compatibility alias** over GlassBox | GlassBox-backed (`pipeline_runs`, `pipeline_steps`) | **Strict** pipeline run id (`pipeline_runs.id`) | New pipeline status panel (run detail card) |
-| `GET /api/admin/pipeline/runs/{run_id}/steps` | **Compatibility alias** over GlassBox | GlassBox-backed (`pipeline_steps`) | **Strict** pipeline run id (`pipeline_runs.id`) | New pipeline status panel (step timeline) |
-| `GET /api/admin/pipeline/runs/{run_id}/evidence` | GlassBox-backed evidence projection | GlassBox-backed run payload (`pipeline_runs.result`) | **Strict** pipeline run id (`pipeline_runs.id`) | New pipeline status panel (evidence tab) |
+| `GET /api/admin/pipeline/runs/{run_id}` | **Compatibility alias** over GlassBox | GlassBox-backed (`pipeline_runs`, `pipeline_steps`) | **Strict** pipeline run id (`pipeline_runs.id`) | No primary frontend owner; prefer Audit Trace detail for run debugging |
+| `GET /api/admin/pipeline/runs/{run_id}/steps` | **Compatibility alias** over GlassBox | GlassBox-backed (`pipeline_steps`) | **Strict** pipeline run id (`pipeline_runs.id`) | No primary frontend owner; prefer Audit Trace detail for step debugging |
+| `GET /api/admin/pipeline/runs/{run_id}/evidence` | GlassBox-backed evidence projection | GlassBox-backed run payload (`pipeline_runs.result`) | **Strict** pipeline run id (`pipeline_runs.id`) | No primary frontend owner; kept only as compatibility/product-evidence projection |
 | `POST /api/admin/pipeline/jurisdictions/{jurisdiction_id}/refresh` | Backend accepted/manual wiring | `jurisdictions` lookup only | Jurisdiction id/name key | Admin status panel refresh action |
 
 ## Consolidation Notes
@@ -21,3 +21,4 @@ Scope: backend API/read-model consolidation for `bd-bupjb.1`
 - Duplicated SQL run/steps read-shaping was removed from `/api/admin/pipeline/runs/*`.
 - Compatibility endpoints now normalize their response from GlassBox outputs.
 - Product-specific freshness/status remains a distinct endpoint because it is jurisdiction/source-family scoped and not part of generic run trace inspection.
+- `PipelineStatusPanel` links to Audit Trace only through a backend-provided `pipeline_run_id`; it no longer renders run detail, steps, or evidence directly.

--- a/frontend/src/components/admin/PipelineStatusPanel.tsx
+++ b/frontend/src/components/admin/PipelineStatusPanel.tsx
@@ -2,14 +2,12 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { AlertTriangle, ExternalLink, Loader2, RefreshCcw } from 'lucide-react';
+import Link from 'next/link';
 import { adminService } from '@/services/adminService';
 import type {
     Jurisdiction,
     PipelineJurisdictionStatus,
     PipelineRefreshResponse,
-    PipelineRunDetail,
-    PipelineRunEvidenceResponse,
-    PipelineRunStepsResponse,
 } from '@/services/adminService';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
@@ -24,10 +22,6 @@ const SOURCE_FAMILIES = [
     'general_web_reference',
 ];
 
-type Props = {
-    runId?: string | null;
-};
-
 function formatTime(value?: string | null): string {
     if (!value) return 'n/a';
     const date = new Date(value);
@@ -35,15 +29,12 @@ function formatTime(value?: string | null): string {
     return date.toLocaleString();
 }
 
-export function PipelineStatusPanel({ runId }: Props) {
+export function PipelineStatusPanel() {
     const [jurisdictions, setJurisdictions] = useState<Jurisdiction[]>([]);
     const [selectedJurisdiction, setSelectedJurisdiction] = useState<string>('');
     const [sourceFamily, setSourceFamily] = useState<string>('meeting_minutes');
 
     const [status, setStatus] = useState<PipelineJurisdictionStatus | null>(null);
-    const [runDetail, setRunDetail] = useState<PipelineRunDetail | null>(null);
-    const [runSteps, setRunSteps] = useState<PipelineRunStepsResponse | null>(null);
-    const [runEvidence, setRunEvidence] = useState<PipelineRunEvidenceResponse | null>(null);
     const [refreshAck, setRefreshAck] = useState<PipelineRefreshResponse | null>(null);
 
     const [loading, setLoading] = useState(false);
@@ -87,33 +78,6 @@ export function PipelineStatusPanel({ runId }: Props) {
         loadStatus(selectedJurisdiction, sourceFamily);
     }, [selectedJurisdiction, sourceFamily]);
 
-    useEffect(() => {
-        const loadRunData = async () => {
-            if (!runId) {
-                setRunDetail(null);
-                setRunSteps(null);
-                setRunEvidence(null);
-                return;
-            }
-            try {
-                const [detail, steps, evidence] = await Promise.all([
-                    adminService.getPipelineRun(runId),
-                    adminService.getPipelineRunSteps(runId),
-                    adminService.getPipelineRunEvidence(runId),
-                ]);
-                setRunDetail(detail);
-                setRunSteps(steps);
-                setRunEvidence(evidence);
-            } catch (err) {
-                console.error('Failed to load pipeline run detail bundle:', err);
-                setRunDetail(null);
-                setRunSteps(null);
-                setRunEvidence(null);
-            }
-        };
-        loadRunData();
-    }, [runId]);
-
     const statusBadge = useMemo(() => {
         const value = status?.pipeline_status || 'unknown';
         if (value === 'fresh') return <Badge className="bg-emerald-600 text-white">fresh</Badge>;
@@ -139,6 +103,8 @@ export function PipelineStatusPanel({ runId }: Props) {
             setRefreshing(false);
         }
     };
+
+    const pipelineRunId = status?.latest_pipeline_run_id || status?.operator_links?.pipeline_run_id || null;
 
     return (
         <Card data-testid="pipeline-status-panel">
@@ -240,6 +206,14 @@ export function PipelineStatusPanel({ runId }: Props) {
                                     Open Windmill run <ExternalLink className="ml-1 h-3 w-3" />
                                 </a>
                             ) : null}
+                            {pipelineRunId ? (
+                                <Link
+                                    href={`/admin/audits/trace/${encodeURIComponent(pipelineRunId)}`}
+                                    className="mt-2 inline-flex items-center text-xs text-blue-700 underline"
+                                >
+                                    Open Audit Trace run <ExternalLink className="ml-1 h-3 w-3" />
+                                </Link>
+                            ) : null}
                         </div>
                         <div className="rounded border border-slate-200 p-3">
                             <p className="text-sm font-medium text-slate-900">Counts</p>
@@ -270,19 +244,6 @@ export function PipelineStatusPanel({ runId }: Props) {
                 {refreshAck ? (
                     <div className="rounded border border-slate-200 bg-slate-50 p-2 text-xs text-slate-600">
                         {refreshAck.message}
-                    </div>
-                ) : null}
-
-                {runDetail ? (
-                    <div className="rounded border border-slate-200 p-3 text-xs text-slate-700">
-                        <p className="font-medium text-slate-900">Selected Run Context</p>
-                        <p className="mt-1">Run: {runDetail.run_id}</p>
-                        <p>Status: {runDetail.status}</p>
-                        <p>Source family: {runDetail.source_family}</p>
-                        <p>
-                            Steps: {runSteps?.steps.length ?? 0} / Evidence refs:{' '}
-                            {runEvidence?.evidence_count ?? 0}
-                        </p>
                     </div>
                 ) : null}
             </CardContent>

--- a/frontend/src/components/admin/SubstrateExplorer.tsx
+++ b/frontend/src/components/admin/SubstrateExplorer.tsx
@@ -227,7 +227,7 @@ export function SubstrateExplorer() {
 
     return (
         <div className="space-y-6" data-testid="substrate-explorer">
-            <PipelineStatusPanel runId={selectedRunId} />
+            <PipelineStatusPanel />
 
             <div className="flex items-center justify-between">
                 <div>

--- a/frontend/src/services/adminService.ts
+++ b/frontend/src/services/adminService.ts
@@ -163,6 +163,7 @@ export interface PipelineLatestAnalysis {
 export interface PipelineOperatorLinks {
     windmill_run_url?: string | null;
     windmill_workspace?: string | null;
+    pipeline_run_id?: string | null;
 }
 
 export interface PipelineJurisdictionStatus {
@@ -177,60 +178,7 @@ export interface PipelineJurisdictionStatus {
     latest_analysis: PipelineLatestAnalysis;
     alerts: string[];
     operator_links: PipelineOperatorLinks;
-}
-
-export interface PipelineRunDetail {
-    contract_version: string;
-    run_id: string;
-    status: string;
-    jurisdiction: string;
-    source_family: string;
-    bill_id: string | null;
-    started_at: string | null;
-    completed_at: string | null;
-    error: string | null;
-    trigger_source: string | null;
-    counts: PipelineCounts;
-    latest_analysis: PipelineLatestAnalysis;
-    alerts: string[];
-    operator_links: PipelineOperatorLinks;
-}
-
-export interface PipelineRunStep {
-    contract_version: string;
-    step_id: string;
-    run_id: string;
-    command: string;
-    status: string;
-    decision_reason: string | null;
-    retry_class: string;
-    alerts: string[];
-    counts: Record<string, number>;
-    refs: Record<string, unknown>;
-    duration_ms: number;
-    error: string | null;
-    timestamp: string | null;
-}
-
-export interface PipelineRunStepsResponse {
-    contract_version: string;
-    run_id: string;
-    steps: PipelineRunStep[];
-}
-
-export interface PipelineEvidenceItem {
-    id: string;
-    type: string;
-    label: string;
-    confidence: number | null;
-    source_ref: string | null;
-}
-
-export interface PipelineRunEvidenceResponse {
-    contract_version: string;
-    run_id: string;
-    evidence_count: number;
-    items: PipelineEvidenceItem[];
+    latest_pipeline_run_id?: string | null;
 }
 
 export interface PipelineRefreshResponse {
@@ -321,24 +269,6 @@ export const adminService = {
             NO_STORE_FETCH,
         );
         if (!res.ok) throw new Error('Failed to fetch pipeline jurisdiction status');
-        return res.json();
-    },
-
-    async getPipelineRun(runId: string): Promise<PipelineRunDetail> {
-        const res = await fetch(`${API_URL}/api/admin/pipeline/runs/${encodeURIComponent(runId)}`, NO_STORE_FETCH);
-        if (!res.ok) throw new Error('Failed to fetch pipeline run');
-        return res.json();
-    },
-
-    async getPipelineRunSteps(runId: string): Promise<PipelineRunStepsResponse> {
-        const res = await fetch(`${API_URL}/api/admin/pipeline/runs/${encodeURIComponent(runId)}/steps`, NO_STORE_FETCH);
-        if (!res.ok) throw new Error('Failed to fetch pipeline run steps');
-        return res.json();
-    },
-
-    async getPipelineRunEvidence(runId: string): Promise<PipelineRunEvidenceResponse> {
-        const res = await fetch(`${API_URL}/api/admin/pipeline/runs/${encodeURIComponent(runId)}/evidence`, NO_STORE_FETCH);
-        if (!res.ok) throw new Error('Failed to fetch pipeline run evidence');
         return res.json();
     },
 


### PR DESCRIPTION
Feature-Key: bd-bupjb
Agent: codex

Beads: bd-bupjb.1, bd-bupjb.2, and bd-bupjb.3 completed. This PR consolidates admin pipeline observability surfaces after PR #426.

## Summary
- Keeps GlassBox/Audit Trace as the owner for pipeline run list, run detail, steps, analysis output, and citations.
- Keeps the product pipeline status endpoint as the owner for jurisdiction/source-family freshness, policy windows, counts, alerts, latest analysis readiness, and refresh acknowledgement.
- Converts `/api/admin/pipeline/runs/*` run/step endpoints into GlassBox-backed compatibility aliases instead of independent SQL/read-shaping paths.
- Refactors `PipelineStatusPanel` into a status-only widget and stops `SubstrateExplorer` from passing substrate/manual run IDs as pipeline run IDs.
- Documents backend and frontend ownership maps for future Windmill/frontend work.

## Boundary Locked
- Audit Trace: pipeline run/step/LLM trace debugging.
- Substrate Explorer: substrate/manual run rows, failure buckets, and raw row inspection.
- Pipeline Status: jurisdiction/source-family health, freshness, coverage, evidence readiness, operator links, and refresh action.
- Identifier semantics: `pipeline_run_id`, `windmill_run_id`, substrate/manual run keys, and `raw_scrape_id` are distinct.

## Validation
Local:
- `cd backend && poetry run pytest -q tests/routers/test_admin_pipeline_read_model.py tests/routers/test_admin_substrate_contract.py tests/services/test_pipeline_truth.py`: 32 passed.
- Targeted Ruff on touched backend files: pass.
- `pnpm --filter frontend lint`: pass with pre-existing hook-dependency warnings only.
- `pnpm --filter frontend build`: pass with pre-existing static-generation/backend-unreachable logs.
- `make ci-lite`: pass; backend tests 447 passed.
- `git diff --check`: pass.

Independent QA:
- gpt-5.3-codex final validation (`bd-bupjb.3`) verdict: approve, no P1/P2 issues.

GitHub CI at head `b49dde2bd5644e6c2e2f72b8145e9447203863cb`:
- Backend Lint & Test: pass.
- Backend Ruff Preflight: pass.
- Beads Validation: pass.
- Frontend Lint & Build: pass.
- Frontend Preservation Gate: pass.
- validate-skills: pass.

## Residual Risk
Compatibility `/api/admin/pipeline/runs/*` routes remain for transition. They are now GlassBox-backed, but can be considered for deprecation once all callers normalize on Audit Trace for run debugging.
