### PR TITLE
bd-s6yjk.9.6: add affordabot repo-memory maps

### DIFF
--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -16,6 +16,16 @@ dx-check
 bd create "title" --type task
 ```
 
+## Repo-Memory Brownfield Maps
+
+Before changing pipeline, storage, Windmill orchestration, analysis, or admin
+frontend surfaces, read:
+- `docs/architecture/README.md`
+- `docs/architecture/BROWNFIELD_MAP.md`
+- `docs/architecture/DATA_AND_STORAGE.md`
+- `docs/architecture/WORKFLOWS_AND_PATTERNS.md`
+- `docs/architecture/ECONOMIC_ANALYSIS_PIPELINE.md`
+
 ## Repo Layout
 
 - `frontend/` - Next.js Prism GUI (canonical frontend)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -676,6 +676,22 @@ VISUAL_BASE_URL=http://localhost:5173 pnpm --filter frontend test:visual:update
 
 ## Repo-Specific Addendum
 
+## Repo-Memory Brownfield Maps
+
+Before changing pipeline, storage, analysis, Windmill orchestration, or admin
+frontend surfaces, read the maintained repo-memory maps:
+
+- `docs/architecture/README.md`
+- `docs/architecture/BROWNFIELD_MAP.md`
+- `docs/architecture/DATA_AND_STORAGE.md`
+- `docs/architecture/WORKFLOWS_AND_PATTERNS.md`
+- `docs/architecture/ECONOMIC_ANALYSIS_PIPELINE.md`
+
+These maps are the repo-owned source of truth for brownfield orientation. Beads
+memory is a pointer/decision log, not proof. Legacy context-area workflows may
+exist in `.github/workflows`; do not treat regenerated context-area output as
+canonical unless a task explicitly targets that legacy system.
+
 ## Beads Integration
 
 ### Beads State Sync

--- a/docs/architecture/BROWNFIELD_MAP.md
+++ b/docs/architecture/BROWNFIELD_MAP.md
@@ -1,0 +1,95 @@
+---
+repo_memory: true
+status: active
+owner: affordabot-architecture
+last_verified_commit: f0a29e3b24e4d7f752614216b44d1d5d084852a2
+last_verified_at: 2026-04-16T16:24:11Z
+stale_if_paths:
+  - backend/**
+  - frontend/**
+  - ops/**
+  - contracts/**
+  - docs/specs/**
+---
+
+# Brownfield Map
+
+Affordabot is not just a web app with a scraper. The product moat is the
+evidence system: source discovery, raw/substrate capture, structured official
+data, provenance, retrieval, reader output, economic analysis, and final
+explanation. Treat pipeline changes as product changes.
+
+## Current Pipeline Shape
+
+- Discovery and scrape entry points are still split across existing backend
+  cron endpoints and newer domain-command experiments. Do not assume the new
+  Windmill domain-boundary POC has replaced every legacy path.
+- `backend/services/pipeline/domain/commands.py` is the important new boundary
+  surface for search execution, candidate ranking, freshness gates, reader
+  calls, indexing, and analysis orchestration.
+- `backend/services/pipeline/domain/in_memory.py` is a POC storage adapter. It
+  proves contracts but is not durable product storage.
+- `ops/windmill/f/affordabot/pipeline_daily_refresh_domain_boundary.py` is the
+  Windmill-native flow harness. Windmill should own scheduling, retries,
+  branching, fanout, and observability; backend/domain code should own product
+  invariants and storage writes.
+- `backend/services/ingestion_service.py` maps raw scrape material into chunks
+  and vector storage. It is part of the data moat and must preserve provenance.
+- `backend/services/glass_box.py` exposes traces and pipeline/admin read-model
+  data. Prefer extending this surface before inventing another admin status
+  API.
+- `frontend/src/services/adminService.ts` is the existing frontend client for
+  admin pipeline/substrate views. Check it before adding any admin panel data
+  surface.
+
+## Source Families
+
+- Scraped search lane: private SearXNG is the intended low-cost primary probe
+  path once quality gates pass; Tavily is a hot fallback candidate; Exa is
+  useful for bakeoffs/evals but cost and quota make it less attractive as the
+  default.
+- Reader lane: Z.ai direct reader remains valuable and should stay canonical
+  unless evidence shows quality failure. Z.ai web search is deprecated as a
+  primary path because repeated tests found it unreliable.
+- Structured lane: OpenStates, Legistar-derived official records, CKAN,
+  ArcGIS, OpenDataSoft, Socrata, static CSV/JSON feeds, and other free
+  API/raw-file sources should run in parallel with scraped search. Do not turn
+  hard-to-ingest portals into a second scraper layer without a separate ROI
+  decision.
+
+## Critical Product Invariants
+
+- Canonical document identity must be stable across scraped and structured
+  lanes. Prefer jurisdiction-scoped identity over URL-only identity.
+- Every claim in the analysis path must point back to raw or structured
+  evidence with provenance.
+- Promotion tiers matter: captured candidate, durable raw artifact, indexed
+  chunk, promoted substrate, and analysis-ready package are different states.
+- Zero-result search is not the same as provider failure. Fallback policies
+  must distinguish weak recall, portal misranking, reader failure, and stale
+  but usable evidence.
+- Windmill reruns whole flows rather than resuming a single failed step. Backend
+  commands and storage writes must be idempotent.
+
+## Known Fragile Areas
+
+- Ranking and reader gates are the likely failure point for scraped sources.
+  Prior San Jose bakeoffs showed SearXNG often found artifact URLs, but backend
+  ranking selected portals instead.
+- Storage proof must include Postgres rows, pgvector derivation, MinIO object
+  readability, replay/idempotency, and admin read-model visibility.
+- Economic analysis quality cannot be inferred from source count. The package
+  must include mechanism, parameters, assumptions, uncertainty, and rejection of
+  unsupported claims.
+- Frontend status/admin work should reuse existing glass-box/admin surfaces
+  unless there is a documented gap.
+
+## Before Changing This Area
+
+Read these first:
+- `docs/specs/2026-04-13-windmill-domain-brownfield-spec-lock.md`
+- `docs/specs/2026-04-14-evidence-package-dependency-lockdown.md`
+- `docs/specs/2026-03-19-affordabot-california-pipeline-truth-remediation.md`
+- `docs/research/2026-04-14-private-searxng-quality-review.md`
+- `docs/architecture/2026-04-12-windmill-affordabot-boundary-adr.md`
+- `docs/architecture/2026-04-13-admin-pipeline-read-model-map.md`

--- a/docs/architecture/BROWNFIELD_MAP.md
+++ b/docs/architecture/BROWNFIELD_MAP.md
@@ -88,7 +88,6 @@ explanation. Treat pipeline changes as product changes.
 
 Read these first:
 - `docs/specs/2026-04-13-windmill-domain-brownfield-spec-lock.md`
-- `docs/specs/2026-04-14-evidence-package-dependency-lockdown.md`
 - `docs/specs/2026-03-19-affordabot-california-pipeline-truth-remediation.md`
 - `docs/research/2026-04-14-private-searxng-quality-review.md`
 - `docs/architecture/2026-04-12-windmill-affordabot-boundary-adr.md`

--- a/docs/architecture/DATA_AND_STORAGE.md
+++ b/docs/architecture/DATA_AND_STORAGE.md
@@ -1,0 +1,90 @@
+---
+repo_memory: true
+status: active
+owner: affordabot-architecture
+last_verified_commit: f0a29e3b24e4d7f752614216b44d1d5d084852a2
+last_verified_at: 2026-04-16T16:24:11Z
+stale_if_paths:
+  - backend/models/**
+  - backend/services/**
+  - backend/db/**
+  - backend/scripts/**
+  - frontend/src/services/**
+  - docs/specs/**
+  - docs/research/**
+  - ops/**
+---
+
+# Data And Storage
+
+Affordabot's durable value is the evidence corpus and its provenance, not the
+fact that a scheduler ran. Storage decisions must preserve the data moat.
+
+## Storage Layers
+
+- Postgres stores source metadata, pipeline runs, step status, raw scrape rows,
+  structured source rows, analysis package metadata, and frontend/admin read
+  models.
+- pgvector is a derived retrieval index over promoted chunks. It is not the
+  source of truth for raw evidence.
+- MinIO stores raw and intermediate artifacts that are too large or too binary
+  for normal relational rows. A stored object is not proven until the pipeline
+  can read it back by storage URI.
+- Backend/domain code owns writes that need product invariants: canonical
+  document key, source provenance, promotion tier, idempotency key, analysis
+  package shape, and economic quality gates.
+- Windmill may pass artifact handles and step outputs, but should not become
+  the keeper of product identity rules.
+
+## Scraped Evidence Lane
+
+Minimum durable record for a scraped candidate:
+- jurisdiction and source family
+- query family and provider
+- result URL, title, snippet, rank, score, and provider metadata
+- candidate classification, portal/artifact signals, and ranker decision
+- reader status, content length, substance verdict, and raw artifact URI
+- canonical document key and promotion tier
+
+Quality gates must measure top-N artifact recall, selected-candidate quality,
+portal skip behavior, reader substance, fallback trigger, and staleness policy.
+
+## Structured Evidence Lane
+
+Minimum durable record for a structured source:
+- source catalog ID and access method
+- jurisdiction coverage and cadence
+- raw fetch URI or API response hash
+- schema version and normalization status
+- canonical entity/document keys
+- provenance link to the official source
+- economic usefulness score and policy-domain tags
+
+Free API/raw-file sources should be favored. A source that requires custom
+browser scraping belongs in the scraped lane, not the structured lane, unless a
+separate product decision approves it.
+
+## Unified Evidence Package
+
+A package passed to economic analysis should combine scraped and structured
+items into one provenance-preserving shape:
+- source inventory with freshness and confidence
+- legislation/action summary and jurisdiction context
+- mechanism candidates
+- parameter table with source-bound values and units
+- assumptions with provenance and uncertainty
+- retrieval chunks and reader excerpts
+- unsupported or missing claims
+
+The package is not analysis-ready until it can be persisted, replayed, read
+from admin/glass-box surfaces, and regenerated idempotently.
+
+## Storage Proof Required
+
+For any pipeline implementation PR, evidence should show:
+- Postgres rows written for run, step, source, package, and analysis metadata
+- pgvector chunks derived from promoted evidence
+- MinIO objects written and read back by URI
+- partial-write recovery or transaction boundaries
+- replay/idempotency with the same canonical keys
+- frontend/admin read model can inspect the run and package

--- a/docs/architecture/ECONOMIC_ANALYSIS_PIPELINE.md
+++ b/docs/architecture/ECONOMIC_ANALYSIS_PIPELINE.md
@@ -66,7 +66,6 @@ A final analysis should be rejected or downgraded when it lacks:
 
 Before redesigning this area, inspect:
 - `docs/specs/2026-03-19-affordabot-california-pipeline-truth-remediation.md`
-- `docs/specs/2026-04-14-evidence-package-dependency-lockdown.md`
 - `docs/research/`
 - backend analysis, prompt, agent, and verification code under `backend/`
 

--- a/docs/architecture/ECONOMIC_ANALYSIS_PIPELINE.md
+++ b/docs/architecture/ECONOMIC_ANALYSIS_PIPELINE.md
@@ -1,0 +1,75 @@
+---
+repo_memory: true
+status: active
+owner: affordabot-architecture
+last_verified_commit: f0a29e3b24e4d7f752614216b44d1d5d084852a2
+last_verified_at: 2026-04-16T16:24:11Z
+stale_if_paths:
+  - backend/services/**
+  - backend/agents/**
+  - backend/prompts/**
+  - llm_common/**
+  - docs/specs/**
+  - docs/research/**
+  - frontend/src/**
+---
+
+# Economic Analysis Pipeline
+
+The final product is not a scrape report. It is a source-grounded economic
+analysis of how policy affects cost of living. The evidence pipeline exists to
+make that analysis trustworthy.
+
+## Required Analysis Inputs
+
+An analysis-ready package should include:
+- policy action and jurisdiction context
+- source-bound facts from scraped and structured evidence
+- mechanism hypotheses
+- parameter table with units, values, source links, and confidence
+- secondary research needs
+- uncertainty and sensitivity ranges
+- explicit unsupported or missing claims
+
+For indirect costs, the package must support a mechanism chain. Example class:
+a land-use or parking rule may affect construction cost, which may affect unit
+price or rents, which may affect household cost burden. The system should not
+pretend the raw meeting agenda alone is enough.
+
+## Secondary Research
+
+The economic analysis agent may need a second research pass. That pass should
+be explicit and auditable:
+- query family and provider
+- source quality classification
+- reader output
+- parameters extracted
+- citations retained
+- missing evidence called out
+
+Do not collapse this into the first local-government source-gathering pass.
+The two passes answer different questions: what happened locally, and what
+economic evidence supports the cost mechanism.
+
+## Quality Rubric
+
+A final analysis should be rejected or downgraded when it lacks:
+- mechanism graph from policy action to household/business impact
+- parameter table with source-bound assumptions
+- quantitative estimate or a justified refusal to estimate
+- uncertainty/sensitivity range
+- citations for every material claim
+- distinction between direct fiscal cost, compliance cost, housing supply cost,
+  consumer price effect, and distributional impact
+
+## Existing Evidence To Reuse
+
+Before redesigning this area, inspect:
+- `docs/specs/2026-03-19-affordabot-california-pipeline-truth-remediation.md`
+- `docs/specs/2026-04-14-evidence-package-dependency-lockdown.md`
+- `docs/research/`
+- backend analysis, prompt, agent, and verification code under `backend/`
+
+The known risk is rediscovering existing economic-analysis work while focusing
+too narrowly on search quality. Start with code and docs map review, then run
+POCs that connect evidence quality to analysis quality.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,33 @@
+---
+repo_memory: true
+status: active
+owner: affordabot-architecture
+last_verified_commit: f0a29e3b24e4d7f752614216b44d1d5d084852a2
+last_verified_at: 2026-04-16T16:24:11Z
+stale_if_paths:
+  - backend/**
+  - frontend/**
+  - ops/**
+  - docs/specs/**
+  - docs/research/**
+  - contracts/**
+---
+
+# Architecture Docs Index
+
+This directory contains the repo-owned brownfield maps for Affordabot. These
+maps are the first source to read before changing the pipeline, storage model,
+or analysis surface.
+
+- `BROWNFIELD_MAP.md`: current codebase map from source discovery through
+  backend commands, storage, analysis, and frontend/admin read models.
+- `DATA_AND_STORAGE.md`: product data moat, Postgres/pgvector/MinIO ownership,
+  and how scraped plus structured evidence should be persisted.
+- `WORKFLOWS_AND_PATTERNS.md`: Windmill/backend/frontend/storage boundaries and
+  operational workflow patterns.
+- `ECONOMIC_ANALYSIS_PIPELINE.md`: economic analysis path, evidence packaging
+  expectations, and known gaps before decision-grade analysis.
+
+These files are maintained by the repo-memory freshness contract. Beads memory
+is a pointer and decision log; these maps are the repo-owned source of truth for
+brownfield orientation.

--- a/docs/architecture/WORKFLOWS_AND_PATTERNS.md
+++ b/docs/architecture/WORKFLOWS_AND_PATTERNS.md
@@ -1,0 +1,92 @@
+---
+repo_memory: true
+status: active
+owner: affordabot-architecture
+last_verified_commit: f0a29e3b24e4d7f752614216b44d1d5d084852a2
+last_verified_at: 2026-04-16T16:24:11Z
+stale_if_paths:
+  - ops/**
+  - backend/services/pipeline/**
+  - backend/api/**
+  - backend/routes/**
+  - backend/scripts/verification/**
+  - frontend/src/**
+  - .github/workflows/**
+---
+
+# Workflows And Patterns
+
+## Boundary Rule
+
+Use Windmill maximally for orchestration, not for product logic.
+
+Windmill owns:
+- schedules
+- retries and backoff
+- branch/for-loop/fanout control
+- job visibility
+- manual reruns and approvals where useful
+- passing handles between coarse steps
+
+Backend/domain code owns:
+- provider contracts
+- ranker and reader quality rules
+- canonical document identity
+- storage writes and idempotency
+- promotion tiers
+- evidence package contract
+- economic analysis gates
+- frontend/admin read models
+
+## Preferred Flow Shape
+
+The preferred pipeline is a Windmill flow that calls coarse domain commands:
+search/materialize, rank/read, freshness gate, persist/promote/index, package,
+analyze, and publish/admin read model. Avoid step-by-step business logic in
+Windmill scripts.
+
+Windmill does not provide true resume-from-step for arbitrary Python state.
+Design reruns as full-flow retries where backend commands deduplicate by
+idempotency keys and canonical document identity.
+
+## Provider Strategy
+
+- Private SearXNG: primary low-cost search candidate after metric gates pass.
+- Tavily: hot fallback for higher quality/managed search when private search
+  quality is weak.
+- Exa: bakeoff/evaluation lane unless cost/quality evidence changes.
+- Z.ai direct reader: canonical reader path while it continues to perform well.
+- Z.ai web search: deprecated primary path; keep only a scheduled/manual
+  health check for recovery evidence.
+- Z.ai LLM analysis: still canonical for analysis unless a later quality review
+  changes the model boundary.
+
+## Verification Pattern
+
+Every meaningful pipeline POC should produce machine-readable artifacts plus a
+human audit summary:
+- provider/query metrics
+- selected candidates and skipped portals
+- reader output with substance verdict
+- persisted storage handles
+- chunk/index status
+- evidence package JSON
+- economic analysis output
+- unsupported-claim list
+- admin/glass-box visibility
+
+Do not call a POC successful only because a flow completed. The acceptance
+question is whether the resulting package is good enough for quantitative
+economic analysis.
+
+## Frontend Pattern
+
+Frontend is a display and review layer. It should read backend/admin APIs and
+show status, provenance, evidence packages, and final analysis. It should not
+own search, scraping, storage, or economic inference.
+
+Before adding a new admin route or status panel, check:
+- `backend/services/glass_box.py`
+- existing admin API routes
+- `frontend/src/services/adminService.ts`
+- existing admin components

--- a/fragments/repo-addendum.md
+++ b/fragments/repo-addendum.md
@@ -1,3 +1,19 @@
+## Repo-Memory Brownfield Maps
+
+Before changing pipeline, storage, analysis, Windmill orchestration, or admin
+frontend surfaces, read the maintained repo-memory maps:
+
+- `docs/architecture/README.md`
+- `docs/architecture/BROWNFIELD_MAP.md`
+- `docs/architecture/DATA_AND_STORAGE.md`
+- `docs/architecture/WORKFLOWS_AND_PATTERNS.md`
+- `docs/architecture/ECONOMIC_ANALYSIS_PIPELINE.md`
+
+These maps are the repo-owned source of truth for brownfield orientation. Beads
+memory is a pointer/decision log, not proof. Legacy context-area workflows may
+exist in `.github/workflows`; do not treat regenerated context-area output as
+canonical unless a task explicitly targets that legacy system.
+
 ## Beads Integration
 
 ### Beads State Sync


### PR DESCRIPTION
Agent: codex

## Summary
- add repo-owned brownfield maps for Affordabot pipeline, storage, workflows, and economic analysis
- wire AGENTS.md and AGENTS.local.md to the maps through the repo addendum
- document the data moat boundary across scraped search, structured sources, storage, Windmill, backend, and frontend/admin read models

## Verification
- scripts/agents-md-compile.zsh
- dx-repo-memory-check --repo . --base-ref origin/master
- dx-repo-memory-audit --repo .
- git diff --check

Feature-Key: bd-s6yjk.9.6