### PR TITLE
bd-9qjof.6: Document Windmill CLI smoke path

### DIFF
--- a/backend/tests/ops/test_pipeline_daily_refresh_domain_boundary_orchestration.py
+++ b/backend/tests/ops/test_pipeline_daily_refresh_domain_boundary_orchestration.py
@@ -108,6 +108,34 @@ def test_run_summary_aggregates_fanout_scope_results():
     assert "freshness_gate:stale_blocked" in summary["alerts"]
 
 
+def test_windmill_null_optional_inputs_coalesce_to_contract_defaults():
+    result = module.main(
+        step="run_scope_pipeline",
+        contract_version=None,
+        architecture_path=None,
+        windmill_workspace=None,
+        windmill_flow_path=None,
+        windmill_run_id=None,
+        windmill_job_id=None,
+        idempotency_key="run:null-coalesce",
+        mode=None,
+        scope_item={"jurisdiction": "San Jose CA", "source_family": "meeting_minutes"},
+        scope_index=0,
+        stale_status=None,
+        search_query="query",
+        analysis_question="question",
+    )
+
+    envelope = result["steps"]["search_materialize"]["envelope"]
+    assert envelope["contract_version"] == "2026-04-13.windmill-domain.v1"
+    assert envelope["architecture_path"] == "affordabot_domain_boundary"
+    assert envelope["windmill_workspace"] == "affordabot"
+    assert envelope["windmill_flow_path"] == "f/affordabot/pipeline_daily_refresh_domain_boundary__flow"
+    assert envelope["windmill_run_id"] == "run:null-coalesce"
+    assert envelope["windmill_job_id"] == "run_scope_pipeline:0:search_materialize"
+    assert envelope["mode"] == "scheduled"
+
+
 def test_windmill_assets_reference_coarse_command_stubs_not_storage_apis():
     text = SCRIPT_PATH.read_text(encoding="utf-8") + "\n" + FLOW_PATH.read_text(encoding="utf-8")
     forbidden_terms = [

--- a/docs/poc/windmill-domain-boundary-integration/live-windmill-preflight.md
+++ b/docs/poc/windmill-domain-boundary-integration/live-windmill-preflight.md
@@ -11,6 +11,95 @@ Target PR head at start: `44d0bbe9bfc546cd937b20273991895117e2d7f9`
 
 Live remote preflight cannot proceed in this session because no Windmill workspace/profile is configured locally, and no non-interactive remote context is available without introducing secret/auth mutation risk.
 
+### 2026-04-13 Expanded CLI Smoke Update
+
+`pass_for_windmill_cli_and_skeleton_flow`, not blocked by CLI auth.
+
+The earlier auth blocker was resolved with agent-safe cached 1Password access
+and a throwaway Windmill CLI profile. No raw `op` commands, GUI-backed auth, or
+persistent local Windmill profile were used.
+
+Validated canonical variables:
+
+- `WINDMILL_API_TOKEN`: cached at
+  `op://dev/Agent-Secrets-Production/WINDMILL_API_TOKEN`.
+- `WINDMILL_DEV_LOGIN_URL`: cached at
+  `op://dev/Agent-Secrets-Production/WINDMILL_DEV_LOGIN_URL`.
+- `WINDMILL_BASE_URL`: derived by stripping `/user/login` from
+  `WINDMILL_DEV_LOGIN_URL`.
+- `WINDMILL_WORKSPACE`: `affordabot`.
+- `TMP_WMILL_CONFIG`: per-run temporary config directory.
+
+Expanded read-only surface verified:
+
+- temporary workspace profile creation via `workspace add`
+- `workspace list`
+- `job list --json`
+- `flow list`
+- `flow get f/affordabot/manual_substrate_expansion --json`
+- `script list`
+- `script get f/affordabot/trigger_cron_job --json`
+
+Observed live workspace state:
+
+- Existing scheduled flows are visible:
+  - `f/affordabot/discovery_run`
+  - `f/affordabot/daily_scrape`
+  - `f/affordabot/rag_spiders`
+  - `f/affordabot/universal_harvester`
+- Existing manual flow is visible:
+  - `f/affordabot/manual_substrate_expansion`
+- Existing script is visible:
+  - `f/affordabot/trigger_cron_job`
+- Domain-boundary POC flow was initially not deployed:
+  - `f/affordabot/pipeline_daily_refresh_domain_boundary__flow`
+  - CLI result: `Flow not found`
+- Domain-boundary POC script and flow were then deployed as unscheduled dev
+  assets.
+- Manual San Jose meeting-minutes skeleton flow run completed successfully:
+  - job id: `019d87a2-41c1-9576-7d85-55834a78dbfc`
+  - created at: `2026-04-13T16:17:31.052996Z`
+  - script path: `f/affordabot/pipeline_daily_refresh_domain_boundary__flow`
+  - success: `true`
+  - idempotency key: `bd-9qjof.6-cli-smoke-2026-04-13-r5`
+  - scope: `San Jose CA` / `meeting_minutes`
+  - final status: `succeeded`
+  - scope totals: `scope_total=1`, `scope_succeeded=1`,
+    `scope_failed=0`, `scope_blocked=0`
+  - verified step sequence:
+    - `search_materialize`
+    - `freshness_gate`
+    - `read_fetch`
+    - `index`
+    - `analyze`
+    - `summarize_run`
+  - every step envelope included:
+    - `contract_version=2026-04-13.windmill-domain.v1`
+    - `orchestrator=windmill`
+    - `windmill_workspace=affordabot`
+    - `windmill_flow_path=f/affordabot/pipeline_daily_refresh_domain_boundary__flow`
+    - `jurisdiction_id=San Jose CA`
+    - `source_family=meeting_minutes`
+
+CLI friction discovered:
+
+- `windmill-cli` `1.682.0` rejects the runbook's old `-r "$WINDMILL_BASE_URL"`
+  form.
+- Direct `--base-url` commands require `--token` and `--workspace`, but the
+  temporary-profile pattern is more reliable and easier to audit.
+- `flow push` help says `file_path`, but passing the nested `flow.yaml` path made
+  CLI `1.682.0` look for `flow.yaml/flow.yaml`; pass the local flow directory.
+- The cached `WINDMILL_DEV_LOGIN_URL` is a browser login URL; using it directly
+  returns HTML from some commands. Normalize it to instance root before API use.
+- `ops/windmill/wmill.yaml` warns that `gitBranches` is deprecated in favor of
+  `workspaces`.
+- For-loop step transforms cannot use `iter.value` / `iter.index` directly in
+  this exported YAML shape; use `flow_input.iter.value` and
+  `flow_input.iter.index`.
+- Windmill can pass omitted optional script inputs as `null`; the script
+  entrypoint now coalesces nulls back to contract defaults, and the flow passes
+  explicit contract metadata for every script step.
+
 ## Scope Checked
 
 Reviewed domain-boundary design and flow assets:
@@ -50,7 +139,6 @@ Proven:
 
 Not proven:
 
-- Authenticated access to the development Windmill workspace.
 - Presence of required remote workspace paths/resources for domain-boundary dry-run.
 - Safe isolated run namespace in live workspace.
 - Backend endpoint + internal auth token wiring for live command execution.
@@ -58,15 +146,20 @@ Not proven:
 
 ## Risk Assessment
 
-Live execution is **not safe to proceed autonomously** from this session because:
+Live skeleton execution is safe to proceed in the existing affordabot dev
+workspace if it remains manual and unscheduled because:
 
-1. Remote workspace context is absent (no active profile/workspace).
-2. Attempting to establish auth/workspace here would require secret/bootstrap steps that are outside this no-mutation preflight lane.
-3. Shared workspace isolation is not yet proven (dev-only folder/flow path plus no-schedule policy).
+1. The `affordabot` workspace is reachable with agent-safe cached auth.
+2. Existing flows/scripts are inspectable.
+3. The target domain-boundary POC flow is now deployed under a new unscheduled
+   path.
+4. The skeleton flow does not perform product writes.
 
 ## Required Next Step
 
-Run a controlled auth/bootstrap preflight in a dedicated dev context (cache/service-account path only, no interactive 1Password prompts), then repeat read-only remote checks before any flow run.
+Replace skeleton stubs with backend domain-command calls behind the same
+Windmill flow shape, then repeat the manual San Jose run and verify persisted
+Postgres/pgvector/MinIO evidence.
 
 If remote preflight passes, run only a **manual non-scheduled dry-run** of:
 

--- a/ops/windmill/README.md
+++ b/ops/windmill/README.md
@@ -62,6 +62,21 @@ Auth source for CLI and automation:
 - `op://dev/Agent-Secrets-Production/WINDMILL_API_TOKEN`
 - `op://dev/Agent-Secrets-Production/WINDMILL_DEV_LOGIN_URL`
 
+Canonical shell variables for agent runs:
+
+- `WINDMILL_API_TOKEN`: resolved from the cached 1Password helper.
+- `WINDMILL_DEV_LOGIN_URL`: resolved from the cached 1Password helper. This is
+  the browser login URL and currently ends with `/user/login`.
+- `WINDMILL_BASE_URL`: derived by stripping `/user/login` from
+  `WINDMILL_DEV_LOGIN_URL`. Windmill CLI API calls need this instance root.
+- `WINDMILL_WORKSPACE`: `affordabot`.
+- `TMP_WMILL_CONFIG`: a temporary `wmill` config directory created per run.
+
+Do not depend on ambient `~/.config/windmill` state in agent workflows. Create a
+throwaway profile with `--config-dir` for each CLI smoke test, dry-run, or sync
+operation. Do not use raw `op read`, `op item get`, `op item list`, or GUI-backed
+1Password auth from agents.
+
 Slack webhook note:
 - `trigger_cron_job` now normalizes accidentally quoted webhook values (for example `"https://hooks.slack..."`) before posting.
 - Keep `SLACK_WEBHOOK_URL` as a plain URL string in Windmill to avoid ambiguity.
@@ -160,20 +175,109 @@ Safe auth pattern with cached 1Password helper (token never printed):
 
 ```bash
 source ~/agent-skills/scripts/lib/dx-auth.sh
-export WINDMILL_API_TOKEN="$(dx_auth_read_secret_cached "op://dev/Agent-Secrets-Production/WINDMILL_API_TOKEN")"
-export WINDMILL_BASE_URL="$(dx_auth_read_secret_cached "op://dev/Agent-Secrets-Production/WINDMILL_DEV_LOGIN_URL")"
+export WINDMILL_API_TOKEN="$(DX_AUTH_CACHE_ONLY=1 dx_auth_read_secret_cached "op://dev/Agent-Secrets-Production/WINDMILL_API_TOKEN")"
+WINDMILL_DEV_LOGIN_URL="$(DX_AUTH_CACHE_ONLY=1 dx_auth_read_secret_cached "op://dev/Agent-Secrets-Production/WINDMILL_DEV_LOGIN_URL")"
+WINDMILL_BASE_URL="${WINDMILL_DEV_LOGIN_URL%/user/login}"
+WINDMILL_WORKSPACE="affordabot"
+TMP_WMILL_CONFIG="$(mktemp -d)"
+trap 'rm -rf "$TMP_WMILL_CONFIG"' EXIT
+
+npx --yes windmill-cli workspace add "$WINDMILL_WORKSPACE" "$WINDMILL_WORKSPACE" "$WINDMILL_BASE_URL" \
+  --token "$WINDMILL_API_TOKEN" \
+  --config-dir "$TMP_WMILL_CONFIG"
 ```
 
-Safe live checks:
+Safe live checks for CLI version `1.682.0`:
 
 ```bash
-npx windmill-cli version -r "$WINDMILL_BASE_URL"
-npx windmill-cli workspace list-remote -r "$WINDMILL_BASE_URL"
+npx --yes windmill-cli workspace list \
+  --config-dir "$TMP_WMILL_CONFIG"
+
+npx --yes windmill-cli job list \
+  --workspace "$WINDMILL_WORKSPACE" \
+  --config-dir "$TMP_WMILL_CONFIG" \
+  --limit 5 \
+  --json
+
+npx --yes windmill-cli flow list \
+  --workspace "$WINDMILL_WORKSPACE" \
+  --config-dir "$TMP_WMILL_CONFIG"
+
+npx --yes windmill-cli flow get f/affordabot/manual_substrate_expansion \
+  --workspace "$WINDMILL_WORKSPACE" \
+  --config-dir "$TMP_WMILL_CONFIG" \
+  --json
+
+npx --yes windmill-cli script list \
+  --workspace "$WINDMILL_WORKSPACE" \
+  --config-dir "$TMP_WMILL_CONFIG"
+
+npx --yes windmill-cli script get f/affordabot/trigger_cron_job \
+  --workspace "$WINDMILL_WORKSPACE" \
+  --config-dir "$TMP_WMILL_CONFIG" \
+  --json
+```
+
+CLI notes:
+- `WINDMILL_DEV_LOGIN_URL` is intentionally a login URL in the current secret
+  cache; normalize it before API use.
+- Do not use `-r "$WINDMILL_BASE_URL"` with `windmill-cli` `1.682.0`; this
+  build rejects `-r`. Use the temporary-profile pattern above.
+- `wmill.yaml` currently emits a deprecation warning because it uses
+  `gitBranches`; this does not block read-only checks, but should be cleaned up
+  before relying on broad sync automation.
+
+Domain-boundary POC live gate:
+
+```bash
+npx --yes windmill-cli flow get f/affordabot/pipeline_daily_refresh_domain_boundary__flow \
+  --workspace "$WINDMILL_WORKSPACE" \
+  --config-dir "$TMP_WMILL_CONFIG" \
+  --json
+```
+
+Deploy only the unscheduled domain-boundary POC assets:
+
+```bash
+npx --yes windmill-cli script push f/affordabot/pipeline_daily_refresh_domain_boundary.py \
+  --workspace "$WINDMILL_WORKSPACE" \
+  --config-dir "$TMP_WMILL_CONFIG" \
+  --message "bd-9qjof.6 deploy domain-boundary POC script"
+
+# For flow push, pass the local flow directory, not the nested flow.yaml file.
+npx --yes windmill-cli flow push \
+  f/affordabot/pipeline_daily_refresh_domain_boundary__flow \
+  f/affordabot/pipeline_daily_refresh_domain_boundary__flow \
+  --workspace "$WINDMILL_WORKSPACE" \
+  --config-dir "$TMP_WMILL_CONFIG" \
+  --message "bd-9qjof.6 deploy domain-boundary POC flow"
+```
+
+Manual San Jose skeleton run:
+
+```bash
+npx --yes windmill-cli flow run f/affordabot/pipeline_daily_refresh_domain_boundary__flow \
+  --workspace "$WINDMILL_WORKSPACE" \
+  --config-dir "$TMP_WMILL_CONFIG" \
+  -d '{
+    "idempotency_key": "bd-9qjof.6-cli-smoke-YYYY-MM-DD",
+    "jurisdictions": ["San Jose CA"],
+    "source_families": ["meeting_minutes"],
+    "search_query": "San Jose CA city council meeting minutes housing",
+    "analysis_question": "Summarize housing-related signals from recent San Jose meeting minutes.",
+    "mode": "manual",
+    "scope_parallelism": 1,
+    "stale_status": "fresh"
+  }'
 ```
 
 Sync safety:
 - Always confirm target workspace is `affordabot` before `sync push`.
 - Do not run broad sync operations if schedule mutation intent is not explicit.
+- A missing domain-boundary POC flow means live dry-run is blocked on deployment,
+  not on CLI auth.
+- The domain-boundary POC flow is unscheduled and should remain unscheduled until
+  the backend domain commands replace the current skeleton stubs.
 
 ## Manual Operator Run (CLI-Safe)
 

--- a/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.py
+++ b/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.py
@@ -697,6 +697,15 @@ def main(
     command_client: str = "stub",
     domain_state: Any | None = None,
 ) -> Dict[str, Any]:
+    contract_version = contract_version or CONTRACT_VERSION
+    architecture_path = architecture_path or "affordabot_domain_boundary"
+    windmill_workspace = windmill_workspace or "affordabot"
+    windmill_flow_path = windmill_flow_path or "f/affordabot/pipeline_daily_refresh_domain_boundary__flow"
+    windmill_run_id = windmill_run_id or idempotency_key or "windmill-run-id"
+    windmill_job_id = windmill_job_id or step
+    idempotency_key = idempotency_key or "run:2026-04-13"
+    mode = mode or "scheduled"
+    stale_status = stale_status or "fresh"
     jurisdictions = jurisdictions or ["San Jose CA"]
     source_families = source_families or ["meeting_minutes"]
 

--- a/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary__flow/flow.yaml
+++ b/ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary__flow/flow.yaml
@@ -13,9 +13,21 @@ value:
         step:
           type: static
           value: failure_handler
-        windmill_run_id:
+        contract_version:
           type: static
-          value: $flow_job_id
+          value: 2026-04-13.windmill-domain.v1
+        architecture_path:
+          type: static
+          value: affordabot_domain_boundary
+        windmill_workspace:
+          type: static
+          value: affordabot
+        windmill_flow_path:
+          type: static
+          value: f/affordabot/pipeline_daily_refresh_domain_boundary__flow
+        windmill_run_id:
+          type: javascript
+          expr: "typeof flow_job_id !== 'undefined' ? flow_job_id : flow_input.idempotency_key"
         windmill_job_id:
           type: static
           value: failure_handler
@@ -34,9 +46,21 @@ value:
         step:
           type: static
           value: build_scope_matrix
-        windmill_run_id:
+        contract_version:
           type: static
-          value: $flow_job_id
+          value: 2026-04-13.windmill-domain.v1
+        architecture_path:
+          type: static
+          value: affordabot_domain_boundary
+        windmill_workspace:
+          type: static
+          value: affordabot
+        windmill_flow_path:
+          type: static
+          value: f/affordabot/pipeline_daily_refresh_domain_boundary__flow
+        windmill_run_id:
+          type: javascript
+          expr: "typeof flow_job_id !== 'undefined' ? flow_job_id : flow_input.idempotency_key"
         windmill_job_id:
           type: static
           value: build_scope_matrix
@@ -61,6 +85,7 @@ value:
       skip_failures: false
       parallel: true
       parallelism:
+        type: javascript
         expr: flow_input.scope_parallelism
       modules:
       - id: run_scope_pipeline
@@ -77,9 +102,21 @@ value:
             step:
               type: static
               value: run_scope_pipeline
-            windmill_run_id:
+            contract_version:
               type: static
-              value: $flow_job_id
+              value: 2026-04-13.windmill-domain.v1
+            architecture_path:
+              type: static
+              value: affordabot_domain_boundary
+            windmill_workspace:
+              type: static
+              value: affordabot
+            windmill_flow_path:
+              type: static
+              value: f/affordabot/pipeline_daily_refresh_domain_boundary__flow
+            windmill_run_id:
+              type: javascript
+              expr: "typeof flow_job_id !== 'undefined' ? flow_job_id : flow_input.idempotency_key"
             windmill_job_id:
               type: static
               value: run_scope_pipeline
@@ -91,10 +128,10 @@ value:
               expr: flow_input.mode
             scope_item:
               type: javascript
-              expr: iter.value
+              expr: flow_input.iter.value
             scope_index:
               type: javascript
-              expr: iter.index
+              expr: flow_input.iter.index
             stale_status:
               type: javascript
               expr: flow_input.stale_status
@@ -122,9 +159,21 @@ value:
               step:
                 type: static
                 value: aggregate_run_summary
-              windmill_run_id:
+              contract_version:
                 type: static
-                value: $flow_job_id
+                value: 2026-04-13.windmill-domain.v1
+              architecture_path:
+                type: static
+                value: affordabot_domain_boundary
+              windmill_workspace:
+                type: static
+                value: affordabot
+              windmill_flow_path:
+                type: static
+                value: f/affordabot/pipeline_daily_refresh_domain_boundary__flow
+              windmill_run_id:
+                type: javascript
+                expr: "typeof flow_job_id !== 'undefined' ? flow_job_id : flow_input.idempotency_key"
               windmill_job_id:
                 type: static
                 value: blocked_or_failed_summary
@@ -143,9 +192,21 @@ value:
             step:
               type: static
               value: aggregate_run_summary
-            windmill_run_id:
+            contract_version:
               type: static
-              value: $flow_job_id
+              value: 2026-04-13.windmill-domain.v1
+            architecture_path:
+              type: static
+              value: affordabot_domain_boundary
+            windmill_workspace:
+              type: static
+              value: affordabot
+            windmill_flow_path:
+              type: static
+              value: f/affordabot/pipeline_daily_refresh_domain_boundary__flow
+            windmill_run_id:
+              type: javascript
+              expr: "typeof flow_job_id !== 'undefined' ? flow_job_id : flow_input.idempotency_key"
             windmill_job_id:
               type: static
               value: successful_summary


### PR DESCRIPTION
Agent: codex

## Summary

- Documented the canonical agent-safe Windmill CLI path using cached 1Password variables, normalized base URL, and throwaway `--config-dir` profiles.
- Expanded the live Windmill preflight evidence from auth-blocked to successful read-only workspace checks plus a live manual San Jose domain-boundary skeleton run.
- Fixed the domain-boundary flow export so Windmill CLI lint passes, for-loop inputs resolve in live Windmill, and every script step receives explicit contract metadata.
- Hardened the Windmill script entrypoint against Windmill passing omitted optional inputs as `null`.

## Live Evidence

- Deployed unscheduled POC assets to the existing `affordabot` Windmill dev workspace:
  - `f/affordabot/pipeline_daily_refresh_domain_boundary`
  - `f/affordabot/pipeline_daily_refresh_domain_boundary__flow`
- Manual San Jose meeting-minutes skeleton run completed successfully.
- Windmill job id: `019d87a2-41c1-9576-7d85-55834a78dbfc`
- Final status: `succeeded`
- Scope: `San Jose CA` / `meeting_minutes`
- Contract version propagated: `2026-04-13.windmill-domain.v1`

## Validation

- `npx --yes windmill-cli lint .`
- `poetry run pytest tests/ops/test_windmill_contract.py tests/ops/test_pipeline_daily_refresh_domain_boundary_orchestration.py -q`
- `git diff --check`

## Notes

- `windmill-cli` `1.682.0` rejects the older `-r` shortcut documented in the previous runbook.
- `flow push` requires the local flow directory path for this exported layout, not the nested `flow.yaml` path.
- `ops/windmill/wmill.yaml` still warns that `gitBranches` is deprecated in favor of `workspaces`; this is documented but not migrated here.