### PR TITLE
bd-3wefe.13.4.11: Cycle 53 structured-source runtime proof overlay

### DIFF
--- a/backend/scripts/verification/regenerate_local_government_corpus_scorecard.py
+++ b/backend/scripts/verification/regenerate_local_government_corpus_scorecard.py
@@ -29,6 +29,14 @@ DEFAULT_WINDMILL_ORCHESTRATION_PATH = (
     / "artifacts"
     / "local_government_corpus_windmill_orchestration.json"
 )
+DEFAULT_STRUCTURED_SOURCE_PROOF_PATH = (
+    ROOT
+    / "docs"
+    / "poc"
+    / "policy-evidence-quality-spine"
+    / "artifacts"
+    / "local_government_corpus_structured_source_proof.json"
+)
 DEFAULT_SCORECARD_PATH = (
     ROOT
     / "docs"
@@ -119,6 +127,54 @@ def _row_id_list(value: Any) -> list[str]:
     return rows
 
 
+def _live_structured_attempt_rows(artifact: dict[str, Any]) -> list[str]:
+    rows: set[str] = set()
+    for key in ("attempts", "rows"):
+        payloads = artifact.get(key)
+        if not isinstance(payloads, list):
+            continue
+        for payload in payloads:
+            if not isinstance(payload, dict):
+                continue
+            row_id = str(payload.get("corpus_row_id") or "")
+            if not row_id:
+                continue
+            proof_status = str(
+                payload.get("proof_status")
+                or payload.get("status")
+                or payload.get("row_status")
+                or ""
+            ).strip()
+            if proof_status.lower() not in {"live_proven", "proven"}:
+                continue
+            rows.add(row_id)
+    return sorted(rows)
+
+
+def _blocked_structured_attempt_rows(artifact: dict[str, Any]) -> list[str]:
+    rows: set[str] = set()
+    for key in ("attempts", "rows"):
+        payloads = artifact.get(key)
+        if not isinstance(payloads, list):
+            continue
+        for payload in payloads:
+            if not isinstance(payload, dict):
+                continue
+            row_id = str(payload.get("corpus_row_id") or "")
+            if not row_id:
+                continue
+            proof_status = str(
+                payload.get("proof_status")
+                or payload.get("status")
+                or payload.get("row_status")
+                or ""
+            ).strip()
+            blocker = str(payload.get("blocker_class") or payload.get("blocker") or "")
+            if proof_status.lower() == "blocked" or blocker:
+                rows.add(row_id)
+    return sorted(rows)
+
+
 def _overlay_burndown_summary(artifact: dict[str, Any]) -> dict[str, Any]:
     post_metrics = artifact.get("post_metrics")
     if not isinstance(post_metrics, dict):
@@ -152,10 +208,26 @@ def _overlay_burndown_summary(artifact: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _structured_overlay_burndown_summary(artifact: dict[str, Any]) -> dict[str, Any]:
+    summary = artifact.get("summary")
+    if not isinstance(summary, dict):
+        summary = {}
+    return {
+        "attempted_row_count": int(summary.get("attempted_row_count") or 0),
+        "live_proven_count": int(summary.get("live_proven_count") or 0),
+        "blocked_count": int(summary.get("blocked_count") or 0),
+        "attempted_row_ids": _row_id_list(summary.get("attempted_row_ids")),
+        "live_proven_row_ids": _row_id_list(summary.get("live_proven_row_ids")),
+        "blocked_row_ids": _row_id_list(summary.get("blocked_row_ids")),
+    }
+
+
 def _build_artifact_inputs(
     *,
     windmill_orchestration_path: Path,
     windmill_orchestration_artifact: dict[str, Any],
+    structured_source_proof_path: Path,
+    structured_source_proof_artifact: dict[str, Any],
 ) -> dict[str, Any]:
     return {
         "windmill_orchestration_artifact": _repo_relative(windmill_orchestration_path),
@@ -175,6 +247,21 @@ def _build_artifact_inputs(
         "windmill_overlay_burndown_summary": _overlay_burndown_summary(
             windmill_orchestration_artifact
         ),
+        "structured_source_proof_artifact": _repo_relative(structured_source_proof_path),
+        "structured_source_proof_digest": _hash_payload(structured_source_proof_artifact),
+        "structured_source_proof_generated_at": structured_source_proof_artifact.get(
+            "generated_at"
+        ),
+        "structured_source_live_attempt_rows": _live_structured_attempt_rows(
+            structured_source_proof_artifact
+        ),
+        "structured_source_blocked_attempt_rows": _blocked_structured_attempt_rows(
+            structured_source_proof_artifact
+        ),
+        "structured_source_overlay_burndown_summary": _structured_overlay_burndown_summary(
+            structured_source_proof_artifact
+        ),
+        "structured_overlay_applied": True,
         "overlay_applied": True,
     }
 
@@ -183,19 +270,24 @@ def run(
     *,
     matrix_path: Path,
     windmill_orchestration_path: Path,
+    structured_source_proof_path: Path,
     scorecard_output_path: Path,
     report_output_path: Path,
 ) -> dict[str, Any]:
     matrix = _load_json(matrix_path)
     windmill_orchestration_artifact = _load_json(windmill_orchestration_path)
+    structured_source_proof_artifact = _load_json(structured_source_proof_path)
     service = LocalGovernmentCorpusBenchmarkService()
     scorecard = service.evaluate(
         matrix=matrix,
         windmill_orchestration_artifact=windmill_orchestration_artifact,
+        structured_source_proof_artifact=structured_source_proof_artifact,
     )
     scorecard["artifact_inputs"] = _build_artifact_inputs(
         windmill_orchestration_path=windmill_orchestration_path,
         windmill_orchestration_artifact=windmill_orchestration_artifact,
+        structured_source_proof_path=structured_source_proof_path,
+        structured_source_proof_artifact=structured_source_proof_artifact,
     )
 
     report_markdown = service.render_markdown_report(matrix=matrix, scorecard=scorecard)
@@ -220,6 +312,11 @@ def _parse_args() -> argparse.Namespace:
         type=Path,
         default=DEFAULT_WINDMILL_ORCHESTRATION_PATH,
     )
+    parser.add_argument(
+        "--structured-source-proof-path",
+        type=Path,
+        default=DEFAULT_STRUCTURED_SOURCE_PROOF_PATH,
+    )
     parser.add_argument("--scorecard-out", type=Path, default=DEFAULT_SCORECARD_PATH)
     parser.add_argument("--report-out", type=Path, default=DEFAULT_REPORT_PATH)
     return parser.parse_args()
@@ -230,13 +327,18 @@ def main() -> int:
     result = run(
         matrix_path=args.matrix_path,
         windmill_orchestration_path=args.windmill_orchestration_path,
+        structured_source_proof_path=args.structured_source_proof_path,
         scorecard_output_path=args.scorecard_out,
         report_output_path=args.report_out,
     )
     c13 = ((result["scorecard"].get("gates") or {}).get("C13") or {})
+    c2 = ((result["scorecard"].get("gates") or {}).get("C2") or {})
     metrics = c13.get("metrics") or {}
+    c2_metrics = c2.get("metrics") or {}
     print(
         "local_government_corpus_scorecard regenerated: "
+        f"c2_status={c2.get('status')} "
+        f"live_structured_coverage_ratio={c2_metrics.get('live_structured_coverage_ratio')} "
         f"c13_status={c13.get('status')} "
         f"seeded_not_live_proven_rows={metrics.get('seeded_not_live_proven_rows')} "
         f"corpus_state={result['scorecard'].get('corpus_state')}"

--- a/backend/scripts/verification/verify_local_government_corpus_structured_source_proof.py
+++ b/backend/scripts/verification/verify_local_government_corpus_structured_source_proof.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Probe/fail-close structured-source runtime proof for local-government corpus rows."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+from urllib import error, request
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_MATRIX_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "poc"
+    / "policy-evidence-quality-spine"
+    / "artifacts"
+    / "local_government_corpus_matrix.json"
+)
+DEFAULT_OUTPUT_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "poc"
+    / "policy-evidence-quality-spine"
+    / "artifacts"
+    / "local_government_corpus_structured_source_proof.json"
+)
+DEFAULT_TARGET_ROW_IDS = ("lgm-065",)
+FEATURE_KEY = "bd-3wefe.13.4.11"
+SCHEMA_VERSION = "local_government_corpus_structured_source_proof_v1"
+CONTRACT_VERSION = "2026-04-25.structured-source-proof.v1"
+
+
+@dataclass(frozen=True)
+class ProbeRecipe:
+    endpoint_url: str
+    access_method: str
+    normalized_fields: tuple[str, ...]
+
+
+PROBE_RECIPES: dict[tuple[str, str, str], ProbeRecipe] = {
+    (
+        "austin_tx",
+        "socrata_api",
+        "affordability_units",
+    ): ProbeRecipe(
+        endpoint_url="https://data.austintexas.gov/resource/2h5e-ntwt.json?$limit=5",
+        access_method="http_get_json",
+        normalized_fields=(
+            "_10_to_19_units",
+            "_20_units",
+            "_2023_population",
+        ),
+    ),
+}
+
+
+def _iso_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        msg = f"expected object JSON at {path}"
+        raise ValueError(msg)
+    return payload
+
+
+def _hash_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _hash_payload(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return _hash_bytes(encoded)
+
+
+def _row_by_id(matrix: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    rows: dict[str, dict[str, Any]] = {}
+    for row in matrix.get("rows", []):
+        if not isinstance(row, dict):
+            continue
+        if row.get("row_type") != "corpus_package":
+            continue
+        row_id = str(row.get("corpus_row_id") or "")
+        if row_id:
+            rows[row_id] = row
+    return rows
+
+
+def _first_matching_observation(row: dict[str, Any]) -> dict[str, Any] | None:
+    observations = row.get("structured_source_observations")
+    if not isinstance(observations, list):
+        return None
+    for observation in observations:
+        if not isinstance(observation, dict):
+            continue
+        if not bool(observation.get("true_structured")):
+            continue
+        if str(observation.get("proof_status") or "") != "cataloged_intent":
+            continue
+        return observation
+    return None
+
+
+def _blocked_attempt(
+    *,
+    row: dict[str, Any] | None,
+    corpus_row_id: str,
+    source_family: str,
+    extraction_depth: str,
+    blocker_class: str,
+    blocker_detail: str,
+    proof_source: str = "structured_source_runtime_probe",
+) -> dict[str, Any]:
+    jurisdiction_id = ""
+    package_id = ""
+    known_policy_reference_id = ""
+    if isinstance(row, dict):
+        jurisdiction_id = str((row.get("jurisdiction") or {}).get("id") or "")
+        package_id = str(row.get("package_id") or "")
+        known_policy_reference_id = str(row.get("known_policy_reference_id") or "")
+    return {
+        "corpus_row_id": corpus_row_id,
+        "package_id": package_id,
+        "known_policy_reference_id": known_policy_reference_id,
+        "jurisdiction_id": jurisdiction_id,
+        "source_family": source_family,
+        "extraction_depth": extraction_depth,
+        "proof_status": "blocked",
+        "proof_source": proof_source,
+        "blocker_class": blocker_class,
+        "blocker_detail": blocker_detail,
+        "retrieved_at": _iso_now(),
+    }
+
+
+def _probe_row(
+    *,
+    row: dict[str, Any],
+    source_family: str,
+    extraction_depth: str,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    jurisdiction_id = str((row.get("jurisdiction") or {}).get("id") or "")
+    package_id = str(row.get("package_id") or "")
+    known_policy_reference_id = str(row.get("known_policy_reference_id") or "")
+    corpus_row_id = str(row.get("corpus_row_id") or "")
+
+    recipe = PROBE_RECIPES.get((jurisdiction_id, source_family, extraction_depth))
+    if recipe is None:
+        return _blocked_attempt(
+            row=row,
+            corpus_row_id=corpus_row_id,
+            source_family=source_family,
+            extraction_depth=extraction_depth,
+            blocker_class="probe_recipe_missing",
+            blocker_detail=(
+                "No runtime probe recipe for jurisdiction/source_family/depth tuple."
+            ),
+        )
+
+    request_obj = request.Request(
+        recipe.endpoint_url,
+        headers={"User-Agent": "affordabot-cycle53-structured-proof/1.0"},
+    )
+    try:
+        with request.urlopen(request_obj, timeout=timeout_seconds) as response:
+            response_body = response.read()
+            http_status = int(response.getcode() or 0)
+    except error.HTTPError as exc:
+        return _blocked_attempt(
+            row=row,
+            corpus_row_id=corpus_row_id,
+            source_family=source_family,
+            extraction_depth=extraction_depth,
+            blocker_class="http_error",
+            blocker_detail=f"HTTP {exc.code}: {exc.reason}",
+        )
+    except error.URLError as exc:
+        return _blocked_attempt(
+            row=row,
+            corpus_row_id=corpus_row_id,
+            source_family=source_family,
+            extraction_depth=extraction_depth,
+            blocker_class="network_error",
+            blocker_detail=str(exc.reason),
+        )
+
+    retrieved_at = _iso_now()
+    response_hash = _hash_bytes(response_body)
+    try:
+        payload = json.loads(response_body.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        return _blocked_attempt(
+            row=row,
+            corpus_row_id=corpus_row_id,
+            source_family=source_family,
+            extraction_depth=extraction_depth,
+            blocker_class="invalid_json",
+            blocker_detail=str(exc),
+        )
+
+    rows: list[dict[str, Any]] = []
+    if isinstance(payload, list):
+        rows = [item for item in payload if isinstance(item, dict)]
+    elif isinstance(payload, dict):
+        rows = [payload]
+    sample_row_count = len(rows)
+    if sample_row_count == 0:
+        return _blocked_attempt(
+            row=row,
+            corpus_row_id=corpus_row_id,
+            source_family=source_family,
+            extraction_depth=extraction_depth,
+            blocker_class="empty_payload",
+            blocker_detail="Structured endpoint returned no object/list rows.",
+        )
+
+    first_row = rows[0]
+    normalized_fields_proven = [
+        field for field in recipe.normalized_fields if field in first_row
+    ]
+    schema_fields = sorted(first_row.keys())
+    schema_hash = _hash_bytes(
+        json.dumps(schema_fields, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+
+    proof_status = "live_proven"
+    blocker_class = ""
+    blocker_detail = ""
+    if http_status != 200:
+        proof_status = "blocked"
+        blocker_class = "non_200_status"
+        blocker_detail = f"Expected HTTP 200, received {http_status}."
+    elif not normalized_fields_proven:
+        proof_status = "blocked"
+        blocker_class = "normalized_fields_missing"
+        blocker_detail = "No required normalized fields present in first row."
+
+    result = {
+        "corpus_row_id": corpus_row_id,
+        "package_id": package_id,
+        "known_policy_reference_id": known_policy_reference_id,
+        "jurisdiction_id": jurisdiction_id,
+        "source_family": source_family,
+        "extraction_depth": extraction_depth,
+        "proof_status": proof_status,
+        "proof_source": "structured_source_runtime_probe",
+        "endpoint_url": recipe.endpoint_url,
+        "access_method": recipe.access_method,
+        "retrieved_at": retrieved_at,
+        "http_status": http_status,
+        "response_hash": response_hash,
+        "schema_hash": schema_hash,
+        "sample_row_count": sample_row_count,
+        "normalized_fields_proven": normalized_fields_proven,
+    }
+    if blocker_class:
+        result["blocker_class"] = blocker_class
+    if blocker_detail:
+        result["blocker_detail"] = blocker_detail
+    return result
+
+
+def run(
+    *,
+    matrix_path: Path,
+    target_row_ids: list[str],
+    timeout_seconds: int,
+    out_path: Path,
+) -> dict[str, Any]:
+    matrix = _load_json(matrix_path)
+    rows_by_id = _row_by_id(matrix)
+
+    attempts: list[dict[str, Any]] = []
+    for row_id in target_row_ids:
+        row = rows_by_id.get(row_id)
+        if row is None:
+            attempts.append(
+                _blocked_attempt(
+                    row=None,
+                    corpus_row_id=row_id,
+                    source_family="unknown",
+                    extraction_depth="unknown",
+                    blocker_class="row_not_found",
+                    blocker_detail="Target row id not present in matrix.",
+                )
+            )
+            continue
+
+        observation = _first_matching_observation(row)
+        if observation is None:
+            attempts.append(
+                _blocked_attempt(
+                    row=row,
+                    corpus_row_id=row_id,
+                    source_family="unknown",
+                    extraction_depth="unknown",
+                    blocker_class="cataloged_target_missing",
+                    blocker_detail=(
+                        "No true_structured cataloged_intent observation found on row."
+                    ),
+                )
+            )
+            continue
+
+        source_family = str(observation.get("source_family") or "")
+        extraction_depth = str(observation.get("depth") or "")
+        attempts.append(
+            _probe_row(
+                row=row,
+                source_family=source_family,
+                extraction_depth=extraction_depth,
+                timeout_seconds=timeout_seconds,
+            )
+        )
+
+    live_proven_rows = [
+        str(item.get("corpus_row_id") or "")
+        for item in attempts
+        if str(item.get("proof_status") or "") == "live_proven"
+    ]
+    blocked_rows = [
+        str(item.get("corpus_row_id") or "")
+        for item in attempts
+        if str(item.get("proof_status") or "") == "blocked"
+    ]
+
+    artifact = {
+        "schema_version": SCHEMA_VERSION,
+        "feature_key": FEATURE_KEY,
+        "contract_version": CONTRACT_VERSION,
+        "generated_at": _iso_now(),
+        "benchmark_id": str(matrix.get("benchmark_id") or ""),
+        "matrix_digest": _hash_payload(matrix),
+        "attempts": attempts,
+        "rows": attempts,
+        "summary": {
+            "attempted_row_count": len(attempts),
+            "live_proven_count": len(live_proven_rows),
+            "blocked_count": len(blocked_rows),
+            "attempted_row_ids": target_row_ids,
+            "live_proven_row_ids": live_proven_rows,
+            "blocked_row_ids": blocked_rows,
+        },
+    }
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(artifact, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return artifact
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--matrix-path", type=Path, default=DEFAULT_MATRIX_PATH)
+    parser.add_argument("--target-row-id", action="append", default=[])
+    parser.add_argument("--timeout-seconds", type=int, default=20)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUTPUT_PATH)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    target_row_ids = (
+        [str(row_id) for row_id in args.target_row_id if str(row_id).strip()]
+        or list(DEFAULT_TARGET_ROW_IDS)
+    )
+    artifact = run(
+        matrix_path=args.matrix_path,
+        target_row_ids=target_row_ids,
+        timeout_seconds=args.timeout_seconds,
+        out_path=args.out,
+    )
+    summary = artifact.get("summary") or {}
+    print(
+        "local_government_corpus_structured_source_proof: "
+        f"attempted={summary.get('attempted_row_count')} "
+        f"live_proven={summary.get('live_proven_count')} "
+        f"blocked={summary.get('blocked_count')}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/services/pipeline/local_government_corpus_benchmark.py
+++ b/backend/services/pipeline/local_government_corpus_benchmark.py
@@ -1600,40 +1600,51 @@ class LocalGovernmentCorpusBenchmarkService:
         matrix: dict[str, Any],
         windmill_orchestration_artifact: dict[str, Any] | None = None,
         windmill_row_proof_overlay: dict[str, dict[str, Any]] | None = None,
+        structured_source_proof_artifact: dict[str, Any] | None = None,
+        structured_source_row_proof_overlay: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         rows = [
             row
             for row in matrix.get("rows", [])
             if isinstance(row, dict) and row.get("row_type") == "corpus_package"
         ]
-        c13_rows = self._build_c13_rows_with_proof_overlay(
+        structured_rows = self._build_rows_with_structured_source_proof_overlay(
             matrix=matrix,
             rows=rows,
+            structured_source_proof_artifact=structured_source_proof_artifact,
+            structured_source_row_proof_overlay=structured_source_row_proof_overlay,
+        )
+        c13_rows = self._build_c13_rows_with_proof_overlay(
+            matrix=matrix,
+            rows=structured_rows,
             windmill_orchestration_artifact=windmill_orchestration_artifact,
             windmill_row_proof_overlay=windmill_row_proof_overlay,
         )
 
         gate_results: dict[str, GateResult] = {
-            "C0": self._evaluate_c0(matrix=matrix, rows=rows),
-            "C1": self._evaluate_c1(rows=rows),
-            "C2": self._evaluate_c2(rows=rows),
-            "C3": self._evaluate_c3(rows=rows),
-            "C4": self._evaluate_c4(rows=rows),
-            "C5": self._evaluate_c5(rows=rows),
-            "C6": self._evaluate_c6(matrix=matrix, rows=rows),
-            "C7": self._evaluate_c7(rows=rows),
-            "C8": self._evaluate_c8(rows=rows),
-            "C9": self._evaluate_c9(rows=rows),
+            "C0": self._evaluate_c0(matrix=matrix, rows=structured_rows),
+            "C1": self._evaluate_c1(rows=structured_rows),
+            "C2": self._evaluate_c2(rows=structured_rows),
+            "C3": self._evaluate_c3(rows=structured_rows),
+            "C4": self._evaluate_c4(rows=structured_rows),
+            "C5": self._evaluate_c5(rows=structured_rows),
+            "C6": self._evaluate_c6(matrix=matrix, rows=structured_rows),
+            "C7": self._evaluate_c7(rows=structured_rows),
+            "C8": self._evaluate_c8(rows=structured_rows),
+            "C9": self._evaluate_c9(rows=structured_rows),
             "C9a": self._evaluate_c9a(matrix=matrix),
-            "C10": self._evaluate_c10(rows=rows),
-            "C11": self._evaluate_c11(matrix=matrix, rows=rows),
-            "C12": self._evaluate_c12(matrix=matrix, rows=rows),
+            "C10": self._evaluate_c10(rows=structured_rows),
+            "C11": self._evaluate_c11(matrix=matrix, rows=structured_rows),
+            "C12": self._evaluate_c12(matrix=matrix, rows=structured_rows),
             "C13": self._evaluate_c13(matrix=matrix, rows=c13_rows),
-            "C14": self._evaluate_c14(matrix=matrix, rows=rows),
+            "C14": self._evaluate_c14(matrix=matrix, rows=structured_rows),
         }
 
-        core_metrics = self._build_core_metrics(rows=rows, gate_results=gate_results)
-        package_gate_projection = self._build_package_gate_projection(rows=rows)
+        core_metrics = self._build_core_metrics(
+            rows=structured_rows,
+            gate_results=gate_results,
+        )
+        package_gate_projection = self._build_package_gate_projection(rows=structured_rows)
         gate_json = {gate_id: gate.to_json() for gate_id, gate in gate_results.items()}
         corpus_state = self._derive_corpus_state(gates=gate_json)
         next_blocker = self._derive_next_blocker(gates=gate_json)
@@ -1650,8 +1661,10 @@ class LocalGovernmentCorpusBenchmarkService:
             "matrix_digest": _hash_payload(matrix),
             "matrix_summary": {
                 "row_count_total": len(matrix.get("rows", [])),
-                "package_row_count": len(rows),
-                "milestone_row_count": len(matrix.get("rows", [])) - len(rows),
+                "package_row_count": len(structured_rows),
+                "milestone_row_count": (
+                    len(matrix.get("rows", [])) - len(structured_rows)
+                ),
                 "seed_mode": matrix.get("seed_mode"),
                 "corpus_readiness_target": matrix.get("corpus_readiness_target"),
             },
@@ -2921,6 +2934,306 @@ class LocalGovernmentCorpusBenchmarkService:
             overlaid_rows.append(overlaid_row)
 
         return overlaid_rows
+
+    def _build_rows_with_structured_source_proof_overlay(
+        self,
+        *,
+        matrix: dict[str, Any],
+        rows: list[dict[str, Any]],
+        structured_source_proof_artifact: dict[str, Any] | None,
+        structured_source_row_proof_overlay: dict[str, Any] | None,
+    ) -> list[dict[str, Any]]:
+        overlay_by_row_id = self._collect_structured_source_row_overlay(
+            matrix=matrix,
+            structured_source_proof_artifact=structured_source_proof_artifact,
+            structured_source_row_proof_overlay=structured_source_row_proof_overlay,
+        )
+        if not overlay_by_row_id:
+            return rows
+
+        overlaid_rows: list[dict[str, Any]] = []
+        for row in rows:
+            row_id = str(row.get("corpus_row_id") or "")
+            row_overlays = overlay_by_row_id.get(row_id)
+            if not row_overlays:
+                overlaid_rows.append(row)
+                continue
+
+            jurisdiction_id = str((row.get("jurisdiction") or {}).get("id") or "")
+            package_id = str(row.get("package_id") or "")
+            known_policy_reference_id = str(row.get("known_policy_reference_id") or "")
+
+            observations = row.get("structured_source_observations")
+            if not isinstance(observations, list):
+                overlaid_rows.append(row)
+                continue
+
+            overlaid_observations: list[dict[str, Any]] = []
+            upgraded_depths: set[str] = set()
+            matched_proofs: list[dict[str, Any]] = []
+            changed = False
+
+            for observation in observations:
+                if not isinstance(observation, dict):
+                    overlaid_observations.append(observation)
+                    continue
+                overlaid_observation = dict(observation)
+                for proof in row_overlays:
+                    if str(proof.get("proof_status") or "") not in LIVE_STRUCTURED_PROOF_STATUSES:
+                        continue
+                    if str(proof.get("jurisdiction_id") or "") != jurisdiction_id:
+                        continue
+                    proof_package_id = str(proof.get("package_id") or "")
+                    if proof_package_id and proof_package_id != package_id:
+                        continue
+                    proof_known_policy_reference_id = str(
+                        proof.get("known_policy_reference_id") or ""
+                    )
+                    if (
+                        proof_known_policy_reference_id
+                        and proof_known_policy_reference_id != known_policy_reference_id
+                    ):
+                        continue
+                    if not bool(overlaid_observation.get("true_structured")):
+                        continue
+                    if (
+                        str(overlaid_observation.get("source_family") or "")
+                        != str(proof.get("source_family") or "")
+                    ):
+                        continue
+                    if str(overlaid_observation.get("depth") or "") != str(
+                        proof.get("extraction_depth") or ""
+                    ):
+                        continue
+
+                    overlaid_observation["live_proven"] = True
+                    overlaid_observation["proof_status"] = "live_proven"
+                    overlaid_observation["proof_source"] = str(
+                        proof.get("proof_source")
+                        or "structured_source_runtime_proof_artifact"
+                    )
+                    runtime_proof = {
+                        key: value
+                        for key, value in proof.items()
+                        if key
+                        in {
+                            "endpoint_url",
+                            "access_method",
+                            "retrieved_at",
+                            "http_status",
+                            "response_hash",
+                            "schema_hash",
+                            "sample_row_count",
+                            "normalized_fields_proven",
+                            "proof_source",
+                        }
+                        and value is not None
+                        and value != ""
+                        and value != []
+                    }
+                    if runtime_proof:
+                        overlaid_observation["runtime_proof"] = runtime_proof
+                        matched_proofs.append(runtime_proof)
+                    upgraded_depths.add(str(overlaid_observation.get("depth") or ""))
+                    changed = True
+                    break
+                overlaid_observations.append(overlaid_observation)
+
+            if not changed:
+                overlaid_rows.append(row)
+                continue
+
+            overlaid_row = dict(row)
+            overlaid_row["structured_source_observations"] = overlaid_observations
+            overlaid_row["source_infrastructure_status"] = "live_integrated"
+
+            infrastructure_status = row.get("infrastructure_status")
+            overlaid_infrastructure_status = (
+                dict(infrastructure_status)
+                if isinstance(infrastructure_status, dict)
+                else {}
+            )
+            overlaid_infrastructure_status["source_lane_status"] = "live_integrated"
+            if matched_proofs:
+                overlaid_infrastructure_status["structured_source_runtime_proofs"] = (
+                    matched_proofs
+                )
+            overlaid_row["infrastructure_status"] = overlaid_infrastructure_status
+
+            extraction_depth = row.get("extraction_depth")
+            if isinstance(extraction_depth, dict) and upgraded_depths:
+                overlaid_extraction_depth = dict(extraction_depth)
+                overlaid_extraction_depth["live_exercised"] = True
+                overlaid_extraction_depth["proof_status"] = "live_proven"
+                overlaid_extraction_depth["proof_source"] = str(
+                    matched_proofs[0].get("proof_source")
+                    if matched_proofs
+                    else "structured_source_runtime_proof_artifact"
+                )
+                overlaid_row["extraction_depth"] = overlaid_extraction_depth
+
+            if matched_proofs:
+                overlaid_row["structured_source_runtime_proofs"] = matched_proofs
+            overlaid_rows.append(overlaid_row)
+
+        return overlaid_rows
+
+    def _collect_structured_source_row_overlay(
+        self,
+        *,
+        matrix: dict[str, Any],
+        structured_source_proof_artifact: dict[str, Any] | None,
+        structured_source_row_proof_overlay: dict[str, Any] | None,
+    ) -> dict[str, list[dict[str, Any]]]:
+        overlay: dict[str, list[dict[str, Any]]] = {}
+
+        artifact_payload = structured_source_proof_artifact
+        if not isinstance(artifact_payload, dict):
+            matrix_artifact = matrix.get("structured_source_proof_artifact")
+            artifact_payload = (
+                matrix_artifact if isinstance(matrix_artifact, dict) else None
+            )
+        if artifact_payload:
+            artifact_overlay = self._extract_structured_source_row_overlay_from_artifact(
+                artifact=artifact_payload
+            )
+            for row_id, payloads in artifact_overlay.items():
+                overlay.setdefault(row_id, []).extend(payloads)
+
+        matrix_overlay = matrix.get("structured_source_row_proof_overlay")
+        if isinstance(matrix_overlay, dict):
+            normalized_matrix_overlay = self._normalize_structured_source_row_overlay(
+                matrix_overlay
+            )
+            for row_id, payloads in normalized_matrix_overlay.items():
+                overlay.setdefault(row_id, []).extend(payloads)
+
+        if isinstance(structured_source_row_proof_overlay, dict):
+            normalized_input_overlay = self._normalize_structured_source_row_overlay(
+                structured_source_row_proof_overlay
+            )
+            for row_id, payloads in normalized_input_overlay.items():
+                overlay.setdefault(row_id, []).extend(payloads)
+
+        return overlay
+
+    def _normalize_structured_source_row_overlay(
+        self, overlay: dict[str, Any]
+    ) -> dict[str, list[dict[str, Any]]]:
+        normalized: dict[str, list[dict[str, Any]]] = {}
+        for raw_row_id, payload in overlay.items():
+            row_id = str(raw_row_id or "")
+            if not row_id:
+                continue
+
+            payloads: list[Any]
+            if isinstance(payload, list):
+                payloads = payload
+            elif isinstance(payload, dict):
+                payloads = [payload]
+            else:
+                continue
+
+            for item in payloads:
+                if not isinstance(item, dict):
+                    continue
+                normalized_payload = dict(item)
+                normalized_payload.setdefault("corpus_row_id", row_id)
+                parsed = self._structured_source_overlay_entry_from_artifact_payload(
+                    payload=normalized_payload
+                )
+                if parsed is None:
+                    continue
+                parsed_row_id, parsed_payload = parsed
+                normalized.setdefault(parsed_row_id, []).append(parsed_payload)
+
+        return normalized
+
+    def _extract_structured_source_row_overlay_from_artifact(
+        self, *, artifact: dict[str, Any]
+    ) -> dict[str, list[dict[str, Any]]]:
+        extracted: dict[str, list[dict[str, Any]]] = {}
+        for key in ("rows", "attempts"):
+            payloads = artifact.get(key)
+            if not isinstance(payloads, list):
+                continue
+            for payload in payloads:
+                parsed = self._structured_source_overlay_entry_from_artifact_payload(
+                    payload=payload
+                )
+                if parsed is None:
+                    continue
+                row_id, row_payload = parsed
+                extracted.setdefault(row_id, []).append(row_payload)
+        return extracted
+
+    def _structured_source_overlay_entry_from_artifact_payload(
+        self, *, payload: Any
+    ) -> tuple[str, dict[str, Any]] | None:
+        if not isinstance(payload, dict):
+            return None
+
+        row_id = str(payload.get("corpus_row_id") or "")
+        jurisdiction_id = str(payload.get("jurisdiction_id") or "")
+        source_family = str(payload.get("source_family") or "")
+        extraction_depth = str(
+            payload.get("extraction_depth") or payload.get("depth") or ""
+        )
+        if not row_id or not jurisdiction_id or not source_family or not extraction_depth:
+            return None
+
+        proof_status = str(
+            payload.get("proof_status")
+            or payload.get("status")
+            or payload.get("row_status")
+            or ""
+        ).strip()
+        if not proof_status:
+            return None
+        normalized_status = (
+            "live_proven"
+            if proof_status.lower() in LIVE_STRUCTURED_PROOF_STATUSES
+            else proof_status.lower()
+        )
+
+        parsed: dict[str, Any] = {
+            "corpus_row_id": row_id,
+            "jurisdiction_id": jurisdiction_id,
+            "source_family": source_family,
+            "extraction_depth": extraction_depth,
+            "proof_status": normalized_status,
+            "proof_source": str(
+                payload.get("proof_source") or "structured_source_runtime_proof_artifact"
+            ),
+        }
+
+        for key in (
+            "package_id",
+            "known_policy_reference_id",
+            "endpoint_url",
+            "access_method",
+            "retrieved_at",
+            "response_hash",
+            "schema_hash",
+            "blocker_class",
+            "blocker_detail",
+        ):
+            value = payload.get(key)
+            if isinstance(value, str) and value:
+                parsed[key] = value
+        for key in ("http_status", "sample_row_count"):
+            value = payload.get(key)
+            if isinstance(value, int):
+                parsed[key] = value
+        normalized_fields = payload.get("normalized_fields_proven")
+        if isinstance(normalized_fields, list):
+            parsed["normalized_fields_proven"] = [
+                str(item)
+                for item in normalized_fields
+                if isinstance(item, str) and item
+            ]
+
+        return row_id, parsed
 
     def _collect_windmill_row_overlay(
         self,

--- a/backend/tests/services/pipeline/test_local_government_corpus_benchmark.py
+++ b/backend/tests/services/pipeline/test_local_government_corpus_benchmark.py
@@ -194,6 +194,88 @@ def test_live_proven_structured_sources_can_satisfy_c2_and_c14() -> None:
     assert scorecard["gates"]["C14"]["status"] == "pass"
 
 
+def test_structured_artifact_overlay_upgrades_only_matching_cataloged_row() -> None:
+    service = LocalGovernmentCorpusBenchmarkService()
+    matrix = build_local_government_corpus_matrix_seed()
+    rows = [row for row in matrix["rows"] if row.get("row_type") == "corpus_package"]
+
+    overlaid_rows = service._build_rows_with_structured_source_proof_overlay(
+        matrix=matrix,
+        rows=rows,
+        structured_source_proof_artifact={
+            "rows": [
+                {
+                    "corpus_row_id": "lgm-065",
+                    "package_id": "pkg::lgm-065",
+                    "known_policy_reference_id": "kp-aus-affordable-housing-mandate-c45",
+                    "jurisdiction_id": "austin_tx",
+                    "source_family": "socrata_api",
+                    "extraction_depth": "affordability_units",
+                    "proof_status": "live_proven",
+                    "proof_source": "structured_source_runtime_probe",
+                    "endpoint_url": "https://data.austintexas.gov/resource/2h5e-ntwt.json?$limit=5",
+                    "access_method": "http_get_json",
+                    "retrieved_at": "2026-04-25T08:02:59+00:00",
+                    "http_status": 200,
+                    "response_hash": "abc123",
+                    "schema_hash": "def456",
+                    "sample_row_count": 5,
+                    "normalized_fields_proven": ["_10_to_19_units", "_20_units"],
+                }
+            ]
+        },
+        structured_source_row_proof_overlay=None,
+    )
+
+    upgraded_row = next(row for row in overlaid_rows if row["corpus_row_id"] == "lgm-065")
+    upgraded_observation = upgraded_row["structured_source_observations"][0]
+    assert upgraded_observation["live_proven"] is True
+    assert upgraded_observation["proof_status"] == "live_proven"
+    assert upgraded_observation["proof_source"] == "structured_source_runtime_probe"
+    assert upgraded_row["source_infrastructure_status"] == "live_integrated"
+    assert upgraded_row["extraction_depth"]["live_exercised"] is True
+    assert upgraded_row["extraction_depth"]["proof_status"] == "live_proven"
+
+    untouched_row = next(row for row in overlaid_rows if row["corpus_row_id"] == "lgm-064")
+    untouched_observation = untouched_row["structured_source_observations"][0]
+    assert untouched_observation["live_proven"] is False
+    assert untouched_observation["proof_status"] == "cataloged_intent"
+
+
+def test_structured_artifact_overlay_rejects_false_proof_mismatch() -> None:
+    service = LocalGovernmentCorpusBenchmarkService()
+    matrix = build_local_government_corpus_matrix_seed()
+    rows = [row for row in matrix["rows"] if row.get("row_type") == "corpus_package"]
+
+    overlaid_rows = service._build_rows_with_structured_source_proof_overlay(
+        matrix=matrix,
+        rows=rows,
+        structured_source_proof_artifact={
+            "rows": [
+                {
+                    "corpus_row_id": "lgm-065",
+                    "package_id": "pkg::lgm-065",
+                    "known_policy_reference_id": "kp-aus-affordable-housing-mandate-c45",
+                    "jurisdiction_id": "denver_co",
+                    "source_family": "arcgis_rest",
+                    "extraction_depth": "parcel_zone_rows",
+                    "proof_status": "live_proven",
+                    "proof_source": "structured_source_runtime_probe",
+                }
+            ]
+        },
+        structured_source_row_proof_overlay=None,
+    )
+
+    row = next(row for row in overlaid_rows if row["corpus_row_id"] == "lgm-065")
+    observation = row["structured_source_observations"][0]
+    assert observation["live_proven"] is False
+    assert observation["proof_status"] == "cataloged_intent"
+    assert row["source_infrastructure_status"] == "cataloged_intent"
+    assert row["extraction_depth"]["live_exercised"] is False
+    assert row["extraction_depth"]["proof_status"] == "cataloged_intent"
+
+
 def test_live_proven_windmill_refs_satisfy_c13() -> None:
     service = LocalGovernmentCorpusBenchmarkService()
     matrix = build_local_government_corpus_matrix_seed()

--- a/backend/tests/verification/test_regenerate_local_government_corpus_scorecard.py
+++ b/backend/tests/verification/test_regenerate_local_government_corpus_scorecard.py
@@ -98,15 +98,48 @@ def test_run_uses_overlay_and_records_artifact_inputs(tmp_path: Path) -> None:
             }
         ],
     }
+    structured_proof_artifact = {
+        "generated_at": "2026-04-25T08:03:00+00:00",
+        "rows": [
+            {
+                "corpus_row_id": "lgm-065",
+                "package_id": "pkg::lgm-065",
+                "known_policy_reference_id": "kp-aus-affordable-housing-mandate-c45",
+                "jurisdiction_id": "austin_tx",
+                "source_family": "socrata_api",
+                "extraction_depth": "affordability_units",
+                "proof_status": "live_proven",
+                "proof_source": "structured_source_runtime_probe",
+                "endpoint_url": "https://data.austintexas.gov/resource/2h5e-ntwt.json?$limit=5",
+                "access_method": "http_get_json",
+                "retrieved_at": "2026-04-25T08:02:59+00:00",
+                "http_status": 200,
+                "response_hash": "abc123",
+                "schema_hash": "def456",
+                "sample_row_count": 5,
+                "normalized_fields_proven": ["_10_to_19_units", "_20_units"],
+            }
+        ],
+        "summary": {
+            "attempted_row_count": 1,
+            "live_proven_count": 1,
+            "blocked_count": 0,
+            "attempted_row_ids": ["lgm-065"],
+            "live_proven_row_ids": ["lgm-065"],
+            "blocked_row_ids": [],
+        },
+    }
 
     matrix_path = _write_json(tmp_path / "matrix.json", matrix)
     orchestration_path = _write_json(tmp_path / "orchestration.json", overlay_artifact)
+    structured_path = _write_json(tmp_path / "structured.json", structured_proof_artifact)
     scorecard_path = tmp_path / "scorecard.json"
     report_path = tmp_path / "report.md"
 
     result = regenerate_module.run(
         matrix_path=matrix_path,
         windmill_orchestration_path=orchestration_path,
+        structured_source_proof_path=structured_path,
         scorecard_output_path=scorecard_path,
         report_output_path=report_path,
     )
@@ -123,6 +156,17 @@ def test_run_uses_overlay_and_records_artifact_inputs(tmp_path: Path) -> None:
     )
     assert artifact_inputs["windmill_live_attempt_rows"] == [row_id]
     assert artifact_inputs["windmill_blocked_attempt_rows"] == ["lgm-blocked"]
+    assert artifact_inputs["structured_source_proof_artifact"].endswith("structured.json")
+    assert artifact_inputs["structured_source_live_attempt_rows"] == ["lgm-065"]
+    assert artifact_inputs["structured_source_blocked_attempt_rows"] == []
+    assert artifact_inputs["structured_source_overlay_burndown_summary"] == {
+        "attempted_row_count": 1,
+        "live_proven_count": 1,
+        "blocked_count": 0,
+        "attempted_row_ids": ["lgm-065"],
+        "live_proven_row_ids": ["lgm-065"],
+        "blocked_row_ids": [],
+    }
     assert artifact_inputs["windmill_overlay_burndown_summary"] == {
         "seeded_placeholder_rows_remaining": 2,
         "seeded_placeholder_rows_sample": ["lgm-seeded-a", "lgm-seeded-b"],
@@ -141,6 +185,10 @@ def test_run_uses_overlay_and_records_artifact_inputs(tmp_path: Path) -> None:
     assert (
         scorecard["gates"]["C13"]["metrics"]["live_proof_coverage_ratio"]
         > baseline["gates"]["C13"]["metrics"]["live_proof_coverage_ratio"]
+    )
+    assert (
+        scorecard["gates"]["C2"]["metrics"]["live_structured_coverage_ratio"]
+        > baseline["gates"]["C2"]["metrics"]["live_structured_coverage_ratio"]
     )
     assert row_id not in scorecard["gates"]["C13"]["metrics"]["next_seeded_ref_target_rows"]
     assert scorecard["corpus_state"] == "corpus_ready_with_gaps"
@@ -184,12 +232,17 @@ def test_run_keeps_c13_strict_when_overlay_contains_seeded_refs(tmp_path: Path) 
         tmp_path / "orchestration.json",
         {"rows": seeded_rows},
     )
+    structured_path = _write_json(
+        tmp_path / "structured.json",
+        {"rows": [], "summary": {"attempted_row_count": 0}},
+    )
     scorecard_path = tmp_path / "scorecard.json"
     report_path = tmp_path / "report.md"
 
     result = regenerate_module.run(
         matrix_path=matrix_path,
         windmill_orchestration_path=orchestration_path,
+        structured_source_proof_path=structured_path,
         scorecard_output_path=scorecard_path,
         report_output_path=report_path,
     )

--- a/docs/poc/policy-evidence-quality-spine/artifacts/local_government_corpus_scorecard.json
+++ b/docs/poc/policy-evidence-quality-spine/artifacts/local_government_corpus_scorecard.json
@@ -1,6 +1,26 @@
 {
   "artifact_inputs": {
     "overlay_applied": true,
+    "structured_overlay_applied": true,
+    "structured_source_blocked_attempt_rows": [],
+    "structured_source_live_attempt_rows": [
+      "lgm-065"
+    ],
+    "structured_source_overlay_burndown_summary": {
+      "attempted_row_count": 1,
+      "attempted_row_ids": [
+        "lgm-065"
+      ],
+      "blocked_count": 0,
+      "blocked_row_ids": [],
+      "live_proven_count": 1,
+      "live_proven_row_ids": [
+        "lgm-065"
+      ]
+    },
+    "structured_source_proof_artifact": "docs/poc/policy-evidence-quality-spine/artifacts/local_government_corpus_structured_source_proof.json",
+    "structured_source_proof_digest": "a5a4c9cc656c23dbcc4438bcbed99d34fdaaf361f692a2355d90a17822f4282d",
+    "structured_source_proof_generated_at": "2026-04-25T15:02:31+00:00",
     "windmill_blocked_attempt_rows": [],
     "windmill_live_attempt_rows": [
       "lgm-001",
@@ -379,7 +399,7 @@
         "cataloged_true_structured_family_count": 5,
         "coverage_ratio": 1.0,
         "live_non_legistar_true_structured_present": true,
-        "live_structured_coverage_ratio": 0.1778,
+        "live_structured_coverage_ratio": 0.1889,
         "live_true_structured_family_count": 5,
         "non_legistar_true_structured_present": true,
         "non_primary_cataloged_only_count": 6,
@@ -479,7 +499,7 @@
       "status": "pass"
     }
   },
-  "generated_at": "2026-04-17T11:02:14+00:00",
+  "generated_at": "2026-04-25T15:05:52+00:00",
   "matrix_digest": "bca1c6a3317ad8e942e6c1b2155a64d455dce018db6b3fd34084548b240df9d1",
   "matrix_summary": {
     "corpus_readiness_target": "corpus_ready_with_gaps",

--- a/docs/poc/policy-evidence-quality-spine/artifacts/local_government_corpus_structured_source_proof.json
+++ b/docs/poc/policy-evidence-quality-spine/artifacts/local_government_corpus_structured_source_proof.json
@@ -1,0 +1,68 @@
+{
+  "attempts": [
+    {
+      "access_method": "http_get_json",
+      "corpus_row_id": "lgm-065",
+      "endpoint_url": "https://data.austintexas.gov/resource/2h5e-ntwt.json?$limit=5",
+      "extraction_depth": "affordability_units",
+      "http_status": 200,
+      "jurisdiction_id": "austin_tx",
+      "known_policy_reference_id": "kp-aus-affordable-housing-mandate-c45",
+      "normalized_fields_proven": [
+        "_10_to_19_units",
+        "_20_units",
+        "_2023_population"
+      ],
+      "package_id": "pkg::lgm-065",
+      "proof_source": "structured_source_runtime_probe",
+      "proof_status": "live_proven",
+      "response_hash": "5aa05a3c149d11d109679f498307b466666f1bd65f5c1673e1d1d363f22503db",
+      "retrieved_at": "2026-04-25T15:02:31+00:00",
+      "sample_row_count": 5,
+      "schema_hash": "93f5d339b3aca65c05095a309257786c2a491244edf66df29cd372f65584fbc6",
+      "source_family": "socrata_api"
+    }
+  ],
+  "benchmark_id": "local_government_data_moat_benchmark_v0",
+  "contract_version": "2026-04-25.structured-source-proof.v1",
+  "feature_key": "bd-3wefe.13.4.11",
+  "generated_at": "2026-04-25T15:02:31+00:00",
+  "matrix_digest": "bca1c6a3317ad8e942e6c1b2155a64d455dce018db6b3fd34084548b240df9d1",
+  "rows": [
+    {
+      "access_method": "http_get_json",
+      "corpus_row_id": "lgm-065",
+      "endpoint_url": "https://data.austintexas.gov/resource/2h5e-ntwt.json?$limit=5",
+      "extraction_depth": "affordability_units",
+      "http_status": 200,
+      "jurisdiction_id": "austin_tx",
+      "known_policy_reference_id": "kp-aus-affordable-housing-mandate-c45",
+      "normalized_fields_proven": [
+        "_10_to_19_units",
+        "_20_units",
+        "_2023_population"
+      ],
+      "package_id": "pkg::lgm-065",
+      "proof_source": "structured_source_runtime_probe",
+      "proof_status": "live_proven",
+      "response_hash": "5aa05a3c149d11d109679f498307b466666f1bd65f5c1673e1d1d363f22503db",
+      "retrieved_at": "2026-04-25T15:02:31+00:00",
+      "sample_row_count": 5,
+      "schema_hash": "93f5d339b3aca65c05095a309257786c2a491244edf66df29cd372f65584fbc6",
+      "source_family": "socrata_api"
+    }
+  ],
+  "schema_version": "local_government_corpus_structured_source_proof_v1",
+  "summary": {
+    "attempted_row_count": 1,
+    "attempted_row_ids": [
+      "lgm-065"
+    ],
+    "blocked_count": 0,
+    "blocked_row_ids": [],
+    "live_proven_count": 1,
+    "live_proven_row_ids": [
+      "lgm-065"
+    ]
+  }
+}

--- a/docs/poc/policy-evidence-quality-spine/artifacts/manual_audit_local_government_corpus.json
+++ b/docs/poc/policy-evidence-quality-spine/artifacts/manual_audit_local_government_corpus.json
@@ -8,7 +8,7 @@
     "matrix_package_count": 90,
     "required_sample_count": 30,
     "audited_package_count": 30,
-    "selection_note": "Cycle 45 stratified 30-row sample retained; Cycle 49 adds lightweight live-proven Windmill row entries."
+    "selection_note": "Cycle 45 stratified 30-row sample retained; Cycle 49 adds lightweight live-proven Windmill row entries; Cycle 53 adds one structured-source runtime proof row."
   },
   "live_proven_audits": [
     {
@@ -98,6 +98,24 @@
       "manual_audit_status": "lightweight_live_proven_triage",
       "evidence_boundary": "orchestration_proof_only_not_substantive_quality",
       "manual_audit_note": "Live Windmill refs proven; substantive package quality still governed by C0-C14."
+    }
+  ],
+  "structured_source_live_proven_audits": [
+    {
+      "corpus_row_id": "lgm-065",
+      "package_id": "pkg::lgm-065",
+      "jurisdiction_id": "austin_tx",
+      "policy_family": "affordable_housing_mandate",
+      "source_family": "socrata_api",
+      "extraction_depth": "affordability_units",
+      "proof_status": "live_proven",
+      "proof_source": "structured_source_runtime_probe",
+      "endpoint_url": "https://data.austintexas.gov/resource/2h5e-ntwt.json?$limit=5",
+      "retrieved_at": "2026-04-25T15:02:31+00:00",
+      "http_status": 200,
+      "sample_row_count": 5,
+      "evidence_boundary": "structured_source_runtime_probe_only_not_full_corpus_quality",
+      "manual_audit_note": "Runtime probe upgrades this row from cataloged_intent to live_proven for C2/C14 overlay matching."
     }
   ],
   "audits": [

--- a/docs/poc/policy-evidence-quality-spine/local_government_corpus_report.md
+++ b/docs/poc/policy-evidence-quality-spine/local_government_corpus_report.md
@@ -27,7 +27,7 @@
 
 ## Structured Proof Boundary
 
-- C2 live structured coverage ratio: `0.1778`
+- C2 live structured coverage ratio: `0.1889`
 - C2 live true structured families: `5`
 - C2 cataloged true structured families: `5`
 - C14 live non-fee families: `11`

--- a/docs/poc/policy-evidence-quality-spine/local_government_data_moat_execution_ledger.md
+++ b/docs/poc/policy-evidence-quality-spine/local_government_data_moat_execution_ledger.md
@@ -1007,3 +1007,73 @@ Reason for stopping:
 
 - The founder requested a takeover package and copy/paste prompt for another
   agent, not another local eval cycle.
+
+## Cycle 53: Structured-Source Runtime Proof Overlay
+
+Status: `completed_with_non_destructive_improvement`
+
+Started: 2026-04-25
+
+Scope:
+
+- Add a fail-closed structured-source runtime proof artifact/schema.
+- Consume structured proof artifact inputs in scorecard regeneration.
+- Upgrade `cataloged_intent` structured rows only when proof matches row id,
+  jurisdiction, source family, and extraction depth.
+- Prove at least one non-San-Jose, non-Legistar cataloged target with a live
+  public structured source probe.
+
+Implementation changes:
+
+- Added structured proof overlay logic in
+  `backend/services/pipeline/local_government_corpus_benchmark.py`.
+- Added live probe script
+  `backend/scripts/verification/verify_local_government_corpus_structured_source_proof.py`.
+- Updated scorecard regeneration script to accept and record structured proof
+  artifact inputs:
+  `backend/scripts/verification/regenerate_local_government_corpus_scorecard.py`.
+- Added regression coverage for:
+  - positive structured overlay upgrade;
+  - false-proof mismatch rejection;
+  - scorecard regeneration consuming structured artifact inputs.
+
+Runtime proof artifact:
+
+- Generated
+  `docs/poc/policy-evidence-quality-spine/artifacts/local_government_corpus_structured_source_proof.json`.
+- Live-proven row:
+  - `corpus_row_id=lgm-065`
+  - `jurisdiction_id=austin_tx`
+  - `source_family=socrata_api`
+  - `extraction_depth=affordability_units`
+  - endpoint:
+    `https://data.austintexas.gov/resource/2h5e-ntwt.json?$limit=5`
+  - `http_status=200`
+  - `sample_row_count=5`
+
+Artifact/report impact:
+
+- Regenerated:
+  - `local_government_corpus_matrix.json`
+  - `local_government_corpus_scorecard.json`
+  - `local_government_corpus_report.md`
+  - `manual_audit_local_government_corpus.md`
+  - `manual_audit_local_government_corpus.json`
+- Scorecard now records structured artifact inputs and live proof row IDs under
+  `artifact_inputs`.
+- C2 live structured coverage moved from `0.1778` -> `0.1889`.
+- Corpus state remains `corpus_ready_with_gaps`.
+
+Validation:
+
+- `cd backend && poetry run pytest tests/services/pipeline/test_local_government_corpus_benchmark.py tests/verification/test_regenerate_local_government_corpus_scorecard.py tests/verification/test_verify_local_government_corpus_manual_audit.py -q` -> `30 passed`.
+- `cd backend && poetry run python scripts/verification/verify_local_government_corpus_manual_audit.py` -> `pass`.
+- `cd backend && poetry run pytest -q` -> blocked in collection due missing local deps/modules (`fastapi`, `requests`, `llm_common`, `playwright`, `scrapy`, `minio`, `jwt`), not due Cycle 53 logic failures.
+
+Remaining blocker:
+
+- C2 remains `not_proven` (cataloged structured backlog still large despite one
+  live-proven upgrade).
+- C13 remains `not_proven`.
+- C14 remains `not_proven` (cataloged non-fee extraction families still
+  present).

--- a/docs/poc/policy-evidence-quality-spine/manual_audit_local_government_corpus.md
+++ b/docs/poc/policy-evidence-quality-spine/manual_audit_local_government_corpus.md
@@ -1,6 +1,6 @@
-# Manual Audit: Local Government Corpus (Cycle 49)
+# Manual Audit: Local Government Corpus (Cycle 53)
 
-Feature-Key: `bd-3wefe.13.4.7`
+Feature-Key: `bd-3wefe.13.4.11`
 Benchmark: `local_government_data_moat_benchmark_v0`
 
 ## Scope
@@ -97,7 +97,21 @@ Interpretation:
 - Substantive policy quality and decision-grade handoff quality remain governed
   by C0–C14 (not this lightweight list alone).
 
+## Structured-Source Runtime Proof Rows (Cycle 53 Overlay)
+
+Cycle 53 adds a structured-source runtime proof artifact and fail-closed
+overlay matching (row identity + jurisdiction + source family + extraction
+depth). This is scoped to C2/C14 structured proof only.
+
+| corpus_row_id | jurisdiction_id | policy_family | source_family | extraction_depth | proof_status | endpoint |
+| --- | --- | --- | --- | --- | --- | --- |
+| `lgm-065` | `austin_tx` | `affordable_housing_mandate` | `socrata_api` | `affordability_units` | `live_proven` | `https://data.austintexas.gov/resource/2h5e-ntwt.json?$limit=5` |
+
+Structured evidence boundary marker:
+
+- `evidence_boundary=structured_source_runtime_probe_only_not_full_corpus_quality`
+
 ## Result
 
-Cycle 49 manual-audit verification status: `pass` for C5 stratified sample plus
+Cycle 53 manual-audit verification status: `pass` for C5 stratified sample plus
 live-proven row representation checks.


### PR DESCRIPTION
## Summary
- add structured-source runtime proof overlay path with fail-closed row matching (row id + jurisdiction + source family + extraction depth)
- add live structured-source probe artifact generation for Cycle 53 and wire artifact into scorecard regeneration
- regenerate scorecard/report/manual-audit/ledger artifacts with one real non-San-Jose structured proof row (lgm-065, Austin Socrata)

## Validation
- cd backend && poetry run pytest tests/services/pipeline/test_local_government_corpus_benchmark.py tests/verification/test_regenerate_local_government_corpus_scorecard.py tests/verification/test_verify_local_government_corpus_manual_audit.py -q
- cd backend && poetry run python scripts/verification/verify_local_government_corpus_manual_audit.py
- cd backend && poetry run pytest -q (fails in collection due missing local deps: fastapi/requests/llm_common/playwright/scrapy/minio/jwt)

## Gates/Gaps
- C2 improved (live_structured_coverage_ratio 0.1778 -> 0.1889) but remains not_proven
- C13 remains not_proven
- C14 remains not_proven

Agent: codex