### PR TITLE
bd-9qjof.8: harden private SearXNG source quality gates

### DIFF
--- a/backend/scripts/verification/verify_search_source_quality_bakeoff.py
+++ b/backend/scripts/verification/verify_search_source_quality_bakeoff.py
@@ -96,6 +96,36 @@ NAV_ONLY_NEGATIVE_TERMS = (
     "site map",
 )
 
+FINAL_ARTIFACT_URL_PATTERNS = (
+    "meetingdetail.aspx?id=",
+    "meetingdetail.aspx?legid=",
+    "gateway.aspx?id=",
+    "agendaviewer.php?clip_id=",
+    "/agendacenter/viewfile/minutes/",
+    "/agendacenter/viewfile/agenda/",
+)
+PORTAL_SEED_URL_PATTERNS = (
+    "/agendas-minutes",
+    "/council-agendas-minutes",
+    "/council-agendas",
+    "/resource-library/council-memos",
+    "calendar.aspx",
+    "departmentdetail.aspx",
+)
+LIKELY_NAVIGATION_URL_PATTERNS = (
+    "/your-government/",
+    "/departments-offices/",
+    "/resource-library/",
+    "/city-council/",
+)
+CRITICAL_ENGINE_TERMS = ("suspended", "too many requests", "access denied", "captcha")
+CLASS_PRIORITY = {
+    "final_artifact": 0,
+    "portal_seed": 1,
+    "likely_navigation": 2,
+    "third_party_or_junk": 3,
+}
+
 
 @dataclass(frozen=True)
 class QuerySpec:
@@ -187,6 +217,15 @@ def _host_matches_jurisdiction(url: str, query: QuerySpec) -> bool:
 def _non_primary_source_domain(url: str) -> bool:
     host = urllib.parse.urlsplit(url).netloc.lower()
     return any(host == domain or host.endswith(f".{domain}") for domain in NON_PRIMARY_SOURCE_DOMAINS)
+
+
+def _host_has_public_records_platform(url: str) -> bool:
+    host = urllib.parse.urlsplit(url).netloc.lower()
+    return "legistar.com" in host or "granicus.com" in host
+
+
+def _is_trusted_public_records_host(url: str) -> bool:
+    return _official_domain(url) or _host_has_public_records_platform(url)
 
 
 def _preferred_url_pattern(url: str, query: QuerySpec) -> bool:
@@ -338,6 +377,217 @@ def _normalize_records(
     return normalized
 
 
+def _parse_unresponsive_engines(payload: dict[str, Any]) -> list[dict[str, str]]:
+    value = payload.get("unresponsive_engines")
+    items: list[dict[str, str]] = []
+    if isinstance(value, list):
+        for entry in value:
+            if isinstance(entry, str) and entry.strip():
+                items.append({"engine": entry.strip(), "reason": "unresponsive"})
+    elif isinstance(value, dict):
+        for engine, reason in value.items():
+            engine_name = str(engine).strip()
+            if not engine_name:
+                continue
+            reason_text = str(reason).strip() or "unresponsive"
+            items.append({"engine": engine_name, "reason": reason_text})
+    return items
+
+
+def _parsed_query_params(url: str) -> dict[str, list[str]]:
+    return {key.lower(): values for key, values in urllib.parse.parse_qs(urllib.parse.urlsplit(url).query).items()}
+
+
+def _has_query_key(params: dict[str, list[str]], key: str) -> bool:
+    return key in params and any(str(value).strip() for value in params[key])
+
+
+def _has_query_value(params: dict[str, list[str]], key: str, expected_values: tuple[str, ...]) -> bool:
+    if key not in params:
+        return False
+    allowed = {value.lower() for value in expected_values}
+    return any(str(value).strip().lower() in allowed for value in params[key])
+
+
+def _has_query_suffix(params: dict[str, list[str]], key: str, suffix: str) -> bool:
+    if key not in params:
+        return False
+    target = suffix.lower()
+    return any(str(value).strip().lower().endswith(target) for value in params[key])
+
+
+def _is_concrete_artifact_url(url: str) -> bool:
+    lowered_url = url.lower().strip()
+    parsed = urllib.parse.urlsplit(url)
+    path = parsed.path.lower()
+    host = parsed.netloc.lower()
+    params = _parsed_query_params(url)
+    is_official_host = _official_domain(url)
+    is_legistar_host = "legistar.com" in host
+    is_granicus_host = "granicus.com" in host
+
+    if lowered_url.endswith(".pdf") or "/pdf/" in lowered_url:
+        return _is_trusted_public_records_host(url)
+    if is_legistar_host and "meetingdetail.aspx" in path and (_has_query_key(params, "id") or _has_query_key(params, "legid")):
+        return True
+    if is_legistar_host and "view.ashx" in path and _has_query_key(params, "id") and _has_query_value(params, "m", ("a", "m", "f")):
+        return True
+    if is_legistar_host and "gateway.aspx" in path and _has_query_key(params, "id"):
+        if _has_query_suffix(params, "id", ".pdf") or _has_query_value(params, "m", ("a", "m", "f")):
+            return True
+    if is_granicus_host and "agendaviewer.php" in path and _has_query_key(params, "clip_id"):
+        return True
+    if is_official_host and "/agendacenter/viewfile/minutes/" in path:
+        return True
+    if is_official_host and "/agendacenter/viewfile/agenda/" in path:
+        return True
+    return False
+
+
+def _candidate_class(url: str, title: str = "", snippet: str = "") -> str:
+    lowered_url = url.lower()
+    lowered_text = f"{title} {snippet}".lower()
+    if _non_primary_source_domain(url):
+        return "third_party_or_junk"
+    if _is_concrete_artifact_url(url):
+        return "final_artifact"
+    if any(pattern in lowered_url for pattern in FINAL_ARTIFACT_URL_PATTERNS):
+        return "final_artifact"
+    if any(pattern in lowered_url for pattern in PORTAL_SEED_URL_PATTERNS):
+        return "portal_seed"
+    if any(pattern in lowered_url for pattern in LIKELY_NAVIGATION_URL_PATTERNS):
+        return "likely_navigation"
+    if _contains_any(lowered_text, ("home", "menu", "services", "departments", "residents", "businesses")):
+        return "likely_navigation"
+    if _official_domain(url) or _contains_any(lowered_text, ("legistar", "granicus", "agenda", "minutes")):
+        return "likely_navigation"
+    return "third_party_or_junk"
+
+
+def _recommended_shortlist_size(deduped_count: int) -> int:
+    if deduped_count <= 0:
+        return 0
+    if deduped_count <= 12:
+        return deduped_count
+    if deduped_count <= 36:
+        return 12
+    return 24
+
+
+def _build_searxng_fanout_health_summary(
+    *,
+    probes: list[dict[str, Any]],
+    shortlist_size: int | None = None,
+) -> dict[str, Any]:
+    searx_probes = [probe for probe in probes if probe.get("provider") == "searxng"]
+    per_query: list[dict[str, Any]] = []
+    all_candidates: list[dict[str, Any]] = []
+    critical_engines: set[str] = set()
+    queries_with_results = 0
+    for probe in searx_probes:
+        result_count = int(probe.get("result_count") or 0)
+        if result_count > 0:
+            queries_with_results += 1
+        unresponsive = list(probe.get("unresponsive_engines") or [])
+        for engine_info in unresponsive:
+            reason = str(engine_info.get("reason") or "").lower()
+            if any(term in reason for term in CRITICAL_ENGINE_TERMS):
+                engine_name = str(engine_info.get("engine") or "").strip().lower()
+                if engine_name:
+                    critical_engines.add(engine_name)
+        top_rows = []
+        for item in list(probe.get("top_results") or [])[:5]:
+            top_rows.append({"url": item.get("url"), "title": item.get("title"), "score": item.get("score")})
+        per_query.append(
+            {
+                "query": probe.get("query"),
+                "status": probe.get("status"),
+                "result_count": result_count,
+                "top_results": top_rows,
+                "unresponsive_engines": unresponsive,
+            }
+        )
+        for candidate in list(probe.get("raw_candidates") or []):
+            if not isinstance(candidate, dict):
+                continue
+            all_candidates.append(
+                {
+                    "query": probe.get("query"),
+                    "url": str(candidate.get("url") or ""),
+                    "title": str(candidate.get("title") or ""),
+                    "snippet": str(candidate.get("snippet") or ""),
+                    "score": float(candidate.get("score") or 0.0),
+                }
+            )
+
+    deduped_by_url: dict[str, dict[str, Any]] = {}
+    for candidate in all_candidates:
+        canonical = _canonicalize_url(candidate["url"]) if candidate["url"] else ""
+        if not canonical:
+            continue
+        existing = deduped_by_url.get(canonical)
+        if existing is None or candidate["score"] > existing["score"]:
+            deduped_by_url[canonical] = {
+                "canonical_url": canonical,
+                "url": candidate["url"],
+                "title": candidate["title"],
+                "snippet": candidate["snippet"],
+                "score": round(candidate["score"], 2),
+                "class": _candidate_class(candidate["url"], candidate["title"], candidate["snippet"]),
+                "query": candidate["query"],
+            }
+
+    deduped_candidates = sorted(
+        deduped_by_url.values(),
+        key=lambda item: (
+            CLASS_PRIORITY.get(item["class"], 9),
+            -float(item["score"]),
+            str(item["canonical_url"]),
+        ),
+    )
+    class_counts = {
+        "final_artifact": 0,
+        "portal_seed": 0,
+        "likely_navigation": 0,
+        "third_party_or_junk": 0,
+    }
+    for candidate in deduped_candidates:
+        class_counts[candidate["class"]] += 1
+
+    total_queries = len(searx_probes)
+    coverage = queries_with_results / total_queries if total_queries else 0.0
+    shortlist_limit = shortlist_size if shortlist_size is not None else _recommended_shortlist_size(len(deduped_candidates))
+    shortlist = [
+        candidate
+        for candidate in deduped_candidates
+        if candidate["class"] != "third_party_or_junk"
+    ][: max(0, shortlist_limit)]
+    if total_queries == 0:
+        verdict = "unhealthy"
+    elif coverage >= 0.80 and len(critical_engines) == 0:
+        verdict = "healthy"
+    elif coverage >= 0.50 and len(critical_engines) <= 2:
+        verdict = "degraded"
+    else:
+        verdict = "unhealthy"
+
+    return {
+        "provider": "searxng",
+        "query_count": total_queries,
+        "query_fanout_coverage_percent": round(coverage * 100, 1),
+        "queries_with_results": queries_with_results,
+        "critical_unresponsive_engine_count": len(critical_engines),
+        "critical_unresponsive_engines": sorted(critical_engines),
+        "health_verdict": verdict,
+        "raw_candidate_count": len(all_candidates),
+        "deduped_candidate_count": len(deduped_candidates),
+        "candidate_class_counts": class_counts,
+        "recommended_shortlist_size": shortlist_limit,
+        "selected_shortlist": shortlist,
+        "per_query": per_query,
+    }
+
+
 def _probe_searxng(
     *,
     query: QuerySpec | str,
@@ -358,6 +608,13 @@ def _probe_searxng(
             timeout_seconds=timeout_seconds,
         )
         raw_results = payload.get("results", [])
+        normalized_raw = _normalize_records(
+            provider="searxng",
+            query=query,
+            raw_results=[_searx_item(item) for item in raw_results if isinstance(item, dict)],
+            top_k=max(len(raw_results), top_k),
+            source_label="searxng",
+        )
         top_results = _normalize_records(
             provider="searxng",
             query=query,
@@ -366,7 +623,7 @@ def _probe_searxng(
             source_label="searxng",
         )
         elapsed = int((time.monotonic() - started) * 1000)
-        return _provider_probe(
+        probe = _provider_probe(
             provider="searxng",
             query=query.query,
             status="succeeded",
@@ -375,6 +632,9 @@ def _probe_searxng(
             top_results=top_results,
             endpoint=endpoint,
         )
+        probe["unresponsive_engines"] = _parse_unresponsive_engines(payload)
+        probe["raw_candidates"] = normalized_raw
+        return probe
     except urllib.error.HTTPError as exc:
         return _provider_error(
             provider="searxng",
@@ -605,6 +865,8 @@ def _provider_probe(
         "top_results": top_results,
         "top_score": top_score,
         "average_score": avg_score,
+        "raw_candidates": [],
+        "unresponsive_engines": [],
         "failure_classification": failure_classification,
         "error": error,
     }
@@ -819,6 +1081,22 @@ def _render_markdown(report: dict[str, Any]) -> str:
             f"| {query_summary['query']} | {query_summary['winner_provider']} | "
             f"{query_summary['winner_top_score']:.2f} | {query_summary['winner_url'] or '-'} |"
         )
+    searx_health = report.get("searxng_fanout_health")
+    if isinstance(searx_health, dict):
+        lines.append("")
+        lines.append("## SearXNG Fanout Health")
+        lines.append("")
+        lines.append(f"- Health verdict: `{searx_health.get('health_verdict')}`")
+        lines.append(f"- Query fanout coverage: `{searx_health.get('query_fanout_coverage_percent', 0):.1f}%`")
+        lines.append(f"- Raw candidates: `{searx_health.get('raw_candidate_count', 0)}`")
+        lines.append(f"- Deduped candidates: `{searx_health.get('deduped_candidate_count', 0)}`")
+        lines.append(
+            "- Candidate classes: "
+            f"`{json.dumps(searx_health.get('candidate_class_counts', {}), sort_keys=True)}`"
+        )
+        lines.append(f"- Recommended shortlist size: `{searx_health.get('recommended_shortlist_size', 0)}`")
+        critical = searx_health.get("critical_unresponsive_engines") or []
+        lines.append(f"- Critical unresponsive engines: `{', '.join(critical) if critical else '-'}`")
     lines.append("")
     return "\n".join(lines)
 
@@ -912,6 +1190,9 @@ def _run_bakeoff(config: BakeoffConfig) -> dict[str, Any]:
     summary = _summarize_by_provider(probes)
     query_summary = _summarize_queries(probes)
     recommendation = _recommend_provider(summary)
+    searxng_fanout_health = (
+        _build_searxng_fanout_health_summary(probes=probes) if "searxng" in config.providers else None
+    )
     return {
         "generated_at": datetime.now(UTC).isoformat(),
         "feature_key": FEATURE_KEY,
@@ -927,6 +1208,7 @@ def _run_bakeoff(config: BakeoffConfig) -> dict[str, Any]:
         "provider_summary": summary,
         "query_summary": query_summary,
         "recommendation": recommendation,
+        "searxng_fanout_health": searxng_fanout_health,
     }
 
 
@@ -1004,6 +1286,7 @@ def _parse_providers(args: argparse.Namespace) -> tuple[str, ...]:
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Search/source quality bakeoff harness.")
     parser.add_argument("--provider", action="append", default=[])
+    parser.add_argument("--searxng-only", action="store_true")
     parser.add_argument("--query", action="append", default=[])
     parser.add_argument("--query-file", type=Path, default=None)
     parser.add_argument("--top-k", type=int, default=DEFAULT_TOP_K)
@@ -1016,8 +1299,9 @@ def _parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = _parse_args()
+    providers = ("searxng",) if args.searxng_only else _parse_providers(args)
     config = BakeoffConfig(
-        providers=_parse_providers(args),
+        providers=providers,
         queries=_parse_queries(args),
         top_k=max(1, args.top_k),
         timeout_seconds=max(1, args.timeout_seconds),

--- a/backend/services/pipeline/domain/bridge.py
+++ b/backend/services/pipeline/domain/bridge.py
@@ -18,6 +18,7 @@ from services.llm.web_search_factory import create_web_search_client
 from services.pipeline.domain.commands import (
     PipelineDomainCommands,
     assess_reader_substance,
+    prefetch_skip_reason,
     rank_evidence_chunks,
     rank_reader_candidates,
 )
@@ -690,8 +691,39 @@ class RailwayRuntimeBridge:
         reader_provider_errors: list[dict[str, Any]] = []
         candidate_audit: list[dict[str, Any]] = []
 
+        def _quality_alerts() -> list[str]:
+            alerts: list[str] = []
+            for item in reader_quality_failures:
+                reason = str(item.get("reason", "")).strip()
+                if reason == "prefetch_skipped_low_value_portal":
+                    alerts.append("reader_prefetch_skipped_low_value_portal")
+                elif reason:
+                    alerts.append(f"reader_output_insufficient_substance:{reason}")
+            return alerts
+
         for candidate in ranked_candidates:
             url = str(candidate["url"])
+            skip_reason = prefetch_skip_reason(url)
+            if skip_reason:
+                reader_quality_failures.append(
+                    {
+                        "url": url,
+                        "rank": candidate["rank"],
+                        "score": candidate["score"],
+                        "reason": "prefetch_skipped_low_value_portal",
+                        "quality_details": {"skip_signal": skip_reason},
+                    }
+                )
+                candidate_audit.append(
+                    {
+                        "url": url,
+                        "rank": candidate["rank"],
+                        "score": candidate["score"],
+                        "outcome": "reader_prefetch_skipped_low_value_portal",
+                        "reason": skip_reason,
+                    }
+                )
+                continue
             try:
                 reader_payload = await self.reader_client.fetch_content(url, timeout=60)
             except Exception as exc:
@@ -834,7 +866,7 @@ class RailwayRuntimeBridge:
                 }
             )
             alerts = [
-                *[f"reader_output_insufficient_substance:{item['reason']}" for item in reader_quality_failures],
+                *_quality_alerts(),
                 *[f"reader_error:{item['error']}" for item in reader_provider_errors],
             ]
             response = CommandResponse(
@@ -863,7 +895,7 @@ class RailwayRuntimeBridge:
             return await self._persist_response(run_id=run_id, request=request, response=response)
 
         alerts = [
-            *[f"reader_output_insufficient_substance:{item['reason']}" for item in reader_quality_failures],
+            *_quality_alerts(),
             *[f"reader_error:{item['error']}" for item in reader_provider_errors],
         ]
         if reader_provider_errors:

--- a/backend/services/pipeline/domain/commands.py
+++ b/backend/services/pipeline/domain/commands.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 import hashlib
 import re
 from typing import Any
+from urllib.parse import parse_qs, urlsplit
 
 from services.pipeline.domain.constants import CONTRACT_VERSION
 from services.pipeline.domain.identity import build_v2_canonical_document_key
@@ -43,6 +44,33 @@ HIGH_VALUE_URL_SIGNALS = (
 LOW_VALUE_AGENDA_HEADER_URL_SIGNALS = (
     "granicus.com/agendaviewer",
     "agendaviewer.php",
+    "/your-government/agendas-minutes",
+    "/city-council/council-agendas-minutes",
+    "/city-council/council-agendas",
+    "calendar.aspx",
+    "departmentdetail.aspx",
+    "/resource-library/council-memos",
+    "/resource-library/",
+)
+
+LOW_VALUE_PORTAL_PREFETCH_SKIP_URL_SIGNALS = (
+    "/your-government/agendas-minutes",
+    "/city-council/council-agendas-minutes",
+    "/city-council/council-agendas",
+    "calendar.aspx",
+    "departmentdetail.aspx",
+    "/resource-library/council-memos",
+)
+
+LOW_VALUE_PORTAL_URL_PENALTY = 10
+
+CONCRETE_ARTIFACT_URL_SIGNALS = (
+    "meetingdetail.aspx?id=",
+    "meetingdetail.aspx?legid=",
+    "gateway.aspx?id=",
+    "agendaviewer.php?clip_id=",
+    "/agendacenter/viewfile/minutes/",
+    "/agendacenter/viewfile/agenda/",
 )
 
 MEETING_ARTIFACT_TEXT_SIGNALS = (
@@ -268,6 +296,12 @@ def assess_reader_substance(text: str) -> tuple[bool, dict[str, Any]]:
     elif logistics_marker_hits >= 1 and action_hits == 0 and word_count < 160:
         reason = "agenda_header_logistics_only"
         is_substantive = False
+    elif word_count < 6:
+        reason = "content_too_short"
+        is_substantive = False
+    elif line_count <= 2 and word_count < 24 and action_hits == 0:
+        reason = "content_too_short"
+        is_substantive = False
     elif word_count < 25 and substantive_hits == 0:
         reason = "low_substantive_signal"
         is_substantive = False
@@ -308,9 +342,16 @@ def rank_reader_candidates(
             if signal in lowered_url:
                 score += 6 if signal == ".pdf" else 5
                 reasons.append(f"url_high_value:{signal}")
+        for signal in CONCRETE_ARTIFACT_URL_SIGNALS:
+            if signal in lowered_url:
+                score += 7 if signal == ".pdf" else 6
+                reasons.append(f"url_concrete_artifact:{signal}")
+        if _is_concrete_artifact_url(url):
+            score += 8
+            reasons.append("url_concrete_artifact:parsed")
         for signal in LOW_VALUE_AGENDA_HEADER_URL_SIGNALS:
             if signal in lowered_url:
-                score -= 5
+                score -= LOW_VALUE_PORTAL_URL_PENALTY
                 reasons.append(f"url_penalty:{signal}")
         for signal in MEETING_ARTIFACT_TEXT_SIGNALS:
             if signal in lowered_text:
@@ -353,6 +394,71 @@ def rank_reader_candidates(
     if max_candidates is not None:
         return ranked[: max(0, max_candidates)]
     return ranked
+
+
+def prefetch_skip_reason(url: str) -> str | None:
+    lowered_url = url.strip().lower()
+    for signal in LOW_VALUE_PORTAL_PREFETCH_SKIP_URL_SIGNALS:
+        if signal in lowered_url:
+            return signal
+    return None
+
+
+def _parsed_query_params(url: str) -> dict[str, list[str]]:
+    return {key.lower(): values for key, values in parse_qs(urlsplit(url).query).items()}
+
+
+def _has_query_key(params: dict[str, list[str]], key: str) -> bool:
+    return key in params and any(str(value).strip() for value in params[key])
+
+
+def _has_query_value(params: dict[str, list[str]], key: str, expected_values: tuple[str, ...]) -> bool:
+    if key not in params:
+        return False
+    allowed = {value.lower() for value in expected_values}
+    return any(str(value).strip().lower() in allowed for value in params[key])
+
+
+def _has_query_suffix(params: dict[str, list[str]], key: str, suffix: str) -> bool:
+    if key not in params:
+        return False
+    target = suffix.lower()
+    return any(str(value).strip().lower().endswith(target) for value in params[key])
+
+
+def _is_concrete_artifact_url(url: str) -> bool:
+    lowered_url = url.lower().strip()
+    parsed = urlsplit(url)
+    path = parsed.path.lower()
+    host = parsed.netloc.lower()
+    params = _parsed_query_params(url)
+    is_official_host = host.endswith(".gov") or host.endswith(".ca.gov") or host.endswith(".us")
+    is_legistar_host = "legistar.com" in host
+    is_granicus_host = "granicus.com" in host
+    is_trusted_public_records_host = is_official_host or is_legistar_host or is_granicus_host
+
+    if lowered_url.endswith(".pdf") or "/pdf/" in lowered_url:
+        return is_trusted_public_records_host
+
+    if is_legistar_host and "meetingdetail.aspx" in path and (_has_query_key(params, "id") or _has_query_key(params, "legid")):
+        return True
+
+    if is_legistar_host and "view.ashx" in path and _has_query_key(params, "id") and _has_query_value(params, "m", ("a", "m", "f")):
+        return True
+
+    if is_legistar_host and "gateway.aspx" in path and _has_query_key(params, "id"):
+        if _has_query_suffix(params, "id", ".pdf") or _has_query_value(params, "m", ("a", "m", "f")):
+            return True
+
+    if is_granicus_host and "agendaviewer.php" in path and _has_query_key(params, "clip_id"):
+        return True
+
+    if is_official_host and "/agendacenter/viewfile/minutes/" in path:
+        return True
+    if is_official_host and "/agendacenter/viewfile/agenda/" in path:
+        return True
+
+    return False
 
 
 def _tokenize_question_terms(question: str) -> list[str]:
@@ -693,6 +799,28 @@ class PipelineDomainCommands:
                 title=str(candidate_entry["title"]),
                 snippet=str(candidate_entry["snippet"]),
             )
+            skip_reason = prefetch_skip_reason(candidate.url)
+            if skip_reason:
+                quality_alerts.append("reader_prefetch_skipped_low_value_portal")
+                reader_quality_failures.append(
+                    {
+                        "url": candidate.url,
+                        "rank": candidate_entry["rank"],
+                        "score": candidate_entry["score"],
+                        "reason": "prefetch_skipped_low_value_portal",
+                        "quality_details": {"skip_signal": skip_reason},
+                    }
+                )
+                candidate_audit.append(
+                    {
+                        "url": candidate.url,
+                        "rank": candidate_entry["rank"],
+                        "score": candidate_entry["score"],
+                        "outcome": "reader_prefetch_skipped_low_value_portal",
+                        "reason": skip_reason,
+                    }
+                )
+                continue
             try:
                 doc = self.reader_provider.fetch(url=candidate.url)
             except Exception as exc:

--- a/backend/tests/ops/test_search_source_quality_bakeoff.py
+++ b/backend/tests/ops/test_search_source_quality_bakeoff.py
@@ -263,3 +263,208 @@ def test_render_markdown_contains_summary_and_recommendation():
     assert "Provider Summary" in markdown
     assert "Best candidate: `searxng`" in markdown
     assert "https://example.com/minutes.pdf" in markdown
+
+
+def test_candidate_classification_rules_for_san_jose_sources():
+    assert (
+        module._candidate_class("https://sanjose.legistar.com/MeetingDetail.aspx?ID=1234", "", "")
+        == "final_artifact"
+    )
+    assert module._candidate_class("https://sanjose.legistar.com/View.ashx?M=F&ID=1234", "", "") == "final_artifact"
+    assert (
+        module._candidate_class("https://www.sanjoseca.gov/your-government/agendas-minutes", "", "") == "portal_seed"
+    )
+    assert (
+        module._candidate_class("https://www.sanjoseca.gov/your-government/departments-offices/housing", "", "")
+        == "likely_navigation"
+    )
+    assert module._candidate_class("https://www.reddit.com/r/SanJose/comments/abc", "", "") == "third_party_or_junk"
+
+
+def test_candidate_classification_handles_query_param_order_and_agenda_center_files():
+    assert (
+        module._candidate_class(
+            "https://sanjose.legistar.com/View.ashx?GUID=59FCFBBE-ACEB-4329-9C02-9548AFD46D2D&ID=1328259&M=M",
+            "",
+            "",
+        )
+        == "final_artifact"
+    )
+    assert (
+        module._candidate_class(
+            "https://sanjose.legistar.com/gateway.aspx?M=F&ID=30dfe51f-d23d-4480-a407-44e17ef4c0c3.pdf",
+            "",
+            "",
+        )
+        == "final_artifact"
+    )
+    assert (
+        module._candidate_class(
+            "https://www.saratoga.ca.us/AgendaCenter/ViewFile/Minutes/_03182026-1422",
+            "",
+            "",
+        )
+        == "final_artifact"
+    )
+    assert (
+        module._candidate_class(
+            "https://dig.abclocal.go.com/kgo/PDF/sjmemorandum.pdf",
+            "sjmemorandum",
+            "media mirror",
+        )
+        == "third_party_or_junk"
+    )
+
+
+def test_parse_unresponsive_engines_supports_dict_and_list_shapes():
+    from_dict = module._parse_unresponsive_engines(
+        {"unresponsive_engines": {"brave": "Suspended (too many requests)", "ddg": "access denied"}}
+    )
+    assert from_dict == [
+        {"engine": "brave", "reason": "Suspended (too many requests)"},
+        {"engine": "ddg", "reason": "access denied"},
+    ]
+
+    from_list = module._parse_unresponsive_engines({"unresponsive_engines": ["startpage", "karmasearch"]})
+    assert from_list == [
+        {"engine": "startpage", "reason": "unresponsive"},
+        {"engine": "karmasearch", "reason": "unresponsive"},
+    ]
+
+
+def test_probe_searxng_emits_raw_candidates_and_unresponsive_metadata(monkeypatch):
+    def _fake_request_json(*, method, url, headers, payload, timeout_seconds):
+        assert method == "GET"
+        assert "format=json" in url
+        assert headers["User-Agent"] == module.DEFAULT_USER_AGENT
+        assert payload is None
+        assert timeout_seconds == 9
+        return {
+            "results": [
+                {
+                    "url": "https://sanjose.legistar.com/MeetingDetail.aspx?ID=1234",
+                    "title": "Meeting Detail",
+                    "content": "Affordable housing ordinance agenda item",
+                },
+                {
+                    "url": "https://www.sanjoseca.gov/your-government/agendas-minutes",
+                    "title": "Agendas and Minutes",
+                    "content": "Menu and navigation",
+                },
+            ],
+            "unresponsive_engines": {"brave": "Suspended (too many requests)"},
+        }
+
+    monkeypatch.setattr(module, "_request_json", _fake_request_json)
+    probe = module._probe_searxng(
+        query="San Jose city council housing",
+        endpoint="https://example.test/search",
+        top_k=1,
+        timeout_seconds=9,
+    )
+
+    assert probe["status"] == "succeeded"
+    assert probe["result_count"] == 2
+    assert len(probe["top_results"]) == 1
+    assert len(probe["raw_candidates"]) == 2
+    assert probe["unresponsive_engines"] == [{"engine": "brave", "reason": "Suspended (too many requests)"}]
+
+
+def test_build_searxng_fanout_health_summary_reports_class_counts_and_verdict():
+    probes = [
+        {
+            "provider": "searxng",
+            "query": "q1",
+            "status": "succeeded",
+            "result_count": 2,
+            "top_results": [
+                {"url": "https://sanjose.legistar.com/MeetingDetail.aspx?ID=99", "title": "Meeting", "score": 70.0}
+            ],
+            "raw_candidates": [
+                {
+                    "url": "https://sanjose.legistar.com/MeetingDetail.aspx?ID=99",
+                    "title": "Meeting",
+                    "snippet": "agenda item",
+                    "score": 70.0,
+                },
+                {
+                    "url": "https://www.sanjoseca.gov/your-government/agendas-minutes",
+                    "title": "Agendas and Minutes",
+                    "snippet": "menu",
+                    "score": 10.0,
+                },
+            ],
+            "unresponsive_engines": [],
+        },
+        {
+            "provider": "searxng",
+            "query": "q2",
+            "status": "succeeded",
+            "result_count": 0,
+            "top_results": [],
+            "raw_candidates": [],
+            "unresponsive_engines": [{"engine": "duckduckgo", "reason": "Suspended (access denied)"}],
+        },
+    ]
+
+    summary = module._build_searxng_fanout_health_summary(probes=probes)
+    assert summary["provider"] == "searxng"
+    assert summary["query_count"] == 2
+    assert summary["raw_candidate_count"] == 2
+    assert summary["deduped_candidate_count"] == 2
+    assert summary["candidate_class_counts"]["final_artifact"] == 1
+    assert summary["candidate_class_counts"]["portal_seed"] == 1
+    assert summary["health_verdict"] == "degraded"
+    assert summary["critical_unresponsive_engine_count"] == 1
+    assert len(summary["selected_shortlist"]) >= 1
+
+
+def test_build_searxng_fanout_health_summary_shortlist_sorts_by_class_priority_then_score():
+    probes = [
+        {
+            "provider": "searxng",
+            "query": "q1",
+            "status": "succeeded",
+            "result_count": 4,
+            "top_results": [],
+            "raw_candidates": [
+                {
+                    "url": "https://www.sanjoseca.gov/your-government/agendas-minutes",
+                    "title": "Agendas and Minutes",
+                    "snippet": "portal",
+                    "score": 91.0,
+                },
+                {
+                    "url": "https://www.saratoga.ca.us/AgendaCenter/ViewFile/Minutes/_03182026-1422",
+                    "title": "Minutes File",
+                    "snippet": "minutes",
+                    "score": 60.0,
+                },
+                {
+                    "url": "https://www.sanjoseca.gov/your-government/departments-offices/housing",
+                    "title": "Housing Department",
+                    "snippet": "navigation",
+                    "score": 95.0,
+                },
+                {
+                    "url": "https://www.reddit.com/r/SanJose/comments/abc",
+                    "title": "Thread",
+                    "snippet": "discussion",
+                    "score": 99.0,
+                },
+                {
+                    "url": "https://dig.abclocal.go.com/kgo/PDF/sjmemorandum.pdf",
+                    "title": "sjmemorandum",
+                    "snippet": "media mirror",
+                    "score": 98.0,
+                },
+            ],
+            "unresponsive_engines": [],
+        }
+    ]
+
+    summary = module._build_searxng_fanout_health_summary(probes=probes, shortlist_size=3)
+    shortlist = summary["selected_shortlist"]
+    assert [item["class"] for item in shortlist] == ["final_artifact", "portal_seed", "likely_navigation"]
+    assert shortlist[0]["url"] == "https://www.saratoga.ca.us/AgendaCenter/ViewFile/Minutes/_03182026-1422"
+    assert all(item["url"] != "https://dig.abclocal.go.com/kgo/PDF/sjmemorandum.pdf" for item in shortlist)

--- a/backend/tests/services/pipeline/test_bridge_runtime.py
+++ b/backend/tests/services/pipeline/test_bridge_runtime.py
@@ -231,9 +231,11 @@ class RoutingFakeReaderClient:
     ) -> None:
         self.by_url = by_url or {}
         self.fail_urls = fail_urls or set()
+        self.fetch_calls: list[str] = []
 
     async def fetch_content(self, url: str, **kwargs: Any) -> dict[str, Any]:
         _ = kwargs
+        self.fetch_calls.append(url)
         if url in self.fail_urls:
             raise RuntimeError(f"reader_down_for:{url}")
         return {
@@ -655,6 +657,52 @@ def test_runtime_bridge_falls_through_agenda_header_logistics_to_legistar_pdf() 
     assert response["steps"]["read_fetch"]["details"]["candidate_audit"][1]["outcome"] == "materialized_raw_scrape"
     assert response["steps"]["index"]["status"] in {"succeeded", "succeeded_with_alerts"}
     assert response["steps"]["analyze"]["status"] in {"succeeded", "succeeded_with_alerts"}
+
+
+def test_runtime_bridge_prefetch_skips_portal_url_and_fetches_artifact_candidate() -> None:
+    db = FakeDB()
+    storage = FakeStorage()
+    runtime = RailwayRuntimeBridge(db=db, storage=storage)  # type: ignore[arg-type]
+    runtime.search_client = FakeSearchClient(
+        [
+            {
+                "url": "https://www.sanjoseca.gov/your-government/agendas-minutes",
+                "title": "Agendas & Minutes | City of San Jose",
+                "snippet": "agenda archive and calendar",
+            },
+            {
+                "url": "https://records.sanjoseca.gov/documents/12345",
+                "title": "Home Resources Departments",
+                "snippet": "services menu",
+            },
+        ]
+    )
+    runtime.reader_client = RoutingFakeReaderClient(
+        by_url={
+            "https://records.sanjoseca.gov/documents/12345": (
+                "# Meeting Minutes\n"
+                "Agenda item 4.2 housing affordability ordinance was adopted by vote.\n"
+            )
+        }
+    )
+    runtime._llm_client = FakeLLMClient()
+    runtime.zai_api_key = "x"
+
+    response = asyncio.run(runtime.run_scope_pipeline(_request(idempotency_key="wm:run-scope:prefetch-skip")))
+
+    assert response["steps"]["read_fetch"]["status"] == "succeeded_with_alerts"
+    assert runtime.reader_client.fetch_calls == [
+        "https://records.sanjoseca.gov/documents/12345"
+    ]
+    assert any(
+        item["outcome"] == "reader_prefetch_skipped_low_value_portal"
+        for item in response["steps"]["read_fetch"]["details"]["candidate_audit"]
+    )
+    assert any(
+        item["outcome"] == "materialized_raw_scrape"
+        for item in response["steps"]["read_fetch"]["details"]["candidate_audit"]
+    )
+    assert "reader_prefetch_skipped_low_value_portal" in response["alerts"]
 
 
 def test_runtime_bridge_blocks_when_all_candidates_are_agenda_header_logistics() -> None:

--- a/backend/tests/services/pipeline/test_domain_commands.py
+++ b/backend/tests/services/pipeline/test_domain_commands.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from services.pipeline.domain.commands import rank_reader_candidates
+from services.pipeline.domain.commands import (
+    assess_reader_substance,
+    rank_reader_candidates,
+)
 from services.pipeline.domain import (
     CommandEnvelope,
     FreshnessPolicy,
@@ -59,6 +62,31 @@ class _RoutingReaderProvider:
                     "where housing policy recommendations were adopted by vote."
                 ),
             ),
+            fetched_at=datetime.now(timezone.utc),
+            document_type="meeting_minutes",
+            published_date="2026-04-13",
+        )
+
+
+class _TrackingReaderProvider:
+    def __init__(
+        self,
+        *,
+        by_url: dict[str, str],
+        forbidden_urls: set[str] | None = None,
+    ) -> None:
+        self.by_url = by_url
+        self.forbidden_urls = forbidden_urls or set()
+        self.fetch_calls: list[str] = []
+
+    def fetch(self, *, url: str) -> ReaderDocument:
+        self.fetch_calls.append(url)
+        if url in self.forbidden_urls:
+            raise AssertionError(f"forbidden_fetch:{url}")
+        return ReaderDocument(
+            url=url,
+            title="San Jose City Council",
+            text=self.by_url[url],
             fetched_at=datetime.now(timezone.utc),
             document_type="meeting_minutes",
             published_date="2026-04-13",
@@ -316,6 +344,106 @@ def test_rank_reader_candidates_prefers_legistar_gateway_pdf_with_action_snippet
     assert ranked[0]["url"].startswith("https://sanjose.legistar.com/gateway.aspx")
 
 
+def test_rank_reader_candidates_penalizes_portal_urls_below_artifact_urls() -> None:
+    ranked = rank_reader_candidates(
+        [
+            SearchResultItem(
+                url="https://www.sanjoseca.gov/your-government/agendas-minutes",
+                title="Agendas & Minutes | City of San Jose",
+                snippet="City council agendas and minutes",
+            ),
+            SearchResultItem(
+                url="https://sanjose.legistar.com/MeetingDetail.aspx?ID=12345&GUID=abc",
+                title="Meeting Detail",
+                snippet="Agenda item 4.2 housing ordinance",
+            ),
+            SearchResultItem(
+                url="https://www.sanjoseca.gov/Calendar.aspx?CID=114",
+                title="City Calendar",
+                snippet="meeting calendar",
+            ),
+            SearchResultItem(
+                url="https://sanjose.legistar.com/View.ashx?M=F&ID=12345&GUID=abc",
+                title="Final Agenda Packet",
+                snippet="ordinance no. 31303 approved",
+            ),
+        ]
+    )
+    ranked_urls = [item["url"] for item in ranked]
+    ranked_by_url = {item["url"]: item for item in ranked}
+    assert ranked_urls[0].startswith("https://sanjose.legistar.com/")
+    assert ranked_urls[1].startswith("https://sanjose.legistar.com/")
+    assert ranked_urls[-1].startswith("https://www.sanjoseca.gov/")
+    assert "/agendas-minutes" in ranked_urls[-1] or "calendar.aspx" in ranked_urls[-1].lower()
+    assert (
+        ranked_by_url["https://sanjose.legistar.com/View.ashx?M=F&ID=12345&GUID=abc"]["score"]
+        - ranked_by_url["https://www.sanjoseca.gov/your-government/agendas-minutes"]["score"]
+    ) >= 10
+
+
+def test_rank_reader_candidates_detects_concrete_artifacts_with_unordered_query_params() -> None:
+    ranked = rank_reader_candidates(
+        [
+            SearchResultItem(
+                url="https://www.sanjoseca.gov/your-government/agendas-minutes",
+                title="Agendas & Minutes | City of San Jose",
+                snippet="city council agendas and minutes",
+            ),
+            SearchResultItem(
+                url="https://sanjose.legistar.com/View.ashx?GUID=59FCFBBE-ACEB-4329-9C02-9548AFD46D2D&ID=1328259&M=M",
+                title="Minutes Packet",
+                snippet="city council minutes and housing item",
+            ),
+            SearchResultItem(
+                url="https://www.saratoga.ca.us/AgendaCenter/ViewFile/Minutes/_03182026-1422",
+                title="City Council Minutes",
+                snippet="minutes archive",
+            ),
+        ]
+    )
+    ranked_by_url = {item["url"]: item for item in ranked}
+    assert ranked[0]["url"] == "https://sanjose.legistar.com/View.ashx?GUID=59FCFBBE-ACEB-4329-9C02-9548AFD46D2D&ID=1328259&M=M"
+    assert (
+        ranked_by_url["https://www.saratoga.ca.us/AgendaCenter/ViewFile/Minutes/_03182026-1422"]["score"]
+        > ranked_by_url["https://www.sanjoseca.gov/your-government/agendas-minutes"]["score"]
+    )
+
+
+def test_rank_reader_candidates_does_not_apply_concrete_boost_to_third_party_pdf() -> None:
+    ranked = rank_reader_candidates(
+        [
+            SearchResultItem(
+                url="https://dig.abclocal.go.com/kgo/PDF/sjmemorandum.pdf",
+                title="sjmemorandum",
+                snippet="media mirror pdf",
+            ),
+            SearchResultItem(
+                url="https://www.sanjoseca.gov/your-government/agendas-minutes",
+                title="Agendas & Minutes | City of San Jose",
+                snippet="city council agendas and minutes",
+            ),
+            SearchResultItem(
+                url="https://sanjose.legistar.com/View.ashx?M=F&ID=12345&GUID=abc",
+                title="Final Agenda Packet",
+                snippet="ordinance no. 31303 approved",
+            ),
+        ]
+    )
+    ranked_by_url = {item["url"]: item for item in ranked}
+    assert "url_concrete_artifact:parsed" not in ranked_by_url["https://dig.abclocal.go.com/kgo/PDF/sjmemorandum.pdf"][
+        "reasons"
+    ]
+    assert "url_concrete_artifact:parsed" in ranked_by_url["https://sanjose.legistar.com/View.ashx?M=F&ID=12345&GUID=abc"][
+        "reasons"
+    ]
+
+
+def test_assess_reader_substance_rejects_title_only_agendas_minutes_output() -> None:
+    is_substantive, details = assess_reader_substance("Agendas & Minutes | City of San Jose")
+    assert is_substantive is False
+    assert details["reason"] == "content_too_short"
+
+
 def test_reader_failure_stops_before_index() -> None:
     state, service = _service(
         search_results=[
@@ -419,6 +547,49 @@ def test_read_fetch_falls_through_agenda_header_logistics_to_legistar_pdf() -> N
     assert read.details["candidate_audit"][0]["outcome"] == "reader_output_insufficient_substance"
     assert read.details["candidate_audit"][0]["reason"] == "agenda_header_logistics_only"
     assert read.details["candidate_audit"][1]["outcome"] == "materialized_raw_scrape"
+    assert len(state.raw_scrapes) == 1
+
+
+def test_read_fetch_prefetch_skips_obvious_portal_url_and_fetches_artifact() -> None:
+    state, service = _service(
+        search_results=[
+            SearchResultItem(
+                url="https://www.sanjoseca.gov/your-government/agendas-minutes",
+                title="Agendas & Minutes | City of San Jose",
+                snippet="agenda archive",
+            ),
+            SearchResultItem(
+                url="https://sanjose.legistar.com/MeetingDetail.aspx?ID=12345&GUID=abc",
+                title="Meeting Detail",
+                snippet="agenda item 4.2 housing ordinance adopted",
+            ),
+        ]
+    )
+    tracker = _TrackingReaderProvider(
+        by_url={
+            "https://sanjose.legistar.com/MeetingDetail.aspx?ID=12345&GUID=abc": (
+                "Agenda item 4.2 housing affordability ordinance was adopted by vote "
+                "after public hearing and staff recommendation."
+            )
+        },
+        forbidden_urls={"https://www.sanjoseca.gov/your-government/agendas-minutes"},
+    )
+    service.reader_provider = tracker
+
+    search = service.search_materialize(envelope=_envelope("search_materialize", "ps1"), query="q")
+    read = service.read_fetch(
+        envelope=_envelope("read_fetch", "ps2"),
+        snapshot_id=str(search.refs["search_snapshot_id"]),
+        max_reads=2,
+    )
+
+    assert read.status == "succeeded_with_alerts"
+    assert tracker.fetch_calls == ["https://sanjose.legistar.com/MeetingDetail.aspx?ID=12345&GUID=abc"]
+    assert any(
+        item["outcome"] == "reader_prefetch_skipped_low_value_portal"
+        for item in read.details["candidate_audit"]
+    )
+    assert any(item["outcome"] == "materialized_raw_scrape" for item in read.details["candidate_audit"])
     assert len(state.raw_scrapes) == 1
 
 

--- a/docs/poc/search-source-quality-bakeoff/README.md
+++ b/docs/poc/search-source-quality-bakeoff/README.md
@@ -21,6 +21,31 @@ This bakeoff closes that gap.
 - `EXA_API_KEY`
 - Exa requests must use User-Agent `affordabot-dev-bakeoff/1.0` to avoid Cloudflare 1010 observed with default Python UA.
 
+SearXNG-only mode does not require `TAVILY_API_KEY` or `EXA_API_KEY`.
+
+## SearXNG-only run
+
+```bash
+cd backend
+poetry run python scripts/verification/verify_search_source_quality_bakeoff.py \
+  --searxng-only \
+  --query-file ../docs/poc/search-source-quality-bakeoff/query-corpus.json \
+  --searx-endpoint "https://searxng-railway-production-79aa.up.railway.app/search"
+```
+
+This mode emits the same report files and adds a `searxng_fanout_health` section with:
+
+- per-query result count and top result URL/title rows,
+- per-query `unresponsive_engines` metadata (when returned by SearXNG),
+- `health_verdict` (`healthy` / `degraded` / `unhealthy`),
+- `raw_candidate_count`, `deduped_candidate_count`,
+- deterministic class counts:
+  - `final_artifact`
+  - `portal_seed`
+  - `likely_navigation`
+  - `third_party_or_junk`,
+- deterministic shortlist guidance (`recommended_shortlist_size`, `selected_shortlist`).
+
 ## Expected harness behavior
 
 Implementation does:

--- a/docs/research/2026-04-14-private-searxng-quality-review.md
+++ b/docs/research/2026-04-14-private-searxng-quality-review.md
@@ -1,0 +1,404 @@
+# Private SearXNG quality review — San Jose housing meeting minutes
+
+- Feature key: `bd-9qjof.8`
+- Depends on: `bd-9qjof.6` (live Windmill San Jose validation gate)
+- Context PR: https://github.com/stars-end/affordabot/pull/434
+- Reviewer role: senior search/retrieval consultant (read-only QA pass)
+- Date: 2026-04-14
+
+## 1. Executive verdict
+
+**Private SearXNG can be the MVP primary discovery lane, but not as currently
+wired.** The April 13 bakeoff (`search_source_quality_bakeoff_report.md`) shows
+SearXNG is *already* returning official-domain results at a higher rate than
+Tavily or Exa for the San Jose family (94.7% official-hit rate vs. 84.2% and
+73.7%), and the underlying engines are surfacing Legistar artifact URLs in the
+top‑5. The failure observed in PR #433's live gate — the pipeline selected
+`sanjoseca.gov/.../agendas-minutes`, which rendered as a title-only reader
+shell — is **not** a SearXNG recall problem. It is a *ranking, portal-handling,
+and reader-gate* problem in the backend. SearXNG-native knobs help marginally;
+the decisive fixes are in `services/pipeline/domain/commands.py`
+(`rank_reader_candidates`, `assess_reader_substance`) and in pre-fetch portal
+treatment.
+
+Verdict: **approve_with_changes**. Ship SearXNG as primary after applying the
+S1/S2/B1/B2/R1 fixes in §8. Keep Tavily as cheap hot-fallback and Exa as
+quality bakeoff-only (free-tier capped, needs custom UA).
+
+## 2. Evidence summary
+
+### 2.1 What the April 13 bakeoff actually shows
+
+From `docs/poc/search-source-quality-bakeoff/artifacts/search_source_quality_bakeoff_report.json`,
+SearXNG San Jose probes (all `status: succeeded`, latency 616–768 ms):
+
+| Query (San Jose) | SearXNG top‑1 (before backend re-rank) | Class |
+|---|---|---|
+| council meeting minutes housing | `/your-government/departments-offices/housing/resource-library/council-memos` | **portal** |
+| council agenda affordable housing | `/your-government/departments-offices/housing/resource-library/council-memos` | **portal** |
+| planning commission minutes housing development | `/your-government/.../planning-commission/planning-commission-agendas-minutes` | **portal** |
+| rent stabilization committee meeting minutes | `/your-government/.../resource-library/council-memos` | **portal** |
+| city clerk council minutes PDF housing | `/your-government/.../resource-library/council-memos` | **portal** |
+| city council housing memorandum | `/your-government/.../resource-library/council-memos` | **portal** |
+
+Within each top‑5, SearXNG *also* returns artifact-grade Legistar URLs
+(`View.ashx?M=A`, `MeetingDetail.aspx`, `gateway.aspx?m=l&id=%2Fmatter.aspx`,
+`View.ashx?M=F&ID=...`) — often at position 2–5. Example: the "city council
+housing memorandum" probe returned
+`sanjose.legistar.com/View.ashx?M=F&ID=15266771` at position 3, which is the
+precise artifact the downstream reader/analyzer wanted.
+
+**Diagnosis**: SearXNG recall for this jurisdiction is good. What fails is the
+backend's ability to prefer the artifact over the portal when both are present
+and both match surface signals ("agenda", "minutes", "legistar").
+
+### 2.2 What the Windmill San Jose live gate selected
+
+PR #433's run picked `sanjoseca.gov/your-government/agendas-minutes`. Reader
+output was essentially `Agendas & Minutes | City of San José` — a navigation
+shell. The LLM (correctly) refused to emit housing signals.
+
+### 2.3 Why targeted Legistar queries "worked"
+
+Manual tests with `site:sanjose.legistar.com` produced artifact URLs as top‑1
+because `site:` forces the engine off the city landing pages. This isn't a
+fundamental engine difference — it's a *query shape* and a *re-rank* problem.
+
+## 3. Root cause analysis
+
+Ordered by contribution to the observed failure.
+
+### RC1 — Backend ranker under-penalizes portal/directory URL shapes *(primary)*
+
+`rank_reader_candidates` in
+`backend/services/pipeline/domain/commands.py:290` currently rewards any URL
+containing `legistar.com`, `/agenda`, or `/minutes` and only penalizes
+`granicus.com/agendaviewer` + `agendaviewer.php`. It does **not** penalize:
+
+- `sanjose.legistar.com/DepartmentDetail.aspx` (department calendar, no content)
+- `sanjose.legistar.com/Calendar.aspx` (calendar index)
+- `sanjoseca.gov/your-government/agendas-minutes` (city clerk landing)
+- `sanjoseca.gov/your-government/.../resource-library/council-memos` (memo index)
+- `/commission-agendas-minutes` (commission index)
+
+These all look like "good" URLs to the ranker because they contain the bonus
+substrings `/agenda` or `/minutes` or `legistar.com`. They are in fact directory
+landing pages.
+
+### RC2 — Reader quality gate fires too late, and only on content
+
+`assess_reader_substance` (commands.py:225) can only classify a fetch
+*after* the reader has paid the cost of fetching and extracting the page. For a
+portal landing page the reader output is usually a short title‑only stub, which
+is correctly flagged but too late to recover: by then the ranker has committed
+to that candidate and no alternative is retried with backtracking evidence.
+
+### RC3 — SearXNG query shape is a single bare string
+
+`_probe_searxng` in `verify_search_source_quality_bakeoff.py:341` issues
+`GET /search?q=<raw>&format=json`. It does **not** pass `engines=`, `language=`,
+`categories=`, `time_range=`, `pageno=`, or any SearXNG search-syntax operators
+(`site:`, `filetype:`). This relies entirely on instance defaults and a single
+general-category multi-engine search. For civic records this biases toward
+long-lived domain landing pages (high PageRank, broad title match) over
+transient meeting artifacts.
+
+### RC4 — No source-family query fanout
+
+For a query like "San Jose council meeting minutes housing" the harness issues
+one search. It does not fan out across the known San Jose source families:
+Legistar, Granicus, Agenda Center, city clerk PDF directories. A single query
+cannot rank across those families fairly.
+
+### RC5 — No pre-fetch portal classifier
+
+There is no step that says "this URL shape is a landing page, expand it before
+fetching." The pipeline treats every search hit as a final artifact candidate.
+
+### RC6 — Query-family blindness on expected_signal_terms
+
+The rubric's `expected_signal_terms` are not passed through to the backend
+ranker, so the content-free re-rank cannot see *why* a query exists. A query
+tagged `source_family=meeting_minutes` should boost `MeetingDetail.aspx`
+artifacts more than a `source_family=memos` query would.
+
+## 4. SearXNG-native fixes (S-class)
+
+SearXNG documents the API, query syntax, engine settings, and per-instance
+tuning here:
+
+- Search API: https://docs.searxng.org/dev/search_api.html
+- Search syntax (operators, bangs, site:, filetype:): https://docs.searxng.org/user/search-syntax.html
+- Engine configuration and weights: https://docs.searxng.org/admin/engines/settings.html
+- Configured engines list (which engines exist by default): https://docs.searxng.org/user/configured_engines.html
+
+### S1 — Pin the engine set used for civic queries *(do now)*
+
+Pass `engines=google,bing,duckduckgo,brave,startpage,qwant` on every probe.
+Rationale: without `engines=`, SearXNG uses the instance default, which depends
+on whether individual engines are healthy on the Railway-hosted instance at
+probe time. A pinned set produces reproducible recall and is cheap.
+
+API: `GET /search?q=...&format=json&engines=google,bing,duckduckgo,brave,startpage,qwant`.
+
+### S2 — Set `language=en` and `categories=general` *(do now)*
+
+`GET /search?q=...&language=en&categories=general&format=json`. Prevents
+region/locale drift and excludes `images`, `videos`, `news` merges from the
+`general` bucket. Cheap; avoids YouTube/Reddit noise we already see in the top‑5.
+
+### S3 — Use `site:` / `filetype:` operators directly, not bangs *(do now)*
+
+SearXNG supports inline operators via the aggregator's generic query rewriter
+(documented under "Search syntax"). For San Jose housing minutes this means the
+fanout from §5 should produce queries like
+`"San Jose housing ordinance site:sanjose.legistar.com"` rather than issuing a
+`!go` bang. Bangs route to one engine and defeat the multi-engine voting that
+is SearXNG's whole point.
+
+### S4 — Consider `time_range=year` for action queries *(optional, measure)*
+
+For queries whose signal is "recent housing action" (memos, rent committee),
+`time_range=year` narrows candidates to current-cycle material. Do not apply to
+"housing element" queries (multi-year cadence).
+
+### S5 — Instance-level engine weights *(optional, infra task)*
+
+On the Railway-hosted SearXNG instance (`searxng-railway-production-79aa`),
+`settings.yml` can raise `google`/`bing` weight for civic recall and disable
+engines that are known-broken (Qwant EN, Startpage captcha periods). This is
+an infra change tracked under `bd-ybyy7.1`; it is not required for MVP.
+
+### S6 — Do **not** rely on `!bang` routing for primary recall
+
+Bangs in SearXNG are routing hints; they bypass the multi-engine fusion. Use
+them only in emergency or for debugging ("does Google still know about this?").
+
+## 5. Source-family query fanout (backend-side)
+
+For San Jose housing meeting minutes, issue N parallel SearXNG probes and merge
+their top‑5s before ranking. Minimum 5 recipes (sj-001..sj-006 class):
+
+1. `<jurisdiction> <topic> site:sanjose.legistar.com`
+2. `<topic> ordinance resolution site:sanjose.legistar.com filetype:pdf`
+3. `<jurisdiction> <topic> site:sanjoseca.gov filetype:pdf`
+4. `<jurisdiction> <topic> site:sanjoseca.gov/your-government/appointees/city-clerk/council-agendas-minutes`
+5. `<jurisdiction> city council <topic> sanjose.legistar.com View.ashx`
+6. `<jurisdiction> <topic> sanjose.granicus.com AgendaViewer`
+7. `<jurisdiction> <topic> memorandum site:sanjoseca.gov/your-government/departments-offices/housing/resource-library`
+
+Dedupe by canonical URL (scheme+host+path, lowercased, trailing-slash
+stripped — the harness already has `_canonicalize_url` at line 147). Collapse
+`View.ashx?GUID=...&ID=N&M=A` variants by `ID` parameter.
+
+The fanout happens **before** the ranker. Each sub-query's top‑5 gets merged
+into a candidate pool of ~25 URLs; the ranker then chooses. Cost is linear in
+fanout width; a private SearXNG is the right place to pay that cost because
+there is no per-query free-tier meter.
+
+## 6. Backend ranking fixes (B-class)
+
+All edits land in `backend/services/pipeline/domain/commands.py`.
+
+### B1 — Add portal/directory URL-shape penalties
+
+Expand `LOW_VALUE_AGENDA_HEADER_URL_SIGNALS` (currently line 43) to include:
+
+```
+"legistar.com/departmentdetail.aspx"
+"legistar.com/calendar.aspx"
+"/your-government/agendas-minutes"
+"/resource-library/council-memos"
+"/resource-library/information-memos"
+"/commission-agendas-minutes"
+"/planning-commission-agendas-minutes"
+"/council-agendas-minutes"
+```
+
+Apply a hard `-10` (not `-5`) for these. Rationale: the ranker already gives
+`+5` for `legistar.com` and `+5` for `/agenda` or `/minutes`; a `-5` cancels
+once and leaves a portal tied with an artifact. A `-10` makes the portal
+strictly dominated.
+
+### B2 — Boost true-artifact URL shapes harder
+
+In `HIGH_VALUE_URL_SIGNALS` (line 36) the current `+6` for `.pdf` and `+5` for
+`View.ashx` is correct in direction but weak. Add:
+
+```
+"legistar.com/view.ashx?m=a"  # agenda artifact
+"legistar.com/view.ashx?m=f"  # file artifact
+"legistar.com/gateway.aspx?id="  # direct gateway artifact
+"legistar.com/meetingdetail.aspx?id="  # specific meeting, not department
+```
+
+Score `+8` for these. The key is the *query string* — `DepartmentDetail.aspx`
+vs `MeetingDetail.aspx` is a portal-vs-artifact distinction.
+
+### B3 — Title-shape penalty for bare portal titles
+
+Add a title-regex penalty: if the extracted title matches
+`^[A-Z][A-Za-z &]+\s*\|\s*City of San José$` and contains no date, item
+number, or action verb, apply `-4`. This catches `Agendas & Minutes | City of
+San José` without touching real artifact titles like
+`26-166 - Memorandum from Casey, 2/23/26`.
+
+### B4 — Pass `source_family` and `expected_signal_terms` into the ranker
+
+The rubric already tags queries with `source_family`. Thread that through to
+`rank_reader_candidates` so `memos` queries reward `/information-memos/<id>`
+and `meeting_minutes` queries reward `View.ashx?M=A`. This is a small change
+but removes most of the remaining portal ties.
+
+## 7. Reader-quality gate fix (R-class)
+
+### R1 — Pre-fetch SKIP list for known portal shapes
+
+`assess_reader_substance` (commands.py:225) already classifies nav-heavy reader
+output as `navigation_heavy`. The problem is that the reader has to fetch the
+portal before that fires, and by then the ranker has consumed its budget. Add a
+pre-fetch `is_known_portal_shape(url)` check that rejects the B1 URL patterns
+**before** dispatching the reader call. If every top-ranked candidate is a
+portal, fall through to the second-highest ranked candidate.
+
+### R2 — Character-count floor on reader output
+
+Add a hard minimum: if extracted content length < 400 non-markup characters
+and the URL isn't a small-PDF exception, treat as `reader_content_too_thin`
+and mark the candidate `unusable`, forcing a fallback to the next ranked URL.
+The current `empty_reader_output` check only catches zero-length outputs;
+`Agendas & Minutes | City of San José` is ~35 characters and slips through.
+
+### R3 — Portal expansion instead of final-target treatment
+
+For any URL that matches a known portal pattern (B1 list), treat it as a
+**seed**, not a final artifact. Queue an expansion step: fetch the portal,
+extract outbound links matching artifact shapes from §B2, re-rank those, and
+feed them back through the normal reader path. This reuses the existing
+ranker — it just loops once. Only enable this for the top‑1 candidate to cap
+cost at one extra fetch per pipeline run.
+
+## 8. Proposed acceptance criteria for the next live San Jose run
+
+A live Windmill San Jose gate with SearXNG-primary must meet all of:
+
+1. **Selected source shape**: top‑1 candidate URL matches
+   `View\.ashx|MeetingDetail\.aspx|gateway\.aspx\?id=|\.pdf` on `.gov`,
+   `legistar.com`, or `granicus.com`.
+2. **Reader content floor**: extracted content ≥ 800 non-markup characters;
+   `assess_reader_substance` returns `substantive=true`.
+3. **Z.ai analysis sufficiency**: at least one San Jose housing question
+   returns `sufficient_evidence=true` with a direct citation chain to a
+   document-level URL. (This is the gate PR #433 failed.)
+4. **Provenance chain persisted**: row(s) exist in Postgres linking
+   search_snapshot → reader_document → analysis_evidence with matching
+   canonical document key. MinIO storage ref matches the canonical key.
+5. **No portal top‑1**: pre-fetch portal SKIP list reports zero hits in the
+   final selected candidate; if expansion fires, the gate logs the
+   portal-expansion step and the final artifact URL.
+
+These criteria plug into `verify_windmill_sanjose_live_gate.py` as deterministic
+assertions.
+
+## 9. Minimum bakeoff corpus to prove SearXNG-primary
+
+The current `query-corpus.json` has 20 entries (6 San Jose, 4 Saratoga, 5 SCC,
+2 control cities, 2 negative). To prove private SearXNG is good enough as
+*primary*, extend with:
+
+- 3 `site:legistar.com` positive probes per target jurisdiction (proves recall
+  when the portal is excluded).
+- 3 `filetype:pdf` probes per target jurisdiction (proves PDF surfacing).
+- 2 source-family fanout probes per jurisdiction that exercise B4's family
+  routing.
+
+That lifts the corpus to ~35 queries, still small enough to run end-to-end in
+under a minute against a private SearXNG instance. No extra Exa/Tavily
+quota is needed: those providers can be re-run on the full 35 in one deliberate
+bakeoff after B1-B4 and R1-R3 land.
+
+**MVP threshold after fixes**: keep the rubric thresholds unchanged except
+raise `reader_ready_rate` target from `0.65` to `0.70`; the pre-fetch portal
+SKIP list should make this trivially achievable.
+
+## 10. Provider role recommendation
+
+| Provider | Role after fixes | Rationale |
+|---|---|---|
+| **Private SearXNG** | **Primary** | Already has best official-hit rate; no per-query cost; recall is sufficient once portal re-rank lands. |
+| Tavily | Hot fallback | Low latency (446 ms p90), free tier is the constraint — use only when SearXNG recall is empty or all candidates are portal-shape. |
+| Exa | Bakeoff/eval only | Best per-query quality but requires custom UA (`affordabot-dev-bakeoff/1.0`), Cloudflare-sensitive, free tier is capped; reserve for offline quality checks and corpus curation. |
+
+Do **not** lock this until the acceptance criteria in §8 pass.
+
+## 11. Risk ranking and implementation order
+
+| Order | Change | Class | Risk | Unblocks |
+|---|---|---|---|---|
+| 1 | B1 (portal URL penalties) | backend | low — data-only | selects artifact over portal in current bakeoff set |
+| 2 | B2 (artifact URL boosts) | backend | low — data-only | raises SJ median query score |
+| 3 | R1 (pre-fetch portal SKIP) | backend | low — one new pure fn | stops portal reader fetches in Windmill gate |
+| 4 | R2 (reader content floor) | backend | low | catches residual thin-content cases |
+| 5 | S1+S2 (pinned engines + lang + categories) | searxng probe | very low — query-string only | reproducibility; minor recall lift |
+| 6 | §5 source-family query fanout | backend | medium — new fanout code + dedupe | removes dependence on single-query luck |
+| 7 | B4 (thread source_family into ranker) | backend | medium — signature change | precision lift; test churn |
+| 8 | R3 (portal expansion loop) | backend | medium — one extra fetch per run | worst-case recovery if ranker misses |
+| 9 | S4 (time_range=year for action queries) | searxng probe | low — measurable | marginal |
+| 10 | S5 (instance engine weights) | infra | medium — separate PR | not MVP-blocking; tracked under `bd-ybyy7.1` |
+| 11 | §9 corpus expansion | eval | low | gives confidence to lock SearXNG primary |
+
+**Land order for the next implementation PR**: 1, 2, 3, 4, 5 together — these
+are data-only or near-data-only and have no new subsystems. Ship, re-run the
+Windmill San Jose live gate, verify §8 criteria. Then ship 6, 7, 8 in a
+separate PR.
+
+**Do not land** in the MVP-primary PR: S5 (infra), S6 (anti-pattern).
+
+## 12. Commands run (read-only)
+
+```bash
+git fetch origin pull/434/head:pr-434
+dx-worktree create bd-9qjof.8 affordabot         # workspace already existed
+cd /tmp/agents/bd-9qjof.8/affordabot
+git rev-parse HEAD                                # f12d2d6d96632a72d55badcf0bc51255ea6d56fe
+git stash -u                                      # stashed dirty .serena/project.yml
+
+# Memory lookups
+bdx memories searxng --json
+bdx memories windmill --json
+bdx search "searxng search quality" --label memory --status all --json
+bdx search "private searxng" --status all --json
+# → returned bd-ybyy7.1 (private SearXNG infra provisioning task, open, P1)
+
+# Read and grep key files
+docs/poc/search-source-quality-bakeoff/README.md
+docs/poc/search-source-quality-bakeoff/scoring-rubric.md
+docs/poc/search-source-quality-bakeoff/query-corpus.json
+docs/poc/search-source-quality-bakeoff/artifacts/search_source_quality_bakeoff_report.{json,md}
+backend/services/pipeline/domain/commands.py     # rank_reader_candidates, assess_reader_substance
+backend/scripts/verification/verify_search_source_quality_bakeoff.py  # _probe_searxng
+```
+
+**Not run** (would consume Exa/Tavily free-tier quota and are not required for
+a read-only QA pass):
+
+- Live SearXNG-only probes against the Railway instance
+- Exa/Tavily re-bakeoff
+- Windmill San Jose live gate re-run
+
+The April 13 bakeoff JSON already contains the raw SearXNG probe output needed
+to support every claim in this report.
+
+## 13. Open questions for the implementer
+
+1. Is the Railway SearXNG instance's `settings.yml` under source control in
+   this repo, or only on Railway? If only on Railway, S1 (pinned engines via
+   query string) is the safer fix than S5 (instance weights).
+2. Does the backend reader currently have a way to express "this URL is a
+   seed, not a final target" in its persistence model? If not, R3 needs a
+   small schema addition (a `role` or `kind` column on the reader candidates
+   table) before it can land.
+3. The rubric penalizes candidates with `reader_substance=navigation_heavy`
+   after the fact; would the team prefer a blocking pre-fetch SKIP (R1) or a
+   retry-with-fallback? I recommend R1 because it is cheaper, but retry is a
+   smaller behavior change if the schema constraint from (2) is tight.


### PR DESCRIPTION
## Summary

Implements the private SearXNG quality fixes recommended by the consultant review and keeps the review artifact in this PR. The root failure was not SearXNG recall alone: the backend could rank portal/navigation pages above concrete civic artifacts and the verifier could not surface SearXNG fanout/engine-health evidence.

### Product changes
- Strengthened backend ranking so concrete civic artifacts beat portal/directory pages.
- Added live bridge parity for pre-fetch portal skips before Z.ai reader calls.
- Tightened reader substance checks so title-only pages such as `Agendas & Minutes | City of San Jose` do not become accepted evidence.
- Added robust artifact URL recognition for Legistar, Granicus, and municipal AgendaCenter file URLs regardless of query-param order.
- Added SearXNG-only fanout health reporting with candidate classification and deterministic pre-LLM shortlist guidance.

### Evidence
- `docs/research/2026-04-14-private-searxng-quality-review.md`
- SearXNG-only harness temp run after fixes: `/tmp/searxng_only_rebased_report.json`
  - health: `healthy`
  - query coverage: `100%`
  - raw candidates: `274`
  - deduped candidates: `205`
  - final artifacts: `12`
  - selected shortlist starts with concrete official artifacts

## Beads

- Feature-Key: bd-9qjof.8
- Depends on: bd-9qjof.6
- Agent: codex orchestrator + gpt-5.3-codex subagents

## Test plan

- [x] `cd backend && poetry run pytest -q tests/services/pipeline/test_domain_commands.py tests/services/pipeline/test_bridge_runtime.py tests/ops/test_search_source_quality_bakeoff.py` -> `57 passed`
- [x] `cd backend && python3 -m py_compile scripts/verification/verify_search_source_quality_bakeoff.py`
- [x] `git diff --check origin/master..HEAD`
- [x] `cd backend && poetry run python scripts/verification/verify_search_source_quality_bakeoff.py --searxng-only --query-file ../docs/poc/search-source-quality-bakeoff/query-corpus.json --searx-endpoint https://searxng-railway-production-79aa.up.railway.app/search --out-json /tmp/searxng_only_rebased_report.json --out-md /tmp/searxng_only_rebased_report.md`

## Notes

`dx-verify-clean.sh` still fails for environment reasons unrelated to this PR: canonical affordabot is not on master and canonical clones have pre-existing stashes. Work was done in worktrees.